### PR TITLE
feat(contracts): 002-SharedContracts — typed bindings and CI validation

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -56,3 +56,10 @@ After commit is created:
   - Start testing
   - Update documentation
   - Review and verify
+
+### Step 4: Archive completed QuickPlans
+After a successful commit, check for active QuickPlans:
+1. Scan `Context/QuickPlans/` for `.md` files (ignore `Done/` subdirectory)
+2. If none found, skip this step silently
+3. If plans are found, list them and ask: "Archive these completed QuickPlans?"
+4. If confirmed, move each plan to `Context/QuickPlans/Done/` (create the directory if needed)

--- a/.claude/commands/quick.md
+++ b/.claude/commands/quick.md
@@ -53,5 +53,10 @@ ALWAYS end by recommending the most appropriate execution command:
 
 Quick plans typically use `/impl` since they are smaller in scope.
 
-### Step 5: Clean up
-When task is complete, move quick plan to `Context/Backlog/Done/` for reference, or delete if not needed.
+### Step 5: Archive the QuickPlan
+When the task is complete, archive the plan so it does not accumulate in the active folder:
+1. Create `Context/QuickPlans/Done/` if it does not exist
+2. Move the plan file from `Context/QuickPlans/` to `Context/QuickPlans/Done/`
+3. Confirm the move to the user
+
+Do NOT skip this step or leave it as a suggestion. Perform the move directly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,26 @@ jobs:
       - name: Build and Lint
         run: ./gradlew build lint
 
+  validate-contracts:
+    name: Validate Contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install web dependencies
+        run: bun install
+        working-directory: apps/web
+
+      - name: Run validation script
+        run: bun run packages/contracts/scripts/validate.ts
+
   smoke-test:
     name: Smoke Test
     runs-on: ubuntu-latest
-    needs: [rust, web]
+    needs: [rust, web, android, validate-contracts]
     steps:
       - uses: actions/checkout@v4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,10 +67,10 @@ Quick tasks skip to a single-file quick plan.
 | `/backlog` | Add to or prioritize the backlog |
 
 ### Complexity Routing
-
-- **Simple** (< 50 lines, single file): Direct implementation, no plan needed
-- **Medium** (50-300 lines, 2-5 files): `/quick` plan
-- **Complex** (> 300 lines, cross-cutting): `/blueprint` full planning cycle
+- **Trivial** (single file, obvious fix) -- Execute directly
+- **Moderate** (2-5 files, clear scope) -- `/quick` then execute
+- **Complex** (multi-phase, 5+ files) -- `/blueprint` then `/impl`
+- **Collaborative** (cross-domain integration) -- `/blueprint` then `/team-impl`
 
 ## Conventions
 

--- a/Context/Features/002-SharedContracts/Spec.md
+++ b/Context/Features/002-SharedContracts/Spec.md
@@ -1,0 +1,123 @@
+# Feature 002: Shared Contracts
+
+| Field | Value |
+|---|---|
+| **Feature** | 002-SharedContracts |
+| **Status** | Draft |
+| **Last Updated** | 2026-04-12 |
+| **Plan Reference** | `docs/specs/10-PLAN-001-v1.md` — Step 2 |
+
+---
+
+## Overview
+
+Shared Contracts establishes `packages/contracts/` as the single source of truth for cross-platform identifiers and schema primitives used by all Altair clients. It populates three canonical JSON registries (entity types, relation types, sync stream names) and produces typed language bindings for TypeScript, Kotlin, and Rust. A CI validation script asserts that all three bindings stay in sync with the registries.
+
+---
+
+## Problem Statement
+
+Without a canonical registry, each client stack must independently maintain lists of entity type strings, relation type strings, and sync stream names. This creates drift: a string renamed in one stack silently breaks serialization or sync filtering in another. Contract invariants C-1, C-2, and C-3 require that these identifiers come from a single canonical source. The `packages/contracts/` registries fulfill that requirement; the language bindings enforce it at compile time per stack.
+
+---
+
+## User Stories
+
+- As a backend engineer, I want a Rust enum for entity types so that I can validate incoming entity type strings against a compile-time-checked set and reject unknown types at write time.
+- As an Android engineer, I want a Kotlin enum for entity types so that I can reference entity types without inline magic strings throughout the codebase.
+- As a web engineer, I want a TypeScript const object for entity types so that IDE autocomplete catches typos and unknown types at development time.
+- As any engineer, I want CI to verify that the language bindings match the JSON registry so that a stale or missing binding is caught before it reaches main.
+- As a future maintainer, I want relation types defined consistently in all stacks so that cross-domain links created on any platform round-trip correctly.
+
+---
+
+## Requirements
+
+### Must Have
+
+- `packages/contracts/entity-types.json` — canonical list of all 18 entity type identifiers, matching `02-domain-model.md`
+- `packages/contracts/relation-types.json` — canonical list of all 8 relation type identifiers
+- `packages/contracts/sync-streams.json` — canonical list of PowerSync stream name constants (v1 streams; stubs acceptable if Step 4 design is incomplete)
+- **TypeScript bindings** in `apps/web/src/lib/contracts/`:
+  - `entityTypes.ts` — exports a const object with all entity type values
+  - `relationTypes.ts` — exports a const object with all relation type values
+  - `syncStreams.ts` — exports a const object with all stream name values
+- **Kotlin bindings** in `apps/android/app/src/main/kotlin/com/getaltair/altair/contracts/`:
+  - `EntityType.kt` — enum class with all entity type entries
+  - `RelationType.kt` — enum class with all relation type entries
+  - `SyncStream.kt` — enum class or const object with all stream name values
+- **Rust bindings** in `apps/server/server/src/`:
+  - `contracts.rs` — module containing `EntityType`, `RelationType`, and `SyncStream` enums with `serde` `rename` attributes matching the JSON registry strings
+- **Shared DTOs** defined in all three languages:
+  - `EntityRef` — `entity_type: String`, `entity_id: UUID`
+  - `RelationRecord` — mirrors `entity_relations` table schema from `05-erd.md`
+  - `AttachmentRecord` — mirrors `attachments` table schema from `05-erd.md`
+  - `SyncSubscriptionRequest` — parameters for PowerSync stream subscription
+- **CI validation script** (`packages/contracts/scripts/validate.ts` or equivalent) that:
+  - Reads each JSON registry
+  - Compares registry values against constants extracted from each language binding
+  - Fails with a diff if any binding is missing or has an extra value
+- CI pipeline runs the validation script on every push to main
+
+### Should Have
+
+- Each binding file contains a doc comment pointing back to the source registry file (e.g. `// Generated from packages/contracts/entity-types.json`)
+- JSON registry entries include a `description` field alongside the identifier string
+- A top-level `contracts_version` field in each registry file to support C-4 versioning rules
+- `RelationRecord` and `AttachmentRecord` include all nullable fields from the ERD (not just required fields)
+
+### Won't Have (this iteration)
+
+- Automated code generation — hand-written bindings are acceptable; the registry is small and stable enough that manual authoring + CI validation provides sufficient safety
+- iOS or WearOS bindings — deferred platforms per ADR-001
+- C-5 AI pipeline validation — enforced at server write-time using the Rust `EntityType` enum; no separate validation layer needed in this step
+- `packages/api-contracts/` — request/response DTOs beyond the four shared DTOs are deferred to Step 3 (Server Core)
+
+---
+
+## Testable Assertions
+
+| ID    | Assertion                                                                                                                                        | Verification                                                                                      |
+|-------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| A-001 | `entity-types.json` contains exactly 18 entity type identifiers matching the canonical list in `02-domain-model.md` § Enumerations              | Count registry entries; diff against spec list                                                    |
+| A-002 | `relation-types.json` contains exactly 8 relation type identifiers matching `02-domain-model.md` § Relation Types                               | Count registry entries; diff against spec list                                                    |
+| A-003 | TypeScript `EntityType` const contains every identifier from `entity-types.json` and no additional values                                       | CI validation script: diff JSON registry keys vs. exported TS values                             |
+| A-004 | Kotlin `EntityType` enum contains every identifier from `entity-types.json` and no additional values                                            | CI validation script: diff JSON registry keys vs. Kotlin enum entries                            |
+| A-005 | Rust `EntityType` enum contains every identifier from `entity-types.json` and no additional values (accounting for serde rename attributes)      | CI validation script: diff JSON registry keys vs. serde-renamed Rust enum variants               |
+| A-006 | CI validation covers relation types: same consistency check as A-003/A-004/A-005 applied to `relation-types.json`                               | CI script output includes relation-type coverage                                                  |
+| A-007 | CI validation covers sync streams: same consistency check applied to `sync-streams.json`                                                        | CI script output includes sync-stream coverage                                                    |
+| A-008 | Adding an entry to `entity-types.json` without updating any language binding causes CI validation to fail with a non-zero exit code              | Test: add a dummy entry to registry, run validation script, verify failure; revert                |
+| A-009 | `EntityRef` is defined in TypeScript, Kotlin, and Rust with fields `entity_type` (string) and `entity_id` (UUID/string)                         | Compile each stack; inspect type definitions                                                      |
+| A-010 | `RelationRecord` is defined in all three languages with fields matching the `entity_relations` table schema in `05-erd.md`                       | Compile each stack; field-level comparison against ERD                                            |
+| A-011 | `AttachmentRecord` is defined in all three languages with fields matching the `attachments` table schema in `05-erd.md`                          | Compile each stack; field-level comparison against ERD                                            |
+| A-012 | `SyncSubscriptionRequest` is defined in all three languages and is imported in at least one sync-related module per stack                        | Code import audit; compile each stack                                                             |
+| A-013 | Rust server rejects a write request referencing an unknown entity type with a 422 Unprocessable Entity response                                  | Integration test: POST entity relation with `entity_type = "unknown_fake_type"`; assert 422      |
+| A-014 | Entity type constants are imported and used in at least one Rust service file, one Kotlin Repository or ViewModel, and one SvelteKit route/store | Import audit via grep or LSP; confirm no stack has zero usages                                    |
+
+---
+
+## Open Questions
+
+- [x] **OQ-001 — Binding location**: Write bindings into each app's source tree (`apps/web/src/lib/contracts/`, `apps/android/.../contracts/`, `apps/server/server/src/contracts.rs`). Cross-workspace imports add non-trivial build plumbing (Cargo dependency, Gradle module, bun workspace ref) for ~30 constants. The CI validation script enforces consistency regardless of location. Follows the existing server convention.
+- [x] **OQ-002 — Sync stream content**: Define provisional stream name constants now (e.g., `user_data`, `household_data`, `guidance`, `knowledge`, `tracking`). Stream name constants can be stabilized without the Step 4 SQL bucket queries. If Step 4 renames a stream, updating the JSON registry + three binding files is a small, CI-enforced change. Deferring would require Step 4 to backfill all three stacks mid-implementation.
+- [x] **OQ-003 — api-contracts scope**: All four DTOs (`EntityRef`, `RelationRecord`, `AttachmentRecord`, `SyncSubscriptionRequest`) live in `packages/contracts/` (written into app source trees per OQ-001) for v1. `packages/api-contracts/` is created in Step 3 (Server Core) when real endpoint request/response types appear.
+
+---
+
+## Dependencies
+
+| Dependency | Reason |
+|---|---|
+| `docs/specs/02-domain-model.md` | Canonical source for entity type and relation type identifier lists |
+| `docs/specs/05-erd.md` | Field-level schema for `EntityRef`, `RelationRecord`, `AttachmentRecord` DTO definitions |
+| Step 4 — Sync Engine | Informs `sync-streams.json` stream name content; OQ-002 |
+| `apps/server/server/src/` | Target location for Rust `contracts.rs`; no stub exists yet |
+
+---
+
+## Revision History
+
+| Date       | Change       | ADR |
+|------------|--------------|-----|
+| 2026-04-12 | Initial spec | —   |
+| 2026-04-12 | Resolved OQ-001, OQ-002, OQ-003 | —   |

--- a/Context/Features/002-SharedContracts/Steps.md
+++ b/Context/Features/002-SharedContracts/Steps.md
@@ -1,0 +1,263 @@
+# Implementation Steps: Shared Contracts
+
+**Spec:** `Context/Features/002-SharedContracts/Spec.md`
+**Tech:** `Context/Features/002-SharedContracts/Tech.md`
+
+---
+
+## Progress
+- **Status:** Not started
+- **Current task:** --
+- **Last milestone:** --
+
+---
+
+## Team Orchestration
+
+### Team Members
+
+- **builder-infra**
+  - Role: JSON registries, CI validation script, CI workflow wiring
+  - Agent Type: general-purpose
+  - Resume: false
+
+- **builder-rust**
+  - Role: Rust contracts module — enums, DTOs, serde wiring
+  - Agent Type: general-purpose
+  - Resume: false
+
+- **builder-web**
+  - Role: TypeScript contracts — const objects, DTOs, barrel exports
+  - Agent Type: general-purpose
+  - Resume: false
+
+- **builder-android**
+  - Role: Kotlin contracts — enum classes, DTOs
+  - Agent Type: general-purpose
+  - Resume: false
+
+- **validator**
+  - Role: Quality validation — read-only inspection of all outputs
+  - Agent Type: general-purpose
+  - Resume: false
+
+---
+
+## Tasks
+
+### Phase 1: JSON Registries
+
+Create the three canonical registry files in `packages/contracts/`. These are the source of truth for all language bindings.
+
+- [ ] S001: Create `packages/contracts/entity-types.json` with all 18 entity type identifiers and descriptions
+  - **Assigned:** builder-infra
+  - **Depends:** none
+  - **Parallel:** true
+  - **Content:** `contracts_version: "1.0.0"` field; `values` array with entries `{ "id": "<type>", "description": "<text>" }`. Canonical list from `docs/specs/02-domain-model.md` § Enumerations: Core (user, household, initiative, tag, attachment), Guidance (guidance_epic, guidance_quest, guidance_routine, guidance_focus_session, guidance_daily_checkin), Knowledge (knowledge_note, knowledge_note_snapshot), Tracking (tracking_location, tracking_category, tracking_item, tracking_item_event, tracking_shopping_list, tracking_shopping_list_item).
+
+- [ ] S002: Create `packages/contracts/relation-types.json` with all 8 relation type identifiers and descriptions
+  - **Assigned:** builder-infra
+  - **Depends:** none
+  - **Parallel:** true
+  - **Content:** Same structure as S001. Values: `references`, `supports`, `requires`, `related_to`, `depends_on`, `duplicates`, `similar_to`, `generated_from`.
+
+- [ ] S003: Create `packages/contracts/sync-streams.json` with provisional v1 stream name constants
+  - **Assigned:** builder-infra
+  - **Depends:** none
+  - **Parallel:** true
+  - **Content:** Values: `user_data`, `household`, `guidance`, `knowledge`, `tracking`. Include a top-level `"provisional": true` field and a comment-equivalent `note` field: `"Stream SQL bucket definitions are designed in Step 4 (Sync Engine); these names may be revised."`.
+
+---
+
+🏁 **MILESTONE 1: Registries complete**
+Verify: A-001 (entity-types.json has exactly 18 entries), A-002 (relation-types.json has exactly 8 entries)
+**Contracts:**
+- `packages/contracts/entity-types.json` — canonical entity type identifiers; consumed by all three binding tasks
+- `packages/contracts/relation-types.json` — canonical relation type identifiers
+- `packages/contracts/sync-streams.json` — provisional sync stream name constants
+
+---
+
+### Phase 2: Language Bindings
+
+All three binding tasks run in parallel after Milestone 1. Each stack targets a different directory — no file conflicts.
+
+- [ ] S004: Create Rust contracts module `apps/server/server/src/contracts.rs` with `EntityType` (18 variants), `RelationType` (8 variants), `SyncStream` (5 variants) enums and `EntityRef`, `RelationRecord`, `AttachmentRecord`, `SyncSubscriptionRequest` structs
+  - **Assigned:** builder-rust
+  - **Depends:** S001, S002, S003
+  - **Parallel:** true
+  - **Details:** Each enum variant uses `#[serde(rename = "<registry-id>")]` (per-variant, not rename_all). Derive: `Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize` on enums; `Debug, Clone, Serialize, Deserialize` on structs. UUID fields use `uuid::Uuid`. Timestamp fields use `chrono::DateTime<chrono::Utc>`. Optional fields use `Option<T>`. `RelationRecord` and `AttachmentRecord` mirror the full `entity_relations` and `attachments` table schemas from `docs/specs/05-erd.md` — include all columns including nullable ones. `SyncSubscriptionRequest`: `streams: Vec<SyncStream>`, `user_id: uuid::Uuid`. Add `mod contracts;` and `pub use contracts::*;` to `main.rs`. File must include a top comment: `// Source of truth: packages/contracts/{entity,relation}-types.json`.
+
+- [ ] S004-T: Rust serde round-trip and struct tests for `contracts.rs`
+  - **Assigned:** builder-rust
+  - **Depends:** S004
+  - **Parallel:** false
+  - **Scenarios:** (1) `EntityType::GuidanceEpic` serializes to `"guidance_epic"` and deserializes back; (2) `EntityType::User` serializes to `"user"`; (3) unknown string `"unknown_fake_type"` fails serde deserialization with an error; (4) `RelationType::RelatedTo` serializes to `"related_to"`; (5) `EntityRef` round-trips through serde with field names `entity_type` and `entity_id`
+
+- [ ] S005: Create TypeScript contracts in `apps/web/src/lib/contracts/` — `entityTypes.ts`, `relationTypes.ts`, `syncStreams.ts`, `dtos.ts`, `index.ts`
+  - **Assigned:** builder-web
+  - **Depends:** S001, S002, S003
+  - **Parallel:** true
+  - **Details:** Each binding file uses `as const` object pattern: `export const EntityType = { User: 'user', Household: 'household', ... } as const; export type EntityTypeValue = typeof EntityType[keyof typeof EntityType];`. DTOs in `dtos.ts`: `EntityRef`, `RelationRecord`, `AttachmentRecord`, `SyncSubscriptionRequest` as TypeScript `interface` types. UUID fields typed as `string`, timestamps as `string` (ISO 8601), optionals as `T | null`. `index.ts` re-exports everything from all four files. Each file begins with: `// Source of truth: packages/contracts/<registry-file>.json`.
+
+- [ ] S005-T: TypeScript binding correctness tests (`apps/web/src/lib/contracts/contracts.spec.ts`)
+  - **Assigned:** builder-web
+  - **Depends:** S005
+  - **Parallel:** false
+  - **Scenarios:** (1) `Object.values(EntityType)` has length 18; (2) `EntityType.GuidanceEpic === 'guidance_epic'`; (3) `Object.values(RelationType)` has length 8; (4) `RelationType.RelatedTo === 'related_to'`; (5) `bun run check` (TypeScript type check) passes with no errors — run as part of the test task by invoking `bun run check` in `apps/web/`
+
+- [ ] S006: Create Kotlin contracts in `apps/android/app/src/main/java/com/getaltair/altair/contracts/` — `EntityType.kt`, `RelationType.kt`, `SyncStream.kt`, `Dtos.kt`
+  - **Assigned:** builder-android
+  - **Depends:** S001, S002, S003
+  - **Parallel:** true
+  - **Details:** `enum class EntityType(val value: String)` with all 18 entries in SCREAMING_SNAKE_CASE (e.g., `GUIDANCE_EPIC("guidance_epic")`), plus `companion object { fun fromValue(value: String): EntityType? = entries.find { it.value == value } }`. Same pattern for `RelationType` (8 entries) and `SyncStream` (5 entries). `Dtos.kt` defines `EntityRef`, `RelationRecord`, `AttachmentRecord`, `SyncSubscriptionRequest` as plain `data class` with camelCase field names; no serialization annotations yet (deferred to Step 8 when JSON library is chosen). Each file includes a top comment: `// Source of truth: packages/contracts/<registry-file>.json`. Package: `com.getaltair.altair.contracts`.
+
+- [ ] S006-T: Kotlin unit tests for `EntityType.fromValue()` and enum completeness
+  - **Assigned:** builder-android
+  - **Depends:** S006
+  - **Parallel:** false
+  - **Scenarios:** (1) `EntityType.fromValue("guidance_epic")` returns `EntityType.GUIDANCE_EPIC`; (2) `EntityType.fromValue("unknown_fake_type")` returns null; (3) `EntityType.entries` has size 18; (4) all entries have non-blank `value` strings; (5) `RelationType.fromValue("related_to")` returns `RelationType.RELATED_TO`
+
+---
+
+🏁 **MILESTONE 2: Language bindings complete**
+Verify: A-003 (TS EntityType values match registry), A-004 (Kotlin EntityType entries match registry), A-005 (Rust EntityType variants match registry), A-006 (relation types consistent across all three bindings), A-007 (sync streams consistent across all three bindings), A-008 (EntityRef defined in all three languages), A-009 (RelationRecord defined in all three languages), A-010 (AttachmentRecord defined in all three languages), A-011 (SyncSubscriptionRequest defined in all three languages)
+**Contracts:**
+- `apps/server/server/src/contracts.rs` — Rust enums + DTOs; Step 3 adds `use crate::contracts::EntityType` in domain handlers
+- `apps/web/src/lib/contracts/index.ts` — TypeScript barrel; Step 9 imports via `$lib/contracts`
+- `apps/android/app/src/main/java/com/getaltair/altair/contracts/EntityType.kt` — Kotlin enum; Step 8 imports in repositories
+
+---
+
+### Phase 3: CI Validation
+
+Sequential: script must exist before the CI job can reference it.
+
+- [ ] S007: Create `packages/contracts/scripts/validate.ts` — Bun script that reads all three JSON registries and validates each language binding file
+  - **Assigned:** builder-infra
+  - **Depends:** S004, S005, S006
+  - **Parallel:** false
+  - **Details:** Script reads `entity-types.json`, `relation-types.json`, `sync-streams.json`. For TypeScript: dynamically imports `apps/web/src/lib/contracts/entityTypes.ts` etc. using `bun` and compares `Object.values(EntityType)` against registry `values[].id` arrays. For Kotlin: reads `EntityType.kt`, `RelationType.kt`, `SyncStream.kt` as text and extracts quoted string values from enum entries using regex `/"([^"]+)"\)/g`; diffs against registry. For Rust: reads `contracts.rs` as text, extracts `serde(rename = "...")` values using regex; diffs against registry. Exits 0 if all bindings match; exits 1 with a human-readable diff report if any binding is missing a value or has an extra value not in the registry.
+
+- [ ] S007-T: Test the validation script against known-good and known-bad states
+  - **Assigned:** builder-infra
+  - **Depends:** S007
+  - **Parallel:** false
+  - **Scenarios:** (1) Run script with current correct bindings — assert exit code 0; (2) Temporarily add a dummy entry `{ "id": "test_fake_type", "description": "Test" }` to `entity-types.json`, run script — assert exit code 1 and diff output names `test_fake_type`; (3) Revert the dummy entry — assert exit code 0 again; (4) Remove one entry from a binding file, run script — assert exit code 1
+
+- [ ] S008: Add `validate-contracts` job to `.github/workflows/ci.yml` and update `smoke-test` dependencies
+  - **Assigned:** builder-infra
+  - **Depends:** S007
+  - **Parallel:** false
+  - **Details:** New job `validate-contracts` runs on `ubuntu-latest`, installs Bun via `oven-sh/setup-bun@v2`, installs deps with `bun install` in `apps/web/` (needed for TypeScript module resolution), then runs `bun run packages/contracts/scripts/validate.ts` from repo root. Update `smoke-test` job's `needs:` from `[rust, web]` to `[rust, web, android, validate-contracts]`.
+
+- [ ] S008-D: Update `packages/contracts/README.md` with validation script usage and binding locations
+  - **Assigned:** builder-infra
+  - **Depends:** S008
+  - **Parallel:** false
+  - **Content:** Replace placeholder README with: registry file descriptions (what each contains), binding file locations for each stack, how to run the validation script locally (`bun run packages/contracts/scripts/validate.ts`), how to add a new type (update JSON registry → update all three binding files → run validate script → open PR), versioning rules per C-4 (additive = minor bump, rename/remove = breaking change).
+
+---
+
+🏁 **MILESTONE 3: CI validation complete**
+Verify: A-012 (adding registry entry without updating binding causes CI failure), A-007 (sync-streams validated by script)
+**Note:** A-013 (server rejects unknown entity type with 422) requires Step 3 HTTP handlers — partially satisfied here by the Rust `EntityType` enum rejecting unknown values at serde deserialization; the HTTP status code mapping is Step 3 work.
+**Contracts:**
+- `packages/contracts/scripts/validate.ts` — validation script; Step 3+ engineers run this locally when adding domain entity types
+- `.github/workflows/ci.yml` — updated with validate-contracts job
+
+---
+
+### Phase 4: Usage Verification
+
+Prove all three binding modules compile and are importable in a real file (satisfies A-014 groundwork). All three tasks are independent.
+
+- [ ] S009: Import and use `EntityType` in Rust `apps/server/server/src/routes/health.rs`
+  - **Assigned:** builder-rust
+  - **Depends:** S004
+  - **Parallel:** true
+  - **Details:** Add `use crate::contracts::EntityType;` to `health.rs`. Add a private constant or a comment-free usage that the Rust compiler cannot optimize away as dead code — e.g., a private `fn _assert_contracts() { let _: EntityType = EntityType::Initiative; }` marked `#[allow(dead_code)]`, or preferably integrate it into the health response by including `"entity_types": EntityType::User` in the JSON response as a version hint. Ensure `cargo build` passes with no warnings. Intent: prove the import path `crate::contracts` resolves correctly from a route module.
+
+- [ ] S010: Re-export contracts from `apps/web/src/lib/index.ts` and use `EntityType` in a new placeholder file
+  - **Assigned:** builder-web
+  - **Depends:** S005
+  - **Parallel:** true
+  - **Details:** Add `export * from './contracts';` to `apps/web/src/lib/index.ts`. Create `apps/web/src/lib/contracts/constants.ts` that imports `EntityType` and exports a typed array `export const SYNCED_ENTITY_TYPES: EntityTypeValue[] = [EntityType.Initiative, EntityType.GuidanceQuest, EntityType.KnowledgeNote, EntityType.TrackingItem];` — this is a real utility (the subset of entity types that sync through PowerSync). Ensure `bun run check` passes.
+
+- [ ] S011: Import and use `EntityType` in Android `apps/android/app/src/main/java/com/getaltair/altair/MainActivity.kt`
+  - **Assigned:** builder-android
+  - **Depends:** S006
+  - **Parallel:** true
+  - **Details:** Add `import com.getaltair.altair.contracts.EntityType` to `MainActivity.kt`. Add a `private val coreEntityTypes = listOf(EntityType.USER, EntityType.HOUSEHOLD, EntityType.INITIATIVE)` property — dead-code-free and Kotlin-idiomatic. Ensure `./gradlew assembleDebug` passes without warnings about the import.
+
+---
+
+🏁 **MILESTONE FINAL: Feature complete**
+Verify all assertions:
+- A-001 ✓ entity-types.json has 18 entries
+- A-002 ✓ relation-types.json has 8 entries
+- A-003 ✓ TypeScript EntityType values match registry
+- A-004 ✓ Kotlin EntityType entries match registry
+- A-005 ✓ Rust EntityType variants match registry (serde renames)
+- A-006 ✓ Relation types consistent across all three bindings
+- A-007 ✓ Sync streams consistent across all three bindings
+- A-008 ✓ EntityRef defined in all three languages
+- A-009 ✓ RelationRecord defined in all three languages
+- A-010 ✓ AttachmentRecord defined in all three languages
+- A-011 ✓ SyncSubscriptionRequest defined in all three languages
+- A-012 ✓ CI fails when binding drifts from registry
+- A-013 ⚠️ Partial — Rust enum rejects unknown serde values; HTTP 422 response requires Step 3 handler wiring
+- A-014 ✓ EntityType imported and used in at least one file per stack
+
+### Phase 5: Validation
+
+- [ ] S012: Final read-only inspection of all created files
+  - **Assigned:** validator
+  - **Depends:** S009, S010, S011, S008-D
+  - **Parallel:** false
+  - **Checks:** (1) All 18 entity types present in each of the three binding files; (2) All 8 relation types present in each binding; (3) No TODO/FIXME stubs remaining in any created file; (4) Rust `cargo build` passes; (5) TypeScript `bun run check` passes; (6) Android `./gradlew assembleDebug` passes; (7) `bun run packages/contracts/scripts/validate.ts` exits 0; (8) CI workflow includes `validate-contracts` job with correct `needs` dependencies; (9) README accurately describes the binding locations and add-a-type workflow.
+
+---
+
+## Acceptance Criteria
+
+- [ ] All testable assertions from Spec.md verified (A-001 through A-012, A-014; A-013 partial per note above)
+- [ ] All tests passing (`cargo test`, `bun test`, Android unit tests)
+- [ ] CI `validate-contracts` job green on push
+- [ ] No TODO/FIXME stubs in created files
+- [ ] `packages/contracts/README.md` updated with binding locations and add-a-type workflow
+
+---
+
+## Validation Commands
+
+```bash
+# Verify registries (A-001, A-002)
+jq '.values | length' packages/contracts/entity-types.json   # expect 18
+jq '.values | length' packages/contracts/relation-types.json  # expect 8
+
+# Run CI validation script locally (A-003–A-007, A-012)
+bun run packages/contracts/scripts/validate.ts
+
+# Rust build + tests (A-005, A-008–A-011)
+cd apps/server && cargo build && cargo test
+
+# TypeScript type check + tests (A-003, A-008–A-011)
+cd apps/web && bun run check && bun test
+
+# Android build (A-004, A-006, A-008–A-011)
+cd apps/android && ./gradlew assembleDebug
+
+# Usage import check (A-014)
+grep -r "EntityType" apps/server/server/src/routes/health.rs
+grep -r "EntityType" apps/web/src/lib/contracts/constants.ts
+grep -r "EntityType" apps/android/app/src/main/java/com/getaltair/altair/MainActivity.kt
+```
+
+---
+
+## Notes
+
+- **A-013 partial:** Full 422 rejection test requires Step 3 (Server Core) to add domain write handlers. The foundation (Rust `EntityType` enum + serde deserialization) is laid here; Step 3 adds the HTTP status code mapping.
+- **Kotlin serialization annotations:** `RelationRecord` and `AttachmentRecord` DTOs are plain `data class` without JSON annotations. Gson/Moshi/kotlinx.serialization choice is deferred to Step 8 (Android Client); annotations are added then.
+- **Sync stream names provisional:** `sync-streams.json` includes `"provisional": true`. Step 4 (Sync Engine) will finalize stream bucket designs; if names change, update the registry and run the validation script to catch binding drift.

--- a/Context/Features/002-SharedContracts/Steps.md
+++ b/Context/Features/002-SharedContracts/Steps.md
@@ -219,6 +219,37 @@ Verify all assertions:
 
 ---
 
+### Phase 6: Post-Review Additions (2026-04-12)
+
+Tasks identified during code review that were missed in the original implementation.
+
+- [ ] S013: Implement S007-T drift-detection test scenarios
+  - **Assigned:** builder-infra
+  - **Depends:** S007
+  - **Parallel:** false
+  - **Detail:** S007-T test scenarios were planned but not shipped. Implement all four:
+    (1) Run script with correct bindings — assert exit code 0;
+    (2) Temporarily add `{ "id": "test_fake_type", "description": "Test" }` to entity-types.json, run script — assert exit code 1 and diff output names `test_fake_type`;
+    (3) Revert dummy entry — assert exit code 0 again;
+    (4) Remove one entry from a binding file, run script — assert exit code 1.
+  - **Relates to:** P2-009, A-008, S007-T
+
+- [ ] S014: Add throwing fromValue() companion to all three Kotlin enums
+  - **Assigned:** builder-android
+  - **Depends:** S006
+  - **Parallel:** false
+  - **Detail:** Rename existing `fromValue()` to `fromValueOrNull()` on EntityType, RelationType, and SyncStream. Add a throwing variant: `fun fromValue(value: String): EntityType = fromValueOrNull(value) ?: throw IllegalArgumentException("Unknown EntityType: '$value'")`. This prevents `!!` usage at Step 3/8 callsites per kotlin-android.md convention.
+  - **Relates to:** P2-010
+
+- [ ] S015: Add entry-count tests for RelationType and SyncStream in Kotlin
+  - **Assigned:** builder-android
+  - **Depends:** S006
+  - **Parallel:** false
+  - **Detail:** Add `assertEquals(8, RelationType.entries.size)` and `assertEquals(5, SyncStream.entries.size)` assertions. Add to EntityTypeTest.kt or create RelationTypeTest.kt. Satisfies A-002 fully in Kotlin.
+  - **Relates to:** P2-011, A-002
+
+---
+
 ## Acceptance Criteria
 
 - [ ] All testable assertions from Spec.md verified (A-001 through A-012, A-014; A-013 partial per note above)

--- a/Context/Features/002-SharedContracts/Steps.md
+++ b/Context/Features/002-SharedContracts/Steps.md
@@ -6,9 +6,9 @@
 ---
 
 ## Progress
-- **Status:** Not started
-- **Current task:** --
-- **Last milestone:** --
+- **Status:** Complete
+- **Completed:** 2026-04-13
+- **Last milestone:** M4 — Final validation passed (2026-04-13)
 
 ---
 

--- a/Context/Features/002-SharedContracts/Steps.md
+++ b/Context/Features/002-SharedContracts/Steps.md
@@ -223,7 +223,7 @@ Verify all assertions:
 
 Tasks identified during code review that were missed in the original implementation.
 
-- [ ] S013: Implement S007-T drift-detection test scenarios
+- [x] S013: Implement S007-T drift-detection test scenarios
   - **Assigned:** builder-infra
   - **Depends:** S007
   - **Parallel:** false
@@ -234,14 +234,14 @@ Tasks identified during code review that were missed in the original implementat
     (4) Remove one entry from a binding file, run script — assert exit code 1.
   - **Relates to:** P2-009, A-008, S007-T
 
-- [ ] S014: Add throwing fromValue() companion to all three Kotlin enums
+- [x] S014: Add throwing fromValue() companion to all three Kotlin enums
   - **Assigned:** builder-android
   - **Depends:** S006
   - **Parallel:** false
   - **Detail:** Rename existing `fromValue()` to `fromValueOrNull()` on EntityType, RelationType, and SyncStream. Add a throwing variant: `fun fromValue(value: String): EntityType = fromValueOrNull(value) ?: throw IllegalArgumentException("Unknown EntityType: '$value'")`. This prevents `!!` usage at Step 3/8 callsites per kotlin-android.md convention.
   - **Relates to:** P2-010
 
-- [ ] S015: Add entry-count tests for RelationType and SyncStream in Kotlin
+- [x] S015: Add entry-count tests for RelationType and SyncStream in Kotlin
   - **Assigned:** builder-android
   - **Depends:** S006
   - **Parallel:** false

--- a/Context/Features/002-SharedContracts/Tech.md
+++ b/Context/Features/002-SharedContracts/Tech.md
@@ -1,0 +1,343 @@
+# Tech Plan: Shared Contracts
+
+**Spec:** `Context/Features/002-SharedContracts/Spec.md`
+**Stacks involved:** TypeScript/SvelteKit, Kotlin/Android, Rust/Axum, GitHub Actions CI
+
+---
+
+## Architecture Overview
+
+Shared Contracts is a pure infrastructure step. It produces no user-facing behaviour — it creates the compile-time safety net that all subsequent steps rely on. The output is three JSON registries in `packages/contracts/` and hand-written language bindings written into each app's source tree.
+
+```
+packages/contracts/
+├── entity-types.json
+├── relation-types.json
+├── sync-streams.json
+└── scripts/
+    └── validate.ts          ← Bun script; run by CI
+
+apps/web/src/lib/contracts/
+├── entityTypes.ts
+├── relationTypes.ts
+├── syncStreams.ts
+└── dtos.ts                  ← EntityRef, RelationRecord, AttachmentRecord, SyncSubscriptionRequest
+
+apps/android/app/src/main/java/com/getaltair/altair/contracts/
+├── EntityType.kt
+├── RelationType.kt
+├── SyncStream.kt
+└── Dtos.kt
+
+apps/server/server/src/
+└── contracts.rs             ← All enums + DTOs in one module, re-exported from mod
+```
+
+The CI validation script is the enforcement mechanism. It reads each JSON registry and checks every value appears in the corresponding binding file (all three stacks). A missing or extra value exits 1.
+
+---
+
+## Key Decisions
+
+### Decision 1: TypeScript binding shape — `as const` object vs. string enum
+
+**Options considered:**
+- **Option A: String enum** (`enum EntityType { User = 'user', ... }`) — native TypeScript construct, exhaustive switch possible.
+  - Downside: TypeScript string enums are not structurally compatible with plain strings; passing `'user'` where `EntityType` is expected fails. Forces callers to import the enum rather than using string literals. Harder to iterate values at runtime.
+- **Option B: `as const` object with derived union type** (`export const EntityType = { User: 'user', ... } as const; export type EntityTypeValue = typeof EntityType[keyof typeof EntityType];`) — values are plain strings at runtime; the type is a string literal union. IDE autocomplete works. Iteration via `Object.values(EntityType)` works directly.
+
+**Chosen:** Option B — `as const` object
+
+**Rationale:** PowerSync subscriptions and serialized JSON both deal in plain strings. The `as const` pattern gives the type-safety benefit without the string incompatibility problem. It also makes the CI validation script straightforward: `Object.values(EntityType)` returns the exact string set to compare against the registry.
+
+---
+
+### Decision 2: Kotlin binding shape — enum class vs. sealed class
+
+**Options considered:**
+- **Option A: `enum class EntityType(val value: String)`** — straightforward, iterable via `entries`, `when` exhaustiveness checking works natively. `fromValue()` companion lookup is trivial.
+- **Option B: Sealed class with object subclasses** — more idiomatic for complex ADTs, but overkill for string constants with no associated data variants.
+
+**Chosen:** Option A — `enum class` with a `value: String` constructor parameter
+
+**Rationale:** These are string constants with no variant-specific data. Enums are iterable via `EntityType.entries`, exhaustive `when` works at compile time, and a companion `fromValue(s: String)` method provides safe lookup. Sealed classes add complexity with no benefit here.
+
+---
+
+### Decision 3: Rust binding shape — `rename_all` vs. per-variant `rename`
+
+**Options considered:**
+- **Option A: `#[serde(rename_all = "snake_case")]`** — works cleanly when all variant names map uniformly to snake_case strings. Fails here because entity types have domain prefixes: `GuidanceEpic` → `guidance_epic` works, but `User` → `user` and `TrackingItem` → `tracking_item` diverge in prefix structure. The Rust variant name would have to match the full registry string, e.g., `GuidanceEpic` for `"guidance_epic"` — which works with `rename_all = "snake_case"`. Actually usable.
+- **Option B: Per-variant `#[serde(rename = "guidance_epic")]`** — explicit, no naming ambiguity, resistant to future rename-all policy changes. Slightly more verbose.
+
+**Chosen:** Option B — per-variant `#[serde(rename = "...")]`
+
+**Rationale:** Per-variant renames make the mapping from Rust variant to registry string explicit and readable in the source file. This also makes the CI validation script reliable: it can grep for `rename = "value"` strings without having to simulate Rust's naming transformation logic. The verbosity is acceptable for a ~20-entry enum.
+
+**Serde is already a dependency** (`serde = { version = "1.0.228", features = ["derive"] }` in `server/Cargo.toml`). No new dependencies needed.
+
+---
+
+### Decision 4: UUID representation in DTOs across stacks
+
+**Options considered:**
+- **Option A: String everywhere** — UUIDs as `String` (TypeScript/Kotlin) and `String` (Rust). Simple cross-platform serialization; no special types needed.
+- **Option B: Native UUID types** — `string` (TS), `String` (Kotlin with format doc), `uuid::Uuid` (Rust). Rust already has `uuid` crate; TypeScript and Kotlin treat UUIDs as strings naturally.
+
+**Chosen:** Option B — native `uuid::Uuid` in Rust; `string` in TypeScript; `String` in Kotlin
+
+**Rationale:** The `uuid` crate is already in `server/Cargo.toml`. Using `uuid::Uuid` in Rust DTOs provides parse-time validation and prevents raw string confusion. TypeScript and Kotlin use `string` since both serialize UUIDs as strings for JSON/PowerSync. A JSDoc/KDoc comment documents the UUID constraint.
+
+---
+
+### Decision 5: CI validation approach — dynamic import vs. text parsing
+
+**Options considered:**
+- **Option A: Parse binding files as text** — regex/grep for string literals in each file. Simple, no build step needed. Slightly fragile if formatting changes (e.g., multiline string).
+- **Option B: Dynamic import of TypeScript bindings** — `import * as EntityTypes from '...'` in the validation script, then compare `Object.values()`. Reliable for TypeScript. Kotlin and Rust bindings still require text parsing.
+
+**Chosen:** Hybrid — dynamic import for TypeScript; text parsing for Kotlin and Rust
+
+**Rationale:** For TypeScript, dynamic import is exact and immune to formatting. For Kotlin and Rust, the binding files follow a fixed pattern: Kotlin enums list `EnumVariant("registry_value")` and Rust uses `#[serde(rename = "registry_value")]`. Extracting quoted strings from these patterns is reliable given the disciplined structure of hand-written binding files. The validation script is a Bun TypeScript script at `packages/contracts/scripts/validate.ts`.
+
+---
+
+## Stack-Specific Details
+
+### Rust (`apps/server/server/src/`)
+
+**Files to create:**
+- `contracts.rs` — single module containing `EntityType`, `RelationType`, `SyncStream` enums and `EntityRef`, `RelationRecord`, `AttachmentRecord`, `SyncSubscriptionRequest` structs
+
+**Add to `main.rs`:**
+```rust
+mod contracts;
+pub use contracts::*;
+```
+
+**Enum shape:**
+```rust
+// Source of truth: packages/contracts/entity-types.json
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EntityType {
+    #[serde(rename = "user")]           User,
+    #[serde(rename = "household")]      Household,
+    #[serde(rename = "initiative")]     Initiative,
+    #[serde(rename = "tag")]            Tag,
+    #[serde(rename = "attachment")]     Attachment,
+    #[serde(rename = "guidance_epic")]         GuidanceEpic,
+    #[serde(rename = "guidance_quest")]        GuidanceQuest,
+    // ... all 18 variants
+}
+```
+
+**DTO shapes** (field names snake_case matching the ERD column names):
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntityRef {
+    pub entity_type: EntityType,
+    pub entity_id: uuid::Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelationRecord {
+    pub id: uuid::Uuid,
+    pub from_entity_type: EntityType,
+    pub from_entity_id: uuid::Uuid,
+    pub to_entity_type: EntityType,
+    pub to_entity_id: uuid::Uuid,
+    pub relation_type: RelationType,
+    pub source_type: String,
+    pub status: String,
+    pub confidence: Option<f64>,
+    pub evidence: Option<String>,
+    pub user_id: uuid::Uuid,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+```
+
+**Dependencies:** None new. `serde`, `uuid`, `chrono` already present in `server/Cargo.toml`.
+
+**Patterns to follow:** `.claude/rules/rust-axum.md` — module structure, no `unwrap()`, `derive` macros.
+
+---
+
+### TypeScript (`apps/web/src/lib/contracts/`)
+
+**Files to create:**
+- `entityTypes.ts`
+- `relationTypes.ts`
+- `syncStreams.ts`
+- `dtos.ts`
+- `index.ts` — barrel re-export
+
+**Binding shape:**
+```typescript
+// Source of truth: packages/contracts/entity-types.json
+export const EntityType = {
+  User:           'user',
+  Household:      'household',
+  Initiative:     'initiative',
+  Tag:            'tag',
+  Attachment:     'attachment',
+  GuidanceEpic:         'guidance_epic',
+  GuidanceQuest:        'guidance_quest',
+  // ... all 18
+} as const;
+
+export type EntityTypeValue = typeof EntityType[keyof typeof EntityType];
+```
+
+**DTO shapes:**
+```typescript
+export interface EntityRef {
+  entity_type: EntityTypeValue;
+  entity_id: string; // UUID
+}
+
+export interface RelationRecord {
+  id: string;
+  from_entity_type: EntityTypeValue;
+  from_entity_id: string;
+  to_entity_type: EntityTypeValue;
+  to_entity_id: string;
+  relation_type: RelationTypeValue;
+  source_type: string;
+  status: string;
+  confidence: number | null;
+  evidence: string | null;
+  user_id: string;
+  created_at: string; // ISO 8601
+  updated_at: string;
+  deleted_at: string | null;
+}
+```
+
+**Import path:** `import { EntityType } from '$lib/contracts'`
+
+**Patterns to follow:** `.claude/rules/svelte.md` — `$lib/` alias, barrel exports via `index.ts`, strict TypeScript.
+
+---
+
+### Kotlin (`apps/android/app/src/main/java/com/getaltair/altair/contracts/`)
+
+**Files to create:**
+- `EntityType.kt`
+- `RelationType.kt`
+- `SyncStream.kt`
+- `Dtos.kt`
+
+**Binding shape:**
+```kotlin
+// Source of truth: packages/contracts/entity-types.json
+enum class EntityType(val value: String) {
+    USER("user"),
+    HOUSEHOLD("household"),
+    INITIATIVE("initiative"),
+    TAG("tag"),
+    ATTACHMENT("attachment"),
+    GUIDANCE_EPIC("guidance_epic"),
+    GUIDANCE_QUEST("guidance_quest"),
+    // ... all 18
+
+    companion object {
+        fun fromValue(value: String): EntityType? =
+            entries.find { it.value == value }
+    }
+}
+```
+
+**DTO shapes** (using `@SerializedName` for JSON field mapping with Gson, or `@Json` for Moshi):
+```kotlin
+data class EntityRef(
+    val entityType: String,   // EntityType.value
+    val entityId: String      // UUID string
+)
+```
+
+**Note:** The Android project currently has no DI framework or JSON library set up beyond the scaffold. The DTO serialization annotations (`@SerializedName` vs `@Json`) depend on which JSON library is chosen during Step 3 (Server Core) when the API client is built. For Step 2, define DTOs as plain `data class` without annotations — annotations are added in Step 8 (Android Client).
+
+**Patterns to follow:** `.claude/rules/kotlin-android.md` — `val` over `var`, no `!!`, packages lowercase.
+
+---
+
+## Registry Structure
+
+Each registry is a JSON object with a `version` field and a `values` array. Each entry has an `id` (the canonical string) and a `description`.
+
+```json
+{
+  "contracts_version": "1.0.0",
+  "values": [
+    { "id": "user",           "description": "Platform user account" },
+    { "id": "household",      "description": "Shared household space" },
+    { "id": "initiative",     "description": "High-level goal or project" },
+    { "id": "tag",            "description": "User-defined label" },
+    { "id": "attachment",     "description": "File attached to an entity" },
+    { "id": "guidance_epic",  "description": "Epic: a grouped set of quests within an initiative" },
+    { "id": "guidance_quest", "description": "Quest: a single actionable task" },
+    ...
+  ]
+}
+```
+
+**Provisional sync stream names** for `sync-streams.json` (Step 4 may revise):
+
+| Stream ID      | Scope                                          |
+|----------------|------------------------------------------------|
+| `user_data`    | User's own Core entities (initiatives, tags)   |
+| `household`    | Household-scoped data (membership, locations)  |
+| `guidance`     | Guidance domain tables                         |
+| `knowledge`    | Knowledge domain tables                        |
+| `tracking`     | Tracking domain tables                         |
+
+---
+
+## Integration Points
+
+The contracts module has no runtime integration in Step 2 — the bindings are imported by other modules but no API calls or database writes happen here. The integration point is the CI validation script:
+
+```
+packages/contracts/scripts/validate.ts
+  reads → entity-types.json, relation-types.json, sync-streams.json
+  checks → apps/web/src/lib/contracts/{entityTypes,relationTypes,syncStreams}.ts
+  checks → apps/android/.../contracts/{EntityType,RelationType,SyncStream}.kt
+  checks → apps/server/server/src/contracts.rs
+  exits 1 if any binding is missing a registry value or has an extra value
+```
+
+The CI workflow (`.github/workflows/ci.yml`) gets a new job `validate-contracts` that runs `bun run packages/contracts/scripts/validate.ts` and is declared as a dependency of the existing `smoke-test` job.
+
+**Assertion A-013 dependency:** Step 3 (Server Core) adds the actual HTTP handler that calls `EntityType::from_str()` or match-validates the incoming entity type. That code can reference `contracts::EntityType` from the module added here.
+
+---
+
+## Risks & Unknowns
+
+- **Risk:** Sync stream names defined here conflict with the bucket names chosen in Step 4.
+  - **Mitigation:** Treat `sync-streams.json` as provisional (noted in a comment in the file). When Step 4 finalizes bucket names, update the registry and bindings together — the CI validation script catches any binding left behind.
+
+- **Risk:** Kotlin DTO serialization annotations need to be chosen (Gson vs. Moshi vs. kotlinx.serialization) before Android client work begins in Step 8.
+  - **Mitigation:** DTOs are defined as plain `data class` in Step 2. The JSON library decision is deferred to Step 8 (Android Client); annotations are added then. This avoids a premature dependency on a library that may be revisited.
+
+- **Risk:** `RelationRecord` and `AttachmentRecord` contain `status` and `source_type` as raw `String` — not typed to their enum values — because those enums (`RelationStatus`, `AttachmentState`, etc.) are domain-specific and belong in Step 3/8 domain modules, not the cross-platform contracts layer.
+  - **Mitigation:** Accepted tradeoff. The contracts layer owns the *identifier registries*; domain-specific status enums live in their respective domain modules. Document this boundary in `contracts.rs`.
+
+---
+
+## Testing Strategy
+
+- **Unit tests in Rust** (`#[cfg(test)]` in `contracts.rs`): round-trip serde tests — serialize an `EntityType` variant to JSON string, deserialize back, assert equality. One test per enum is sufficient.
+- **Unit tests in TypeScript** (co-located `contracts.spec.ts`): assert `Object.values(EntityType)` has the expected count and contains specific known values.
+- **CI validation script** (`validate.ts`): this is the primary consistency test. It runs on every push; failure means a binding drifted from the registry.
+- **No Kotlin unit tests in Step 2** — the enum is trivially correct; tested implicitly when the Android project compiles (`./gradlew assembleDebug`).
+
+---
+
+## Revision History
+
+| Date       | Change       | ADR |
+|------------|--------------|-----|
+| 2026-04-12 | Initial tech plan | —   |

--- a/Context/Reviews/PR-feat-shared-contracts-2026-04-12.md
+++ b/Context/Reviews/PR-feat-shared-contracts-2026-04-12.md
@@ -141,7 +141,7 @@
 - [x] All [TASK] findings added to Steps.md (S013, S014, S015 in Phase 6)
 - [x] All [ADR] findings have ADRs created or dismissed (none)
 - [x] All [RULE] findings applied or dismissed (none)
-- [ ] Review verified by review-verify agent
+- [x] Review verified by review-verify agent
 
 ## Resolution Summary
 **Resolved at:** 2026-04-12

--- a/Context/Reviews/PR-feat-shared-contracts-2026-04-12.md
+++ b/Context/Reviews/PR-feat-shared-contracts-2026-04-12.md
@@ -1,0 +1,156 @@
+# PR Review: feat/shared-contracts → main
+
+**Date:** 2026-04-12
+**Feature:** Context/Features/002-SharedContracts/
+**Branch:** feat/shared-contracts
+**Reviewers:** pr-review-toolkit (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer)
+**Status:** 🟡 Partially resolved
+
+## Summary
+
+14 findings across 5 review dimensions. Three critical blockers in `validate.ts` — the Rust extraction logic can silently pass a drifted binding state, `diff()` has no duplicate detection, and the file has live TypeScript compiler errors. One missing task (S007-T drift-test not shipped). The remaining 10 findings are medium/low fixes that should be addressed before merge or tracked for the next pass.
+
+---
+
+## Findings
+
+### Fix-Now
+
+#### [FIX] P2-001: validate.ts Rust extraction logic silently passes drifted state
+- **File:** `packages/contracts/scripts/validate.ts:98-110`
+- **Severity:** Critical
+- **Detail:** `checkRust()` extracts all `serde(rename = "...")` values from the entire `contracts.rs` file into one flat array, then partitions by registry set membership. Values that appear in multiple registries (e.g. `"household"` exists in both entity-types and sync-streams) are double-counted. The second clause of the filter predicate is a tautology — `entityIds.includes(v)` is always true when `entitySet.has(v)` is already true. Any field-level `#[serde(rename = "...")]` annotation added to a Rust struct in the future would be silently swept into `allRenames` and miscategorized. The script can exit 0 when bindings have actually drifted.
+- **Relates to:** A-003, A-005, A-006, A-007 (all CI validation assertions); S007
+- **Status:** ✅ Fixed
+- **Resolution:** Rewrote `checkRust()` to use a new `extractRustEnumValues(text, enumName)` helper that scopes extraction to the named enum block via regex, preventing struct field-level renames from polluting the results.
+
+#### [FIX] P2-002: validate.ts diff() lacks duplicate detection
+- **File:** `packages/contracts/scripts/validate.ts:21-28`
+- **Severity:** Critical
+- **Detail:** `diff()` uses `Array.includes()` for membership checks only — it does not detect if a binding contains a value twice. A duplicated entry in a binding file (as currently produced by P2-001 for Rust) is silently ignored. Add a duplicate check: `const dupes = actual.filter((id, i) => actual.indexOf(id) !== i)` and assert `expected.length === actual.length`.
+- **Relates to:** A-005, A-007; S007
+- **Status:** ✅ Fixed
+- **Resolution:** Added `const dupes = actual.filter((id, i) => actual.indexOf(id) !== i)` check at the top of `diff()`; reports duplicate binding values before missing/extra checks.
+
+#### [FIX] P2-003: TypeScript diagnostic errors in validate.ts
+- **File:** `packages/contracts/scripts/validate.ts:11,63,98`
+- **Severity:** Critical
+- **Detail:** Three live compiler errors reported by diagnostics:
+  - Line 11: `import.meta.dir` — Property 'dir' does not exist on type 'ImportMeta' (TS2339). Use `new URL('.', import.meta.url).pathname` or `path.dirname(fileURLToPath(import.meta.url))` as an alternative, or rely on Bun's `import.meta.dir` which requires a Bun-aware tsconfig (add `"types": ["bun-types"]`).
+  - Lines 63, 98: `matchAll` iterator target error (TS2802) — requires `--target es2015` or `--downlevelIteration`. Add `"target": "ES2020"` (or higher) to the tsconfig covering this file.
+- **Relates to:** S007
+- **Status:** ✅ Fixed
+- **Resolution:** Replaced `import.meta.dir` with `fileURLToPath(new URL('../../..', import.meta.url))` (standard ESM, no bun-types needed). Created `packages/contracts/tsconfig.json` with `target: ES2020` and `module: ES2020` to cover this script. Replaced `[...text.matchAll()]` spread with the same approach — tsconfig target now satisfies TS2802.
+
+#### [FIX] P2-004: SyncSubscriptionRequest.streams typed as string[] instead of SyncStreamValue[]
+- **File:** `apps/web/src/lib/contracts/dtos.ts:47`
+- **Severity:** High
+- **Detail:** Every other enum-typed field in `dtos.ts` uses the narrowed literal union type (e.g. `EntityTypeValue`). `SyncSubscriptionRequest` is not a PowerSync row record — it is application-constructed code, so the "plain-string PowerSync compatibility" rationale does not apply. `SyncStreamValue` is already exported from `syncStreams.ts`. Change to `streams: SyncStreamValue[]`.
+- **Relates to:** A-009, A-012; S005
+- **Status:** ✅ Fixed
+- **Resolution:** Added `import type { SyncStreamValue } from './syncStreams.js'` to `dtos.ts` and changed `streams: string[]` to `streams: SyncStreamValue[]`.
+
+#### [FIX] P2-005: CI bun install / script working-directory mismatch
+- **File:** `.github/workflows/ci.yml:111-116`
+- **Severity:** Medium
+- **Detail:** `bun install` runs in `apps/web` (correct for node_modules), but `bun run packages/contracts/scripts/validate.ts` runs from the checkout root with no `working-directory` override. The dynamic `import()` of TypeScript files from `apps/web/src/lib/contracts/` depends on Bun's module resolution finding the web app's tsconfig. If this breaks in CI, the error is `validate.ts: unexpected error: <import error>` with no indication of the actual cause. Per S008 the approach is intentional — confirm it holds on a clean CI runner, or add a `working-directory: .` comment explaining why root execution is correct.
+- **Relates to:** S008
+- **Status:** ⚠️ Deferred
+- **Resolution:** `security_reminder_hook` blocks all edits to ci.yml. The validate.ts rewrite now uses `fileURLToPath(import.meta.url)` for ROOT resolution (self-documenting). Add an explanatory comment to ci.yml manually: `# Run from repo root — validate.ts resolves ROOT via import.meta.url and imports TS binding files via Bun's dynamic import, using the web app's module graph.`
+
+#### [FIX] P2-006: validate.ts error messages swallow file context
+- **File:** `packages/contracts/scripts/validate.ts:15-19,35-47,61-64`
+- **Severity:** Medium
+- **Detail:** Three failure paths produce undifferentiated top-level errors: (1) `loadRegistry` throws a bare `TypeError` on malformed/missing `values` key with no file name; (2) `checkTypeScript` dynamic `import()` failure produces opaque "unexpected error" with no indication of which binding file failed; (3) `checkKotlin` regex returning 0 matches is indistinguishable from an actual missing binding. Each path should name the file and describe what was expected so CI logs are actionable.
+- **Relates to:** S007
+- **Status:** ✅ Fixed
+- **Resolution:** `loadRegistry` now throws with the file path and parse error; each `checkTypeScript` import is wrapped in try/catch that includes the full file path; `checkKotlin` emits a "no values extracted from ${filePath}" error when the regex finds 0 matches.
+
+#### [FIX] P2-007: contracts.rs top comment says "regenerate bindings" — no codegen exists
+- **File:** `apps/server/server/src/contracts.rs:2`
+- **Severity:** Medium
+- **Detail:** Comment reads: "Do not add inline enum values here — update the JSON registries and regenerate bindings." There is no code generator. A future maintainer will search for a generation script that does not exist. Replace with: "Do not add inline enum values here — update the JSON registries and update all three binding files (contracts.rs, EntityType.kt, entityTypes.ts) manually, then run validate.ts."
+- **Relates to:** S004
+- **Status:** ✅ Fixed
+- **Resolution:** Updated line 2 to: "Do not add inline enum values here — update the JSON registries and update all three / binding files (contracts.rs, EntityType.kt, entityTypes.ts) manually, then run validate.ts."
+
+#### [FIX] P2-008: pub use contracts::* glob re-export in main.rs
+- **File:** `apps/server/server/src/main.rs:10`
+- **Severity:** Low
+- **Detail:** `pub use contracts::*;` re-exports every public item from the contracts module at the crate root. Internal modules already import via `crate::contracts::EntityType` directly (as demonstrated in `health.rs`). For a binary crate this is harmless but pollutes the root namespace and violates the "minimum code" convention. Note: S004 explicitly prescribed this — the prescribing task itself was over-broad.
+- **Relates to:** S004
+- **Status:** ✅ Fixed
+- **Resolution:** Removed `pub use contracts::*;` from `main.rs`. Confirmed `health.rs` and all other route modules import via `crate::contracts::*` directly. `cargo test` passes (12/12).
+
+#### [FIX] P2-012: Kotlin Dtos.kt enum-typed fields use String instead of enum types
+- **File:** `apps/android/app/src/main/java/com/getaltair/altair/contracts/Dtos.kt`
+- **Severity:** Medium
+- **Detail:** `EntityRef.entityType`, `RelationRecord.fromEntityType`, `RelationRecord.toEntityType`, `RelationRecord.relationType`, and `AttachmentRecord.entityType` are all typed `String` with comments like `// EntityType.value`. The `EntityType`, `RelationType` enums are in the same package. Using the enum types for in-memory representation does not require a serialization library and is independent of the Step 8 JSON annotation deferral. The TypeScript DTOs already use `EntityTypeValue` for the same fields. Switching to enum types here closes the cross-stack asymmetry before Step 3 introduces callsites.
+- **Relates to:** A-009, A-010, A-011; S006
+- **Status:** ✅ Fixed
+- **Resolution:** Changed all five fields to their enum types: `EntityRef.entityType: EntityType`, `RelationRecord.fromEntityType/toEntityType: EntityType`, `RelationRecord.relationType: RelationType`, `AttachmentRecord.entityType: EntityType`.
+
+#### [FIX] P2-013: Rust AttachmentRecord size_bytes: Option<i64> should be Option<u64>
+- **File:** `apps/server/server/src/contracts.rs` (`AttachmentRecord`)
+- **Severity:** Low
+- **Detail:** A byte count is conceptually non-negative. Using `i64` allows negative values with no type-level rejection. Change to `Option<u64>`. Also note TypeScript uses `number | null` (f64, 53-bit integer ceiling for large files) and Kotlin uses `Long?` (i64) — document the cross-stack signedness difference.
+- **Relates to:** A-011; S004
+- **Status:** ✅ Fixed
+- **Resolution:** Changed `size_bytes: Option<i64>` to `Option<u64>` and added a doc comment to `AttachmentRecord` noting the cross-stack signedness difference (TypeScript: `number | null`, Kotlin: `Long?`).
+
+#### [FIX] P2-014: Dtos.kt file-header comment references all 3 JSON registries misleadingly
+- **File:** `apps/android/app/src/main/java/com/getaltair/altair/contracts/Dtos.kt:3-5`
+- **Severity:** Low
+- **Detail:** Header reads "Source of truth: packages/contracts/entity-types.json, relation-types.json, sync-streams.json" but `Dtos.kt` is not validated against any of them — the validate.ts script does not check this file at all. Replace with: "DTOs wrapping contracts defined in EntityType.kt, RelationType.kt, and SyncStream.kt. JSON serialization annotations are deferred to Step 8 (Android Client) when the JSON library is chosen."
+- **Relates to:** S006
+- **Status:** ✅ Fixed
+- **Resolution:** Updated Dtos.kt header to accurately describe the file as DTOs wrapping the three Kotlin enum files, with a note that JSON serialization annotations are deferred to Step 8.
+
+---
+
+### Missing Tasks
+
+#### [TASK] P2-009: S007-T drift-detection test not shipped
+- **File:** `packages/contracts/scripts/validate.ts` (no test file exists)
+- **Severity:** High
+- **Detail:** S007-T in Steps.md describes 4 test scenarios for the validation script including the critical bad-state case: add a dummy registry entry, run script, assert exit 1 and that the diff output names the entry. None of these were shipped. The `validate-contracts` CI job only proves the script exits 0 today — it does not prove it exits 1 when drift is introduced. A-008 is unverified.
+- **Relates to:** A-008; S007-T
+- **Status:** ✅ Task created
+- **Resolution:** Added as S013 in Steps.md Phase 6. The 4 test scenarios from S007-T are reproduced in S013.
+
+#### [TASK] P2-010: Kotlin enums need a throwing fromValue() variant before Step 3/8 callsites
+- **File:** `apps/android/app/src/main/java/com/getaltair/altair/contracts/EntityType.kt:29`, `RelationType.kt:19`, `SyncStream.kt:17`
+- **Severity:** Medium
+- **Detail:** All three Kotlin enums expose only `fromValue(value: String): EntityType?` (nullable). There are no production callsites yet, but when Step 3 or Step 8 writes the Android data layer, every deserialization site will either use `!!` (forbidden by `.claude/rules/kotlin-android.md`) or silent null propagation. Add a throwing companion alongside the nullable one: `fun fromValue(value: String): EntityType = fromValueOrNull(value) ?: throw IllegalArgumentException("Unknown EntityType: '$value'")`. Rename existing nullable return to `fromValueOrNull`.
+- **Relates to:** S006
+- **Status:** ✅ Task created
+- **Resolution:** Added as S014 in Steps.md Phase 6.
+
+#### [TASK] P2-011: Kotlin RelationType entry count not tested
+- **File:** `apps/android/app/src/test/java/com/getaltair/altair/contracts/EntityTypeTest.kt`
+- **Severity:** Low
+- **Detail:** `EntityTypeTest.kt` verifies 18 `EntityType` entries (covering A-001/A-004) but contains no `assertEquals(8, RelationType.entries.size)` assertion. A-002 is half-satisfied in Kotlin. Add an entry-count test for `RelationType` (and ideally `SyncStream`) — either in this file or a new `RelationTypeTest.kt`.
+- **Relates to:** A-002; S006-T
+- **Status:** ✅ Task created
+- **Resolution:** Added as S015 in Steps.md Phase 6 covering both RelationType and SyncStream entry-count assertions.
+
+---
+
+## Resolution Checklist
+- [x] All [FIX] findings resolved (10 fixed, 1 deferred — P2-005 blocked by security_reminder_hook)
+- [x] All [TASK] findings added to Steps.md (S013, S014, S015 in Phase 6)
+- [x] All [ADR] findings have ADRs created or dismissed (none)
+- [x] All [RULE] findings applied or dismissed (none)
+- [ ] Review verified by review-verify agent
+
+## Resolution Summary
+**Resolved at:** 2026-04-12
+**Session:** resolve-review session — all FIX and TASK findings executed
+
+| Category | Total | Resolved | Deferred |
+|---|---|---|---|
+| [FIX] | 11 | 10 | 1 (P2-005, hook-blocked) |
+| [TASK] | 3 | 3 | 0 |
+| [ADR] | 0 | — | — |
+| [RULE] | 0 | — | — |
+| **Total** | **14** | **13** | **1** |

--- a/apps/android/app/src/main/java/com/getaltair/altair/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/getaltair/altair/MainActivity.kt
@@ -11,9 +11,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.getaltair.altair.contracts.EntityType
 import com.getaltair.altair.ui.theme.AltairTheme
 
 class MainActivity : ComponentActivity() {
+    private val coreEntityTypes = listOf(EntityType.USER, EntityType.HOUSEHOLD, EntityType.INITIATIVE)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -22,7 +25,7 @@ class MainActivity : ComponentActivity() {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     Greeting(
                         name = "Android",
-                        modifier = Modifier.padding(innerPadding)
+                        modifier = Modifier.padding(innerPadding),
                     )
                 }
             }
@@ -31,10 +34,13 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
+fun Greeting(
+    name: String,
+    modifier: Modifier = Modifier,
+) {
     Text(
         text = "Hello $name!",
-        modifier = modifier
+        modifier = modifier,
     )
 }
 

--- a/apps/android/app/src/main/java/com/getaltair/altair/contracts/Dtos.kt
+++ b/apps/android/app/src/main/java/com/getaltair/altair/contracts/Dtos.kt
@@ -1,23 +1,23 @@
 package com.getaltair.altair.contracts
 
-// Source of truth: packages/contracts/entity-types.json, relation-types.json, sync-streams.json
-// Note: JSON serialization annotations are deferred to Step 8 (Android Client)
-//       when the JSON library (Gson / Moshi / kotlinx.serialization) is chosen.
+// DTOs wrapping contracts defined in EntityType.kt, RelationType.kt, and SyncStream.kt.
+// JSON serialization annotations are deferred to Step 8 (Android Client) when the JSON
+// library (Gson / Moshi / kotlinx.serialization) is chosen.
 
 /** A polymorphic reference to any entity by type and UUID. */
 data class EntityRef(
-    val entityType: String, // EntityType.value
+    val entityType: EntityType,
     val entityId: String, // UUID string
 )
 
 /** Mirrors the entity_relations table schema from docs/specs/05-erd.md. */
 data class RelationRecord(
     val id: String,
-    val fromEntityType: String, // EntityType.value
+    val fromEntityType: EntityType,
     val fromEntityId: String,
-    val toEntityType: String, // EntityType.value
+    val toEntityType: EntityType,
     val toEntityId: String,
-    val relationType: String, // RelationType.value
+    val relationType: RelationType,
     val sourceType: String,
     val status: String,
     val confidence: Double?,
@@ -31,7 +31,7 @@ data class RelationRecord(
 /** Mirrors the attachments table schema from docs/specs/05-erd.md. */
 data class AttachmentRecord(
     val id: String,
-    val entityType: String, // EntityType.value
+    val entityType: EntityType,
     val entityId: String,
     val fileName: String,
     val contentType: String,

--- a/apps/android/app/src/main/java/com/getaltair/altair/contracts/Dtos.kt
+++ b/apps/android/app/src/main/java/com/getaltair/altair/contracts/Dtos.kt
@@ -1,0 +1,51 @@
+package com.getaltair.altair.contracts
+
+// Source of truth: packages/contracts/entity-types.json, relation-types.json, sync-streams.json
+// Note: JSON serialization annotations are deferred to Step 8 (Android Client)
+//       when the JSON library (Gson / Moshi / kotlinx.serialization) is chosen.
+
+/** A polymorphic reference to any entity by type and UUID. */
+data class EntityRef(
+    val entityType: String, // EntityType.value
+    val entityId: String, // UUID string
+)
+
+/** Mirrors the entity_relations table schema from docs/specs/05-erd.md. */
+data class RelationRecord(
+    val id: String,
+    val fromEntityType: String, // EntityType.value
+    val fromEntityId: String,
+    val toEntityType: String, // EntityType.value
+    val toEntityId: String,
+    val relationType: String, // RelationType.value
+    val sourceType: String,
+    val status: String,
+    val confidence: Double?,
+    val evidence: String?,
+    val userId: String,
+    val createdAt: String, // ISO 8601
+    val updatedAt: String,
+    val deletedAt: String?,
+)
+
+/** Mirrors the attachments table schema from docs/specs/05-erd.md. */
+data class AttachmentRecord(
+    val id: String,
+    val entityType: String, // EntityType.value
+    val entityId: String,
+    val fileName: String,
+    val contentType: String,
+    val sizeBytes: Long?,
+    val state: String,
+    val storagePath: String?,
+    val userId: String,
+    val createdAt: String, // ISO 8601
+    val updatedAt: String,
+    val deletedAt: String?,
+)
+
+/** Parameters for subscribing to PowerSync sync streams. */
+data class SyncSubscriptionRequest(
+    val streams: List<String>, // SyncStream.value
+    val userId: String,
+)

--- a/apps/android/app/src/main/java/com/getaltair/altair/contracts/EntityType.kt
+++ b/apps/android/app/src/main/java/com/getaltair/altair/contracts/EntityType.kt
@@ -26,6 +26,8 @@ enum class EntityType(
     ;
 
     companion object {
-        fun fromValue(value: String): EntityType? = entries.find { it.value == value }
+        fun fromValueOrNull(value: String): EntityType? = entries.find { it.value == value }
+
+        fun fromValue(value: String): EntityType = fromValueOrNull(value) ?: throw IllegalArgumentException("Unknown EntityType: '$value'")
     }
 }

--- a/apps/android/app/src/main/java/com/getaltair/altair/contracts/EntityType.kt
+++ b/apps/android/app/src/main/java/com/getaltair/altair/contracts/EntityType.kt
@@ -1,0 +1,31 @@
+package com.getaltair.altair.contracts
+
+// Source of truth: packages/contracts/entity-types.json
+
+enum class EntityType(
+    val value: String,
+) {
+    USER("user"),
+    HOUSEHOLD("household"),
+    INITIATIVE("initiative"),
+    TAG("tag"),
+    ATTACHMENT("attachment"),
+    GUIDANCE_EPIC("guidance_epic"),
+    GUIDANCE_QUEST("guidance_quest"),
+    GUIDANCE_ROUTINE("guidance_routine"),
+    GUIDANCE_FOCUS_SESSION("guidance_focus_session"),
+    GUIDANCE_DAILY_CHECKIN("guidance_daily_checkin"),
+    KNOWLEDGE_NOTE("knowledge_note"),
+    KNOWLEDGE_NOTE_SNAPSHOT("knowledge_note_snapshot"),
+    TRACKING_LOCATION("tracking_location"),
+    TRACKING_CATEGORY("tracking_category"),
+    TRACKING_ITEM("tracking_item"),
+    TRACKING_ITEM_EVENT("tracking_item_event"),
+    TRACKING_SHOPPING_LIST("tracking_shopping_list"),
+    TRACKING_SHOPPING_LIST_ITEM("tracking_shopping_list_item"),
+    ;
+
+    companion object {
+        fun fromValue(value: String): EntityType? = entries.find { it.value == value }
+    }
+}

--- a/apps/android/app/src/main/java/com/getaltair/altair/contracts/RelationType.kt
+++ b/apps/android/app/src/main/java/com/getaltair/altair/contracts/RelationType.kt
@@ -1,0 +1,21 @@
+package com.getaltair.altair.contracts
+
+// Source of truth: packages/contracts/relation-types.json
+
+enum class RelationType(
+    val value: String,
+) {
+    REFERENCES("references"),
+    SUPPORTS("supports"),
+    REQUIRES("requires"),
+    RELATED_TO("related_to"),
+    DEPENDS_ON("depends_on"),
+    DUPLICATES("duplicates"),
+    SIMILAR_TO("similar_to"),
+    GENERATED_FROM("generated_from"),
+    ;
+
+    companion object {
+        fun fromValue(value: String): RelationType? = entries.find { it.value == value }
+    }
+}

--- a/apps/android/app/src/main/java/com/getaltair/altair/contracts/RelationType.kt
+++ b/apps/android/app/src/main/java/com/getaltair/altair/contracts/RelationType.kt
@@ -16,6 +16,9 @@ enum class RelationType(
     ;
 
     companion object {
-        fun fromValue(value: String): RelationType? = entries.find { it.value == value }
+        fun fromValueOrNull(value: String): RelationType? = entries.find { it.value == value }
+
+        fun fromValue(value: String): RelationType =
+            fromValueOrNull(value) ?: throw IllegalArgumentException("Unknown RelationType: '$value'")
     }
 }

--- a/apps/android/app/src/main/java/com/getaltair/altair/contracts/SyncStream.kt
+++ b/apps/android/app/src/main/java/com/getaltair/altair/contracts/SyncStream.kt
@@ -1,0 +1,19 @@
+package com.getaltair.altair.contracts
+
+// Source of truth: packages/contracts/sync-streams.json
+// Note: these stream names are provisional — Step 4 (Sync Engine) may revise them.
+
+enum class SyncStream(
+    val value: String,
+) {
+    USER_DATA("user_data"),
+    HOUSEHOLD("household"),
+    GUIDANCE("guidance"),
+    KNOWLEDGE("knowledge"),
+    TRACKING("tracking"),
+    ;
+
+    companion object {
+        fun fromValue(value: String): SyncStream? = entries.find { it.value == value }
+    }
+}

--- a/apps/android/app/src/main/java/com/getaltair/altair/contracts/SyncStream.kt
+++ b/apps/android/app/src/main/java/com/getaltair/altair/contracts/SyncStream.kt
@@ -14,6 +14,8 @@ enum class SyncStream(
     ;
 
     companion object {
-        fun fromValue(value: String): SyncStream? = entries.find { it.value == value }
+        fun fromValueOrNull(value: String): SyncStream? = entries.find { it.value == value }
+
+        fun fromValue(value: String): SyncStream = fromValueOrNull(value) ?: throw IllegalArgumentException("Unknown SyncStream: '$value'")
     }
 }

--- a/apps/android/app/src/test/java/com/getaltair/altair/contracts/EntityTypeTest.kt
+++ b/apps/android/app/src/test/java/com/getaltair/altair/contracts/EntityTypeTest.kt
@@ -13,8 +13,8 @@ class EntityTypeTest {
     }
 
     @Test
-    fun fromValue_unknownType_returnsNull() {
-        val result = EntityType.fromValue("unknown_fake_type")
+    fun fromValueOrNull_unknownType_returnsNull() {
+        val result = EntityType.fromValueOrNull("unknown_fake_type")
         assertNull(result)
     }
 
@@ -34,5 +34,15 @@ class EntityTypeTest {
     fun fromValue_relatedTo_returnsRelatedTo() {
         val result = RelationType.fromValue("related_to")
         assertEquals(RelationType.RELATED_TO, result)
+    }
+
+    @Test
+    fun relationTypeEntries_hasSize8() {
+        assertEquals(8, RelationType.entries.size)
+    }
+
+    @Test
+    fun syncStreamEntries_hasSize5() {
+        assertEquals(5, SyncStream.entries.size)
     }
 }

--- a/apps/android/app/src/test/java/com/getaltair/altair/contracts/EntityTypeTest.kt
+++ b/apps/android/app/src/test/java/com/getaltair/altair/contracts/EntityTypeTest.kt
@@ -1,0 +1,38 @@
+package com.getaltair.altair.contracts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EntityTypeTest {
+    @Test
+    fun fromValue_guidanceEpic_returnsGuidanceEpic() {
+        val result = EntityType.fromValue("guidance_epic")
+        assertEquals(EntityType.GUIDANCE_EPIC, result)
+    }
+
+    @Test
+    fun fromValue_unknownType_returnsNull() {
+        val result = EntityType.fromValue("unknown_fake_type")
+        assertNull(result)
+    }
+
+    @Test
+    fun entries_hasSize18() {
+        assertEquals(18, EntityType.entries.size)
+    }
+
+    @Test
+    fun allEntries_haveNonBlankValues() {
+        EntityType.entries.forEach { entry ->
+            assertTrue("Entry ${entry.name} has blank value", entry.value.isNotBlank())
+        }
+    }
+
+    @Test
+    fun fromValue_relatedTo_returnsRelatedTo() {
+        val result = RelationType.fromValue("related_to")
+        assertEquals(RelationType.RELATED_TO, result)
+    }
+}

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -2123,6 +2123,7 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/apps/server/server/Cargo.toml
+++ b/apps/server/server/Cargo.toml
@@ -17,7 +17,7 @@ tower = "0.5.3"
 tower-http = { version = "0.6.8", features = ["cors", "trace"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-uuid = { version = "1.23.0", features = ["v4"] }
+uuid = { version = "1.23.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
 serial_test = "3.4.0"

--- a/apps/server/server/src/contracts.rs
+++ b/apps/server/server/src/contracts.rs
@@ -1,5 +1,6 @@
 // Source of truth: packages/contracts/entity-types.json, relation-types.json, sync-streams.json
-// Do not add inline enum values here — update the JSON registries and regenerate bindings.
+// Do not add inline enum values here — update the JSON registries and update all three
+// binding files (contracts.rs, EntityType.kt, entityTypes.ts) manually, then run validate.ts.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -111,6 +112,7 @@ pub struct RelationRecord {
 
 /// Mirrors the attachments table schema from docs/specs/05-erd.md.
 /// Note: state is a raw string — typed enum lives in Step 3 domain modules.
+/// Note: size_bytes is u64 (non-negative); TypeScript uses `number | null` and Kotlin uses `Long?` (i64, signed).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AttachmentRecord {
     pub id: Uuid,
@@ -118,7 +120,7 @@ pub struct AttachmentRecord {
     pub entity_id: Uuid,
     pub file_name: String,
     pub content_type: String,
-    pub size_bytes: Option<i64>,
+    pub size_bytes: Option<u64>,
     pub state: String,
     pub storage_path: Option<String>,
     pub user_id: Uuid,

--- a/apps/server/server/src/contracts.rs
+++ b/apps/server/server/src/contracts.rs
@@ -1,0 +1,179 @@
+// Source of truth: packages/contracts/entity-types.json, relation-types.json, sync-streams.json
+// Do not add inline enum values here — update the JSON registries and regenerate bindings.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Canonical entity type identifiers. Every variant maps to a registry string via serde rename.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EntityType {
+    #[serde(rename = "user")]
+    User,
+    #[serde(rename = "household")]
+    Household,
+    #[serde(rename = "initiative")]
+    Initiative,
+    #[serde(rename = "tag")]
+    Tag,
+    #[serde(rename = "attachment")]
+    Attachment,
+    #[serde(rename = "guidance_epic")]
+    GuidanceEpic,
+    #[serde(rename = "guidance_quest")]
+    GuidanceQuest,
+    #[serde(rename = "guidance_routine")]
+    GuidanceRoutine,
+    #[serde(rename = "guidance_focus_session")]
+    GuidanceFocusSession,
+    #[serde(rename = "guidance_daily_checkin")]
+    GuidanceDailyCheckin,
+    #[serde(rename = "knowledge_note")]
+    KnowledgeNote,
+    #[serde(rename = "knowledge_note_snapshot")]
+    KnowledgeNoteSnapshot,
+    #[serde(rename = "tracking_location")]
+    TrackingLocation,
+    #[serde(rename = "tracking_category")]
+    TrackingCategory,
+    #[serde(rename = "tracking_item")]
+    TrackingItem,
+    #[serde(rename = "tracking_item_event")]
+    TrackingItemEvent,
+    #[serde(rename = "tracking_shopping_list")]
+    TrackingShoppingList,
+    #[serde(rename = "tracking_shopping_list_item")]
+    TrackingShoppingListItem,
+}
+
+/// Canonical relation type identifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RelationType {
+    #[serde(rename = "references")]
+    References,
+    #[serde(rename = "supports")]
+    Supports,
+    #[serde(rename = "requires")]
+    Requires,
+    #[serde(rename = "related_to")]
+    RelatedTo,
+    #[serde(rename = "depends_on")]
+    DependsOn,
+    #[serde(rename = "duplicates")]
+    Duplicates,
+    #[serde(rename = "similar_to")]
+    SimilarTo,
+    #[serde(rename = "generated_from")]
+    GeneratedFrom,
+}
+
+/// Provisional PowerSync sync stream names. Step 4 (Sync Engine) may revise these.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SyncStream {
+    #[serde(rename = "user_data")]
+    UserData,
+    #[serde(rename = "household")]
+    Household,
+    #[serde(rename = "guidance")]
+    Guidance,
+    #[serde(rename = "knowledge")]
+    Knowledge,
+    #[serde(rename = "tracking")]
+    Tracking,
+}
+
+/// A polymorphic reference to any entity by type and UUID.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntityRef {
+    pub entity_type: EntityType,
+    pub entity_id: Uuid,
+}
+
+/// Mirrors the entity_relations table schema from docs/specs/05-erd.md.
+/// Note: source_type and status are raw strings — typed enums live in Step 3 domain modules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelationRecord {
+    pub id: Uuid,
+    pub from_entity_type: EntityType,
+    pub from_entity_id: Uuid,
+    pub to_entity_type: EntityType,
+    pub to_entity_id: Uuid,
+    pub relation_type: RelationType,
+    pub source_type: String,
+    pub status: String,
+    pub confidence: Option<f64>,
+    pub evidence: Option<String>,
+    pub user_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+/// Mirrors the attachments table schema from docs/specs/05-erd.md.
+/// Note: state is a raw string — typed enum lives in Step 3 domain modules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttachmentRecord {
+    pub id: Uuid,
+    pub entity_type: EntityType,
+    pub entity_id: Uuid,
+    pub file_name: String,
+    pub content_type: String,
+    pub size_bytes: Option<i64>,
+    pub state: String,
+    pub storage_path: Option<String>,
+    pub user_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+/// Parameters for subscribing to PowerSync sync streams.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncSubscriptionRequest {
+    pub streams: Vec<SyncStream>,
+    pub user_id: Uuid,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entity_type_guidance_epic_serializes_to_snake_case() {
+        let val = serde_json::to_string(&EntityType::GuidanceEpic).unwrap();
+        assert_eq!(val, r#""guidance_epic""#);
+    }
+
+    #[test]
+    fn entity_type_user_serializes_to_user() {
+        let val = serde_json::to_string(&EntityType::User).unwrap();
+        assert_eq!(val, r#""user""#);
+    }
+
+    #[test]
+    fn entity_type_unknown_string_fails_deserialization() {
+        let result: Result<EntityType, _> = serde_json::from_str(r#""unknown_fake_type""#);
+        assert!(
+            result.is_err(),
+            "Expected deserialization of unknown type to fail"
+        );
+    }
+
+    #[test]
+    fn relation_type_related_to_serializes_correctly() {
+        let val = serde_json::to_string(&RelationType::RelatedTo).unwrap();
+        assert_eq!(val, r#""related_to""#);
+    }
+
+    #[test]
+    fn entity_ref_round_trips_through_serde() {
+        let entity_ref = EntityRef {
+            entity_type: EntityType::Initiative,
+            entity_id: uuid::Uuid::nil(),
+        };
+        let json = serde_json::to_string(&entity_ref).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["entity_type"], "initiative");
+        assert!(parsed["entity_id"].is_string());
+    }
+}

--- a/apps/server/server/src/main.rs
+++ b/apps/server/server/src/main.rs
@@ -7,8 +7,6 @@ mod contracts;
 mod error;
 mod routes;
 
-pub use contracts::*;
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let dotenv_result = dotenvy::dotenv();

--- a/apps/server/server/src/main.rs
+++ b/apps/server/server/src/main.rs
@@ -3,8 +3,11 @@ use tracing::info;
 use tracing_subscriber::EnvFilter;
 
 mod config;
+mod contracts;
 mod error;
 mod routes;
+
+pub use contracts::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/apps/server/server/src/routes/health.rs
+++ b/apps/server/server/src/routes/health.rs
@@ -1,3 +1,4 @@
+use crate::contracts::EntityType;
 use axum::{Json, Router, routing::get};
 use serde_json::{Value, json};
 
@@ -7,6 +8,12 @@ pub fn router() -> Router {
 
 async fn health_handler() -> Json<Value> {
     Json(json!({ "status": "ok" }))
+}
+
+/// Compile-time proof that crate::contracts resolves from a route module (A-014).
+#[allow(dead_code)]
+fn _assert_contracts() {
+    let _: EntityType = EntityType::Initiative;
 }
 
 #[cfg(test)]

--- a/apps/web/src/lib/contracts/constants.ts
+++ b/apps/web/src/lib/contracts/constants.ts
@@ -1,0 +1,18 @@
+import { EntityType } from './entityTypes.js';
+import type { EntityTypeValue } from './entityTypes.js';
+
+/**
+ * The subset of entity types that sync through PowerSync streams.
+ * Source: packages/contracts/sync-streams.json stream definitions.
+ */
+export const SYNCED_ENTITY_TYPES: EntityTypeValue[] = [
+  EntityType.Initiative,
+  EntityType.GuidanceQuest,
+  EntityType.GuidanceRoutine,
+  EntityType.GuidanceEpic,
+  EntityType.GuidanceFocusSession,
+  EntityType.GuidanceDailyCheckin,
+  EntityType.KnowledgeNote,
+  EntityType.TrackingItem,
+  EntityType.TrackingShoppingList,
+];

--- a/apps/web/src/lib/contracts/contracts.spec.ts
+++ b/apps/web/src/lib/contracts/contracts.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { EntityType, RelationType } from './index.js';
+
+describe('EntityType', () => {
+  it('has exactly 18 values', () => {
+    expect(Object.values(EntityType)).toHaveLength(18);
+  });
+
+  it('GuidanceEpic equals guidance_epic', () => {
+    expect(EntityType.GuidanceEpic).toBe('guidance_epic');
+  });
+});
+
+describe('RelationType', () => {
+  it('has exactly 8 values', () => {
+    expect(Object.values(RelationType)).toHaveLength(8);
+  });
+
+  it('RelatedTo equals related_to', () => {
+    expect(RelationType.RelatedTo).toBe('related_to');
+  });
+});

--- a/apps/web/src/lib/contracts/dtos.ts
+++ b/apps/web/src/lib/contracts/dtos.ts
@@ -1,5 +1,6 @@
 import type { EntityTypeValue } from './entityTypes.js';
 import type { RelationTypeValue } from './relationTypes.js';
+import type { SyncStreamValue } from './syncStreams.js';
 
 /** A polymorphic reference to any entity by type and UUID. */
 export interface EntityRef {
@@ -44,6 +45,6 @@ export interface AttachmentRecord {
 
 /** Parameters for subscribing to PowerSync sync streams. */
 export interface SyncSubscriptionRequest {
-  streams: string[];
+  streams: SyncStreamValue[];
   user_id: string;
 }

--- a/apps/web/src/lib/contracts/dtos.ts
+++ b/apps/web/src/lib/contracts/dtos.ts
@@ -1,0 +1,49 @@
+import type { EntityTypeValue } from './entityTypes.js';
+import type { RelationTypeValue } from './relationTypes.js';
+
+/** A polymorphic reference to any entity by type and UUID. */
+export interface EntityRef {
+  entity_type: EntityTypeValue;
+  /** UUID string */
+  entity_id: string;
+}
+
+/** Mirrors the entity_relations table schema from docs/specs/05-erd.md. */
+export interface RelationRecord {
+  id: string;
+  from_entity_type: EntityTypeValue;
+  from_entity_id: string;
+  to_entity_type: EntityTypeValue;
+  to_entity_id: string;
+  relation_type: RelationTypeValue;
+  source_type: string;
+  status: string;
+  confidence: number | null;
+  evidence: string | null;
+  user_id: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+/** Mirrors the attachments table schema from docs/specs/05-erd.md. */
+export interface AttachmentRecord {
+  id: string;
+  entity_type: EntityTypeValue;
+  entity_id: string;
+  file_name: string;
+  content_type: string;
+  size_bytes: number | null;
+  state: string;
+  storage_path: string | null;
+  user_id: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+/** Parameters for subscribing to PowerSync sync streams. */
+export interface SyncSubscriptionRequest {
+  streams: string[];
+  user_id: string;
+}

--- a/apps/web/src/lib/contracts/entityTypes.ts
+++ b/apps/web/src/lib/contracts/entityTypes.ts
@@ -1,0 +1,23 @@
+// Source of truth: packages/contracts/entity-types.json
+export const EntityType = {
+  User:                     'user',
+  Household:                'household',
+  Initiative:               'initiative',
+  Tag:                      'tag',
+  Attachment:               'attachment',
+  GuidanceEpic:             'guidance_epic',
+  GuidanceQuest:            'guidance_quest',
+  GuidanceRoutine:          'guidance_routine',
+  GuidanceFocusSession:     'guidance_focus_session',
+  GuidanceDailyCheckin:     'guidance_daily_checkin',
+  KnowledgeNote:            'knowledge_note',
+  KnowledgeNoteSnapshot:    'knowledge_note_snapshot',
+  TrackingLocation:         'tracking_location',
+  TrackingCategory:         'tracking_category',
+  TrackingItem:             'tracking_item',
+  TrackingItemEvent:        'tracking_item_event',
+  TrackingShoppingList:     'tracking_shopping_list',
+  TrackingShoppingListItem: 'tracking_shopping_list_item',
+} as const;
+
+export type EntityTypeValue = typeof EntityType[keyof typeof EntityType];

--- a/apps/web/src/lib/contracts/index.ts
+++ b/apps/web/src/lib/contracts/index.ts
@@ -1,0 +1,5 @@
+export * from './entityTypes.js';
+export * from './relationTypes.js';
+export * from './syncStreams.js';
+export * from './dtos.js';
+export * from './constants.js';

--- a/apps/web/src/lib/contracts/relationTypes.ts
+++ b/apps/web/src/lib/contracts/relationTypes.ts
@@ -1,0 +1,13 @@
+// Source of truth: packages/contracts/relation-types.json
+export const RelationType = {
+  References:    'references',
+  Supports:      'supports',
+  Requires:      'requires',
+  RelatedTo:     'related_to',
+  DependsOn:     'depends_on',
+  Duplicates:    'duplicates',
+  SimilarTo:     'similar_to',
+  GeneratedFrom: 'generated_from',
+} as const;
+
+export type RelationTypeValue = typeof RelationType[keyof typeof RelationType];

--- a/apps/web/src/lib/contracts/syncStreams.ts
+++ b/apps/web/src/lib/contracts/syncStreams.ts
@@ -1,0 +1,11 @@
+// Source of truth: packages/contracts/sync-streams.json
+// Note: these stream names are provisional — Step 4 (Sync Engine) may revise them.
+export const SyncStream = {
+  UserData:  'user_data',
+  Household: 'household',
+  Guidance:  'guidance',
+  Knowledge: 'knowledge',
+  Tracking:  'tracking',
+} as const;
+
+export type SyncStreamValue = typeof SyncStream[keyof typeof SyncStream];

--- a/apps/web/src/lib/index.ts
+++ b/apps/web/src/lib/index.ts
@@ -1,1 +1,2 @@
 // place files you want to import through the `$lib` alias in this folder.
+export * from './contracts/index.js';

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -4,22 +4,59 @@ This package is the single source of truth for cross-platform data contracts in 
 
 ## Registry Files
 
-The following files will constitute this package once populated:
+- **`entity-types.json`** — Canonical list of all 18 entity type identifiers. Source for all language bindings.
+- **`relation-types.json`** — Canonical list of all 8 relation type identifiers used in the knowledge graph.
+- **`sync-streams.json`** — PowerSync sync stream name constants (v1; marked provisional — Step 4 may revise).
 
-- **`entity-types.json`** — canonical registry of entity type identifiers (notes, goals, items, etc.) shared across all clients
-- **`relation-types.json`** — registry of relation type identifiers used in the knowledge graph
-- **`sync-streams.json`** — PowerSync sync stream definitions (which tables each client subscribes to)
+Each registry follows this structure:
 
-## Code Generation Targets
+```json
+{
+  "contracts_version": "1.0.0",
+  "values": [
+    { "id": "identifier", "description": "Human-readable description" }
+  ]
+}
+```
 
-From these registries, bindings are generated for each client platform:
+## Language Binding Locations
 
-- **TypeScript (`apps/web/`)** — type-safe entity/relation constants
-- **Kotlin (`apps/android/`)** — enum/sealed class definitions
-- **Rust (`apps/server/`)** — enum and serde-compatible type definitions
+| Stack | File(s) |
+|---|---|
+| TypeScript (Web) | `apps/web/src/lib/contracts/entityTypes.ts`, `relationTypes.ts`, `syncStreams.ts`, `dtos.ts` |
+| Kotlin (Android) | `apps/android/app/src/main/java/com/getaltair/altair/contracts/EntityType.kt`, `RelationType.kt`, `SyncStream.kt`, `Dtos.kt` |
+| Rust (Server) | `apps/server/server/src/contracts.rs` |
 
-A code generation script (to be defined) will read the JSON registry files and emit the appropriate bindings into each application's source tree. This ensures all platforms stay in sync from a single authoritative source.
+Import path examples:
+- TypeScript: `import { EntityType } from '$lib/contracts'`
+- Kotlin: `import com.getaltair.altair.contracts.EntityType`
+- Rust: `use crate::contracts::EntityType`
 
-## Status
+## Validation Script
 
-Population of this package is deferred to Step 2 (Shared Contracts). This directory is a placeholder only — no generated code or registry files exist yet.
+The CI validation script checks that all three language bindings match their source registries.
+
+**Run locally:**
+```bash
+bun run packages/contracts/scripts/validate.ts
+```
+
+Exit 0 = bindings are in sync. Exit 1 = drift detected with a human-readable diff.
+
+## How to Add a New Entity Type (or Relation Type)
+
+1. Add an entry to the relevant JSON registry (`entity-types.json` or `relation-types.json`)
+2. Add the corresponding constant to all three language bindings:
+   - TypeScript: add to `apps/web/src/lib/contracts/entityTypes.ts` (or `relationTypes.ts`)
+   - Kotlin: add to `apps/android/app/src/main/java/com/getaltair/altair/contracts/EntityType.kt` (or `RelationType.kt`)
+   - Rust: add a variant with `#[serde(rename = "new_id")]` to `contracts.rs`
+3. Run `bun run packages/contracts/scripts/validate.ts` — must exit 0
+4. Open a PR; CI will re-run the validation script automatically
+
+**Missing a binding file?** The CI `validate-contracts` job will fail with a diff showing which values are missing from which stack.
+
+## Versioning Rules
+
+- **Additive changes** (new entity/relation type): increment minor version (`1.0.0` → `1.1.0`)
+- **Renames or removals**: breaking change — increment major version and coordinate a cross-stack migration
+- `contracts_version` field in each registry tracks the version for CI tooling and future code generation

--- a/packages/contracts/entity-types.json
+++ b/packages/contracts/entity-types.json
@@ -1,0 +1,23 @@
+{
+  "contracts_version": "1.0.0",
+  "values": [
+    { "id": "user",                        "description": "Platform user account" },
+    { "id": "household",                   "description": "Shared household space" },
+    { "id": "initiative",                  "description": "High-level goal or project" },
+    { "id": "tag",                         "description": "User-defined label" },
+    { "id": "attachment",                  "description": "File attached to an entity" },
+    { "id": "guidance_epic",               "description": "Epic: a grouped set of quests within an initiative" },
+    { "id": "guidance_quest",              "description": "Quest: a single actionable task" },
+    { "id": "guidance_routine",            "description": "Routine: a recurring task template" },
+    { "id": "guidance_focus_session",      "description": "Focus session: a timed work block on a quest" },
+    { "id": "guidance_daily_checkin",      "description": "Daily check-in: energy and mood snapshot" },
+    { "id": "knowledge_note",              "description": "Note: a freeform text document" },
+    { "id": "knowledge_note_snapshot",     "description": "Note snapshot: an immutable version of a note" },
+    { "id": "tracking_location",           "description": "Location: a physical or logical storage place" },
+    { "id": "tracking_category",           "description": "Category: a label grouping tracked items" },
+    { "id": "tracking_item",               "description": "Item: a tracked inventory object" },
+    { "id": "tracking_item_event",         "description": "Item event: a quantity change record" },
+    { "id": "tracking_shopping_list",      "description": "Shopping list: a household purchase list" },
+    { "id": "tracking_shopping_list_item", "description": "Shopping list item: a single entry on a shopping list" }
+  ]
+}

--- a/packages/contracts/relation-types.json
+++ b/packages/contracts/relation-types.json
@@ -1,0 +1,13 @@
+{
+  "contracts_version": "1.0.0",
+  "values": [
+    { "id": "references",     "description": "One entity cites or links to another" },
+    { "id": "supports",       "description": "One entity provides evidence or backing for another" },
+    { "id": "requires",       "description": "One entity depends on another to function" },
+    { "id": "related_to",     "description": "General association between two entities" },
+    { "id": "depends_on",     "description": "Completion of one entity is blocked by another" },
+    { "id": "duplicates",     "description": "Two entities represent the same real-world thing" },
+    { "id": "similar_to",     "description": "Two entities share significant overlap in content or purpose" },
+    { "id": "generated_from", "description": "One entity was derived or created from another" }
+  ]
+}

--- a/packages/contracts/scripts/validate.spec.ts
+++ b/packages/contracts/scripts/validate.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from 'bun:test';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const REPO_ROOT = '/home/rghamilton3/workspace/getaltair/altair';
+const SCRIPT = `${REPO_ROOT}/packages/contracts/scripts/validate.ts`;
+const ENTITY_TYPES_JSON = `${REPO_ROOT}/packages/contracts/entity-types.json`;
+const KOTLIN_ENTITY_TYPE = `${REPO_ROOT}/apps/android/app/src/main/java/com/getaltair/altair/contracts/EntityType.kt`;
+
+function runValidate() {
+  return Bun.spawnSync(['bun', 'run', SCRIPT], { cwd: REPO_ROOT });
+}
+
+test('1: clean repo exits 0', () => {
+  const proc = runValidate();
+  expect(proc.exitCode).toBe(0);
+});
+
+test('2: extra entry in entity-types.json causes exit 1 and names the offending id', () => {
+  const original = readFileSync(ENTITY_TYPES_JSON, 'utf8');
+  try {
+    const registry = JSON.parse(original);
+    registry.values.push({ id: 'test_fake_type', description: 'Test' });
+    writeFileSync(ENTITY_TYPES_JSON, JSON.stringify(registry, null, 2));
+
+    const proc = runValidate();
+    const output = proc.stdout.toString() + new TextDecoder().decode(proc.stderr);
+    expect(proc.exitCode).toBe(1);
+    expect(output).toContain('test_fake_type');
+  } finally {
+    writeFileSync(ENTITY_TYPES_JSON, original);
+  }
+});
+
+test('3: after restoring entity-types.json, exits 0 again', () => {
+  const proc = runValidate();
+  expect(proc.exitCode).toBe(0);
+});
+
+test('4: removing USER entry from Kotlin EntityType.kt causes exit 1', () => {
+  const original = readFileSync(KOTLIN_ENTITY_TYPE, 'utf8');
+  try {
+    // Remove the USER("user"), line
+    const modified = original.replace(/^\s*USER\("user"\),\n/m, '');
+    writeFileSync(KOTLIN_ENTITY_TYPE, modified);
+
+    const proc = runValidate();
+    expect(proc.exitCode).toBe(1);
+  } finally {
+    writeFileSync(KOTLIN_ENTITY_TYPE, original);
+  }
+});

--- a/packages/contracts/scripts/validate.ts
+++ b/packages/contracts/scripts/validate.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env bun
+/**
+ * Validates that all language bindings match their source JSON registries.
+ * Run: bun run packages/contracts/scripts/validate.ts
+ * Exit 0 = all bindings match. Exit 1 = drift detected.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dir, '../../..');
+
+type Registry = { contracts_version: string; values: { id: string; description: string }[] };
+
+function loadRegistry(relPath: string): string[] {
+  const abs = resolve(ROOT, relPath);
+  const reg: Registry = JSON.parse(readFileSync(abs, 'utf8'));
+  return reg.values.map((v) => v.id);
+}
+
+function diff(name: string, expected: string[], actual: string[]): string[] {
+  const errors: string[] = [];
+  const missing = expected.filter((id) => !actual.includes(id));
+  const extra = actual.filter((id) => !expected.includes(id));
+  if (missing.length) errors.push(`${name}: missing from binding: ${missing.join(', ')}`);
+  if (extra.length) errors.push(`${name}: extra in binding (not in registry): ${extra.join(', ')}`);
+  return errors;
+}
+
+async function checkTypeScript(): Promise<string[]> {
+  const errors: string[] = [];
+
+  // Entity types
+  const entityIds = loadRegistry('packages/contracts/entity-types.json');
+  const { EntityType } = await import(resolve(ROOT, 'apps/web/src/lib/contracts/entityTypes.ts'));
+  const tsEntityValues = Object.values(EntityType) as string[];
+  errors.push(...diff('TS EntityType', entityIds, tsEntityValues));
+
+  // Relation types
+  const relationIds = loadRegistry('packages/contracts/relation-types.json');
+  const { RelationType } = await import(resolve(ROOT, 'apps/web/src/lib/contracts/relationTypes.ts'));
+  const tsRelationValues = Object.values(RelationType) as string[];
+  errors.push(...diff('TS RelationType', relationIds, tsRelationValues));
+
+  // Sync streams
+  const streamIds = loadRegistry('packages/contracts/sync-streams.json');
+  const { SyncStream } = await import(resolve(ROOT, 'apps/web/src/lib/contracts/syncStreams.ts'));
+  const tsStreamValues = Object.values(SyncStream) as string[];
+  errors.push(...diff('TS SyncStream', streamIds, tsStreamValues));
+
+  return errors;
+}
+
+function checkKotlin(): string[] {
+  const errors: string[] = [];
+
+  const entityIds = loadRegistry('packages/contracts/entity-types.json');
+  const relationIds = loadRegistry('packages/contracts/relation-types.json');
+  const streamIds = loadRegistry('packages/contracts/sync-streams.json');
+
+  const extractKotlinValues = (filePath: string): string[] => {
+    const text = readFileSync(resolve(ROOT, filePath), 'utf8');
+    const matches = [...text.matchAll(/"([^"]+)"\)/g)].map((m) => m[1]);
+    return matches;
+  };
+
+  const kotlinEntityValues = extractKotlinValues(
+    'apps/android/app/src/main/java/com/getaltair/altair/contracts/EntityType.kt'
+  );
+  errors.push(...diff('Kotlin EntityType', entityIds, kotlinEntityValues));
+
+  const kotlinRelationValues = extractKotlinValues(
+    'apps/android/app/src/main/java/com/getaltair/altair/contracts/RelationType.kt'
+  );
+  errors.push(...diff('Kotlin RelationType', relationIds, kotlinRelationValues));
+
+  const kotlinStreamValues = extractKotlinValues(
+    'apps/android/app/src/main/java/com/getaltair/altair/contracts/SyncStream.kt'
+  );
+  errors.push(...diff('Kotlin SyncStream', streamIds, kotlinStreamValues));
+
+  return errors;
+}
+
+function checkRust(): string[] {
+  const errors: string[] = [];
+
+  const entityIds = loadRegistry('packages/contracts/entity-types.json');
+  const relationIds = loadRegistry('packages/contracts/relation-types.json');
+  const streamIds = loadRegistry('packages/contracts/sync-streams.json');
+
+  const contractsText = readFileSync(
+    resolve(ROOT, 'apps/server/server/src/contracts.rs'),
+    'utf8'
+  );
+
+  // Extract all serde rename values: #[serde(rename = "value")]
+  const allRenames = [...contractsText.matchAll(/serde\(rename\s*=\s*"([^"]+)"\)/g)].map(
+    (m) => m[1]
+  );
+
+  // Partition by known registry: entity types come first, then relations, then streams
+  // Use registry sets to categorize
+  const entitySet = new Set(entityIds);
+  const relationSet = new Set(relationIds);
+  const streamSet = new Set(streamIds);
+
+  const rustEntityValues = allRenames.filter((v) => entitySet.has(v) || (!relationSet.has(v) && !streamSet.has(v) && entityIds.includes(v)));
+  const rustRelationValues = allRenames.filter((v) => relationSet.has(v));
+  const rustStreamValues = allRenames.filter((v) => streamSet.has(v));
+
+  errors.push(...diff('Rust EntityType', entityIds, rustEntityValues));
+  errors.push(...diff('Rust RelationType', relationIds, rustRelationValues));
+  errors.push(...diff('Rust SyncStream', streamIds, rustStreamValues));
+
+  return errors;
+}
+
+async function main() {
+  console.log('Validating contract bindings against JSON registries...\n');
+
+  const tsErrors = await checkTypeScript();
+  const kotlinErrors = checkKotlin();
+  const rustErrors = checkRust();
+
+  const allErrors = [...tsErrors, ...kotlinErrors, ...rustErrors];
+
+  if (allErrors.length === 0) {
+    console.log('✓ All bindings match their registries.');
+    process.exit(0);
+  } else {
+    console.error('✗ Binding drift detected:\n');
+    for (const err of allErrors) {
+      console.error(`  - ${err}`);
+    }
+    console.error(`\n${allErrors.length} issue(s) found. Update the binding files to match the JSON registries.`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('validate.ts: unexpected error:', err);
+  process.exit(1);
+});

--- a/packages/contracts/scripts/validate.ts
+++ b/packages/contracts/scripts/validate.ts
@@ -102,7 +102,7 @@ function checkKotlin(): string[] {
 
   const extractKotlinValues = (filePath: string): string[] => {
     const text = readFileSync(resolve(ROOT, filePath), 'utf8');
-    const values = [...text.matchAll(/"([^"]+)"\)/g)].map((m) => m[1]);
+    const values = [...text.matchAll(/[A-Z_]+\("([^"]+)"\)/g)].map((m) => m[1]);
     if (values.length === 0) {
       errors.push(
         `Kotlin: no enum values extracted from ${filePath} — file may be empty or pattern did not match`

--- a/packages/contracts/scripts/validate.ts
+++ b/packages/contracts/scripts/validate.ts
@@ -6,20 +6,32 @@
  */
 
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 
-const ROOT = resolve(import.meta.dir, '../../..');
+// Resolve repo root relative to this script's location (packages/contracts/scripts/).
+const ROOT = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
 
 type Registry = { contracts_version: string; values: { id: string; description: string }[] };
 
 function loadRegistry(relPath: string): string[] {
   const abs = resolve(ROOT, relPath);
-  const reg: Registry = JSON.parse(readFileSync(abs, 'utf8'));
+  let reg: Registry;
+  try {
+    reg = JSON.parse(readFileSync(abs, 'utf8'));
+  } catch (e) {
+    throw new Error(`${relPath}: failed to parse — ${e}`);
+  }
+  if (!Array.isArray(reg.values)) {
+    throw new Error(`${relPath}: missing or invalid "values" array`);
+  }
   return reg.values.map((v) => v.id);
 }
 
 function diff(name: string, expected: string[], actual: string[]): string[] {
   const errors: string[] = [];
+  const dupes = actual.filter((id, i) => actual.indexOf(id) !== i);
+  if (dupes.length) errors.push(`${name}: duplicate values in binding: ${dupes.join(', ')}`);
   const missing = expected.filter((id) => !actual.includes(id));
   const extra = actual.filter((id) => !expected.includes(id));
   if (missing.length) errors.push(`${name}: missing from binding: ${missing.join(', ')}`);
@@ -32,23 +44,53 @@ async function checkTypeScript(): Promise<string[]> {
 
   // Entity types
   const entityIds = loadRegistry('packages/contracts/entity-types.json');
-  const { EntityType } = await import(resolve(ROOT, 'apps/web/src/lib/contracts/entityTypes.ts'));
-  const tsEntityValues = Object.values(EntityType) as string[];
-  errors.push(...diff('TS EntityType', entityIds, tsEntityValues));
+  const entityFile = resolve(ROOT, 'apps/web/src/lib/contracts/entityTypes.ts');
+  let entityMod: { EntityType: Record<string, string> };
+  try {
+    entityMod = await import(entityFile);
+  } catch (e) {
+    errors.push(`TS EntityType: failed to import ${entityFile} — ${e}`);
+    return errors;
+  }
+  errors.push(...diff('TS EntityType', entityIds, Object.values(entityMod.EntityType)));
 
   // Relation types
   const relationIds = loadRegistry('packages/contracts/relation-types.json');
-  const { RelationType } = await import(resolve(ROOT, 'apps/web/src/lib/contracts/relationTypes.ts'));
-  const tsRelationValues = Object.values(RelationType) as string[];
-  errors.push(...diff('TS RelationType', relationIds, tsRelationValues));
+  const relationFile = resolve(ROOT, 'apps/web/src/lib/contracts/relationTypes.ts');
+  let relationMod: { RelationType: Record<string, string> };
+  try {
+    relationMod = await import(relationFile);
+  } catch (e) {
+    errors.push(`TS RelationType: failed to import ${relationFile} — ${e}`);
+    return errors;
+  }
+  errors.push(...diff('TS RelationType', relationIds, Object.values(relationMod.RelationType)));
 
   // Sync streams
   const streamIds = loadRegistry('packages/contracts/sync-streams.json');
-  const { SyncStream } = await import(resolve(ROOT, 'apps/web/src/lib/contracts/syncStreams.ts'));
-  const tsStreamValues = Object.values(SyncStream) as string[];
-  errors.push(...diff('TS SyncStream', streamIds, tsStreamValues));
+  const streamFile = resolve(ROOT, 'apps/web/src/lib/contracts/syncStreams.ts');
+  let streamMod: { SyncStream: Record<string, string> };
+  try {
+    streamMod = await import(streamFile);
+  } catch (e) {
+    errors.push(`TS SyncStream: failed to import ${streamFile} — ${e}`);
+    return errors;
+  }
+  errors.push(...diff('TS SyncStream', streamIds, Object.values(streamMod.SyncStream)));
 
   return errors;
+}
+
+/**
+ * Extracts serde rename values from a named enum block in Rust source text.
+ * Scopes extraction to the enum body to avoid capturing field-level serde renames
+ * from structs, which would cause false positives in drift detection.
+ */
+function extractRustEnumValues(contractsText: string, enumName: string): string[] {
+  const enumBodyRegex = new RegExp(`enum\\s+${enumName}[^{]*\\{([^}]+)\\}`);
+  const match = contractsText.match(enumBodyRegex);
+  if (!match) return [];
+  return [...match[1].matchAll(/serde\(rename\s*=\s*"([^"]+)"\)/g)].map((m) => m[1]);
 }
 
 function checkKotlin(): string[] {
@@ -60,8 +102,13 @@ function checkKotlin(): string[] {
 
   const extractKotlinValues = (filePath: string): string[] => {
     const text = readFileSync(resolve(ROOT, filePath), 'utf8');
-    const matches = [...text.matchAll(/"([^"]+)"\)/g)].map((m) => m[1]);
-    return matches;
+    const values = [...text.matchAll(/"([^"]+)"\)/g)].map((m) => m[1]);
+    if (values.length === 0) {
+      errors.push(
+        `Kotlin: no enum values extracted from ${filePath} — file may be empty or pattern did not match`
+      );
+    }
+    return values;
   };
 
   const kotlinEntityValues = extractKotlinValues(
@@ -89,25 +136,19 @@ function checkRust(): string[] {
   const relationIds = loadRegistry('packages/contracts/relation-types.json');
   const streamIds = loadRegistry('packages/contracts/sync-streams.json');
 
-  const contractsText = readFileSync(
-    resolve(ROOT, 'apps/server/server/src/contracts.rs'),
-    'utf8'
-  );
+  const contractsFile = resolve(ROOT, 'apps/server/server/src/contracts.rs');
+  const contractsText = readFileSync(contractsFile, 'utf8');
 
-  // Extract all serde rename values: #[serde(rename = "value")]
-  const allRenames = [...contractsText.matchAll(/serde\(rename\s*=\s*"([^"]+)"\)/g)].map(
-    (m) => m[1]
-  );
+  const rustEntityValues = extractRustEnumValues(contractsText, 'EntityType');
+  const rustRelationValues = extractRustEnumValues(contractsText, 'RelationType');
+  const rustStreamValues = extractRustEnumValues(contractsText, 'SyncStream');
 
-  // Partition by known registry: entity types come first, then relations, then streams
-  // Use registry sets to categorize
-  const entitySet = new Set(entityIds);
-  const relationSet = new Set(relationIds);
-  const streamSet = new Set(streamIds);
-
-  const rustEntityValues = allRenames.filter((v) => entitySet.has(v) || (!relationSet.has(v) && !streamSet.has(v) && entityIds.includes(v)));
-  const rustRelationValues = allRenames.filter((v) => relationSet.has(v));
-  const rustStreamValues = allRenames.filter((v) => streamSet.has(v));
+  if (rustEntityValues.length === 0)
+    errors.push(`Rust EntityType: enum block not found in ${contractsFile}`);
+  if (rustRelationValues.length === 0)
+    errors.push(`Rust RelationType: enum block not found in ${contractsFile}`);
+  if (rustStreamValues.length === 0)
+    errors.push(`Rust SyncStream: enum block not found in ${contractsFile}`);
 
   errors.push(...diff('Rust EntityType', entityIds, rustEntityValues));
   errors.push(...diff('Rust RelationType', relationIds, rustRelationValues));
@@ -133,7 +174,9 @@ async function main() {
     for (const err of allErrors) {
       console.error(`  - ${err}`);
     }
-    console.error(`\n${allErrors.length} issue(s) found. Update the binding files to match the JSON registries.`);
+    console.error(
+      `\n${allErrors.length} issue(s) found. Update the binding files to match the JSON registries.`
+    );
     process.exit(1);
   }
 }

--- a/packages/contracts/sync-streams.json
+++ b/packages/contracts/sync-streams.json
@@ -1,0 +1,12 @@
+{
+  "contracts_version": "1.0.0",
+  "provisional": true,
+  "note": "Stream SQL bucket definitions are designed in Step 4 (Sync Engine); these names may be revised.",
+  "values": [
+    { "id": "user_data",  "description": "User's own Core entities (initiatives, tags, attachments)" },
+    { "id": "household",  "description": "Household-scoped data (memberships, locations, categories)" },
+    { "id": "guidance",   "description": "Guidance domain tables (epics, quests, routines, focus sessions, daily checkins)" },
+    { "id": "knowledge",  "description": "Knowledge domain tables (notes, note snapshots)" },
+    { "id": "tracking",   "description": "Tracking domain tables (items, item events, shopping lists)" }
+  ]
+}

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary

- Establishes `packages/contracts/` as the single source of truth for cross-platform identifiers — 3 JSON registries (18 entity types, 8 relation types, 5 sync streams)
- Adds typed language bindings in Rust (`serde` enums with per-variant rename), TypeScript (`as const` objects), and Kotlin (`enum class` with string value constructor)
- Adds `packages/contracts/scripts/validate.ts` — Bun script that diffs all three bindings against registries and exits 1 on drift; CI `validate-contracts` job blocks `smoke-test` on failure

## Assertions verified

All 13 fully-evaluated assertions PASS. A-013 (HTTP 422 on unknown entity type) is PARTIAL by design — enum groundwork is laid, enforcement deferred to Step 3 domain handlers.

## Test plan

- [ ] Rust: `cd apps/server && SQLX_OFFLINE=true cargo test --package altair-server contracts` — 5 tests pass
- [ ] TypeScript: `cd apps/web && bun test src/lib/contracts/contracts.spec.ts` — 4 tests pass
- [ ] Kotlin: `cd apps/android && ./gradlew test` — EntityTypeTest 5 tests pass
- [ ] Validate script: `bun run packages/contracts/scripts/validate.ts` — exits 0
- [ ] Drift detection: temporarily add a fake registry entry → validate.ts exits 1 with diff report
- [ ] CI: `validate-contracts` job present; `smoke-test` `needs:` includes it

## Feature

`Context/Features/002-SharedContracts/` — Spec, Tech, Steps all committed on this branch.