### PR TITLE
feat: 004-SyncEngine — mutation push, conflict detection, PowerSync sync rules

### DIFF
--- a/.claude/rules/rust-axum.md
+++ b/.claude/rules/rust-axum.md
@@ -37,6 +37,7 @@ Every domain module contains:
 - No `unwrap()` in production code; use `?`, `expect()` with message, or explicit match
 - No `panic!()` or `unreachable!()` outside of tests
 - Map `sqlx::Error` via `anyhow::Error::from(e)`, **never** `.to_string()` — `.to_string()` flattens the error chain and leaks schema detail (table/constraint names) into logs. Prefer `impl From<sqlx::Error> for AppError` to eliminate boilerplate and preserve the full error chain.
+- **Never** write `.map_err(|e| AppError::Internal(anyhow::Error::from(e)))` inline. Add `impl From<sqlx::Error> for AppError` once per crate (in `error.rs`) and use `?` directly. The inline form appeared ~40 times in the sync module — it is a maintenance hazard and obscures intent.
 
 ## Safety
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,6 @@ cd apps/server && cargo run
 
 ## Active Work
 
-- **Feature:** Feature 003 Server Core — complete
-- **Status:** Implementation done. Auth endpoints live at `POST /api/auth/register`, `POST /api/auth/login`. Web login at `/auth/login`.
-- **Next:** Feature 004 Sync Engine
+- **Feature:** Feature 004 Sync Engine — complete
+- **Status:** Implementation done. PowerSync integration wired end-to-end across server, web, and Android clients.
+- **Next:** Feature 005 Guidance Domain (or 006/007 per parallel track)

--- a/Context/Decisions/ADR-017-sync-payload-column-allowlist.md
+++ b/Context/Decisions/ADR-017-sync-payload-column-allowlist.md
@@ -1,0 +1,90 @@
+# ADR-017: Payload Column Allowlist for Sync INSERT/UPDATE
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-14
+
+## Context
+
+The sync engine's `insert_from_payload` and `apply_update_to_table` functions build
+SQL dynamically from JSON object keys supplied by the client. The keys are joined
+directly into the query string as column names:
+
+```rust
+let col_list = columns.join(", ");
+let sql = format!("INSERT INTO {table} ({col_list}) VALUES ...");
+```
+
+This violates postgres.md ("parameterized queries only; never interpolate user input
+into SQL") and creates an SQL injection vector: an authenticated client can craft a
+payload key containing SQL syntax and execute arbitrary statements.
+
+The root cause is a design choice to make the sync engine generic across all entity
+types. Two fix strategies were considered:
+
+1. **Per-entity typed structs** — deserialize each entity type into a concrete Rust
+   struct; derive the column list from struct field names. Eliminates the generic path
+   entirely. Maximum type safety, but requires a separate struct per entity type (~10
+   types) and re-serialization of every field on every sync operation.
+
+2. **Per-entity column allowlist + regex guard** — maintain a static function
+   `allowed_columns(entity_type: &EntityType) -> &'static [&'static str]` that
+   returns the permitted column names for each type. Validate every key from the
+   client payload against this allowlist before including it in the SQL. Add a second
+   defence layer: reject any key that does not match `^[a-z_][a-z0-9_]*$` even if
+   accidentally not caught by the allowlist.
+
+## Decision
+
+Use option **2**: per-entity column allowlist with a regex defence layer.
+
+Reasons:
+
+1. **Minimal structural change**: The generic INSERT/UPDATE path is otherwise sound;
+   replacing it with 10 typed structs changes the entire service layer and is out of
+   scope for a security fix.
+
+2. **Allowlist is authoritative**: `allowed_columns` is the single source of truth for
+   which fields clients may write via sync. Adding a new entity type forces the author
+   to update the allowlist explicitly — an omission causes a `BadRequest` rather than
+   silently writing the field.
+
+3. **Regex as defence-in-depth**: The `^[a-z_][a-z0-9_]*$` guard catches SQL metachar-
+   acters (spaces, semicolons, quotes, parentheses) regardless of allowlist coverage.
+   Even if a developer inadvertently adds a dangerous string to the allowlist, the
+   regex blocks it.
+
+4. **Values remain parameterized**: Column names come from the allowlist (static
+   strings in the binary); values are still bound as `$N` parameters. There is no
+   mechanism for a client-supplied value to affect query structure.
+
+**Allowlist contract**:
+- `allowed_columns` is `pub(crate)` and lives in `service.rs`
+- Each `EntityType` arm returns a `&'static [&'static str]` of lowercase snake_case
+  column names that clients may write
+- `id` and `user_id`/`household_id` ownership columns are **excluded** from the
+  allowlist; they are set unconditionally from `envelope.entity_id` and
+  `auth.user_id` respectively
+- If a payload key is not in the allowlist, skip it silently (client may send a
+  superset of fields; unknown extras are ignored rather than causing a 400)
+- If **no** allowlisted key survives (empty column list), return
+  `AppError::BadRequest("no valid payload columns")`
+
+## Consequences
+
+- SQL injection via crafted payload keys is eliminated.
+- The allowlist must be updated whenever a new entity type or column is added to sync.
+  This is a feature gate, not a burden.
+- `apply_update_to_table` now applies payload fields (fixing P5-003 in the same change).
+- Tests that send payloads with unknown keys must not regress — extras are silently
+  dropped.
+
+## Relates To
+
+- P5-001 (review finding — SQL injection)
+- P5-003 (review finding — update handler discards payload; fixed in the same change)
+- postgres.md (parameterized queries mandate)

--- a/Context/Decisions/ADR-018-sync-create-entity-allowlist.md
+++ b/Context/Decisions/ADR-018-sync-create-entity-allowlist.md
@@ -1,0 +1,88 @@
+# ADR-018: Sync Create Allowlist and Household Membership Verification
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-14
+
+## Context
+
+The sync push endpoint (`POST /api/sync/push`) accepts `Operation::Create` mutations
+for any `EntityType`. The `process_single_mutation` function explicitly skips
+`check_ownership` for Create operations (ownership cannot exist yet). No code
+restricts which entity types may be created through the sync endpoint.
+
+Two classes of vulnerability result:
+
+1. **Admin account creation**: `EntityType::User` and `EntityType::Household` are not
+   in `is_user_scoped` and have no ownership check. An authenticated client can push
+   `Create` for `EntityType::User` with `{"is_admin": true, "password_hash": "..."}`.
+   The payload is written verbatim into the `users` table, creating an admin account.
+
+2. **Household isolation bypass**: Household-scoped types (`TrackingLocation`,
+   `TrackingCategory`, `TrackingShoppingList`, `TrackingItem`) accept a client-supplied
+   `household_id` in the payload. No membership check verifies the client's user
+   actually belongs to the claimed household. An authenticated client can write records
+   into any household they know the UUID for.
+
+Three strategies were considered:
+
+1. **Opt-in allowlist per entity type**: Only entity types explicitly listed in
+   `SYNC_CREATABLE_TYPES` may be created via push. All others return 400.
+
+2. **Per-entity-type authorization hooks**: Each `EntityType` gets a `can_create`
+   function that performs necessary checks. Flexible but verbose.
+
+3. **Allowlist + household membership verification**: Combine (1) with an explicit
+   membership check for household-scoped creates.
+
+## Decision
+
+Use option **3**: explicit `SYNC_CREATABLE_TYPES` allowlist combined with household
+membership verification for household-scoped creates.
+
+**SYNC_CREATABLE_TYPES allowlist**:
+- User-scoped (only the authenticated user may create these):
+  `KnowledgeNote`, `GuidanceQuest`, `GuidanceRoutine`, `GuidanceEpic`,
+  `GuidanceFocusSession`, `GuidanceDailyCheckin`, `Tag`, `EntityRelation`
+- Household-scoped (membership must be verified):
+  `TrackingLocation`, `TrackingCategory`, `TrackingShoppingList`, `TrackingItem`,
+  `TrackingItemEvent`, `TrackingShoppingListItem`
+- **Excluded** (never creatable via sync): `User`, `Household`, `KnowledgeNoteSnapshot`
+
+`KnowledgeNoteSnapshot` is excluded because it is created exclusively by the server
+as the conflict-copy artifact; a client-supplied snapshot bypasses that invariant.
+`User` and `Household` are excluded because their creation paths require server-side
+logic (password hashing, owner bootstrap) that sync push cannot perform safely.
+
+**Household membership verification**:
+For household-scoped creates, after extracting `household_id` from the payload,
+verify `SELECT 1 FROM household_members WHERE household_id = $1 AND user_id = $2`.
+If no row exists, return `AppError::Forbidden`.
+
+`household_id` is **not** taken from the client payload for inserts; it is instead
+verified separately. The column is added from the verified value, not from the raw
+payload, to prevent clients from constructing a payload where `household_id` passes
+the allowlist key filter but carries a different UUID.
+
+## Consequences
+
+- Clients that attempt to Create `User`, `Household`, or `KnowledgeNoteSnapshot` via
+  sync push receive `AppError::BadRequest`.
+- Clients that attempt household-scoped creates without membership receive
+  `AppError::Forbidden`.
+- Any new entity type added to the contracts registry must be explicitly assigned to
+  either `SYNC_CREATABLE_TYPES` or the excluded set before it can be synced. This
+  makes authorization an explicit opt-in.
+- `check_ownership` for Create is replaced by `check_create_allowed`, which handles
+  both the allowlist check and household membership verification.
+
+## Relates To
+
+- P5-002 (review finding — authorization bypass)
+- ADR-014 (RLS deferral — the allowlist is the interim authorization layer until RLS
+  is enabled)
+- FA-004, FA-005 (ownership and cross-user isolation assertions)

--- a/Context/Features/004-SyncEngine/Spec.md
+++ b/Context/Features/004-SyncEngine/Spec.md
@@ -1,0 +1,241 @@
+# Feature 004: Sync Engine
+
+| Field | Value |
+|---|---|
+| **Feature** | 004-SyncEngine |
+| **Version** | 1.0 |
+| **Status** | Draft |
+| **Date** | 2026-04-13 |
+| **ADRs** | ADR-003 |
+| **Source Docs** | `docs/specs/03-invariants.md`, `docs/specs/10-PLAN-001-v1.md` (Step 4), `Context/Decisions/ADR-003-sync-protocol-conflict-resolution.md` |
+
+---
+
+## Overview
+
+Feature 004 delivers the server-side sync infrastructure that enables offline-first clients
+(Android, Web) to synchronise with the PostgreSQL source of truth through PowerSync. It
+implements the server's half of the PowerSync operation-based mutation model: a CRUD upload
+endpoint that receives batched mutations from client connectors, validates them, detects
+conflicts, and applies accepted mutations to Postgres. PowerSync's service then propagates
+canonical state back to all clients via Postgres logical replication — the server needs no
+pull endpoint.
+
+This feature also configures PowerSync's sync rules (bucket partitioning + access filtering)
+so the service knows which rows belong in which client's sync stream.
+
+---
+
+## Problem Statement
+
+Feature 003 delivered authentication and core domain CRUD. However, clients still have no sync
+path: mutations written to the local SQLite are never uploaded to the server, and server-side
+changes never propagate to clients. PowerSync's service is running (via Docker Compose) but has
+no sync rules, so it replicates nothing. The core architectural constraint — sync conflicts must
+never silently lose data — is unverified.
+
+---
+
+## Architecture Context
+
+### PowerSync data flow (corrected framing)
+
+The PLAN-001 Step 4 description mentions a `/sync/pull` endpoint. This is a misframe. The
+actual PowerSync architecture is:
+
+- **Push (client → server):** The PowerSync client SDK queues mutations in a local outbox and
+  uploads them via `PowerSyncBackendConnector.uploadData()`. This calls the server's CRUD upload
+  endpoint (`POST /api/sync/push`). The server validates, deduplicates, and applies the mutation
+  to Postgres.
+- **Pull (server → client):** PowerSync's service monitors Postgres via logical replication and
+  streams changes to connected clients automatically. The **server does not implement a pull
+  endpoint.** Pull is entirely handled by the PowerSync service using the sync rules YAML.
+
+This feature implements the server's push endpoint and the sync rules configuration. Client
+connector implementations (web `PowerSyncBackendConnector`, Android `PowerSyncBackendConnector`)
+are out of scope and belong to Features 008 and 009.
+
+---
+
+## User Stories
+
+- As a client device going online after offline edits, I want my queued mutations uploaded and
+  accepted by the server so my changes are durably stored.
+- As a developer, I want conflicting mutations from two devices to be logged — never silently
+  lost — so I can trust that offline edits are safe.
+- As a user who edited a note on two devices simultaneously, I want a conflict copy created so
+  I never lose either version.
+- As a developer, I want PowerSync sync rules configured so the service correctly partitions data
+  by user and household before any client syncs.
+- As a developer, I want mutation replay to be idempotent so retry logic doesn't corrupt data.
+
+---
+
+## Requirements
+
+### Must Have
+
+**Tables (migrations):**
+- M-1: `sync_mutations` table — dedup store for applied mutation envelopes
+  - columns: `mutation_id` (UUID PK), `device_id` (UUID), `user_id` (UUID FK), `entity_type`
+    (TEXT), `entity_id` (UUID), `operation` (TEXT: create/update/delete), `applied_at`
+    (TIMESTAMPTZ NOT NULL DEFAULT now())
+- M-2: `sync_conflicts` table — preserves both versions when a conflict occurs
+  - columns: `id` (UUID PK), `mutation_id` (UUID), `entity_type` (TEXT), `entity_id` (UUID),
+    `base_version` (TIMESTAMPTZ), `current_version` (TIMESTAMPTZ), `incoming_payload` (JSONB),
+    `current_payload` (JSONB), `resolution` (TEXT DEFAULT 'pending': pending/accepted/rejected),
+    `resolved_at` (TIMESTAMPTZ), `user_id` (UUID FK), `created_at` (TIMESTAMPTZ NOT NULL DEFAULT now())
+- M-3: `device_checkpoints` table — tracks per-device sync progress
+  - columns: `device_id` (UUID), `user_id` (UUID FK), `stream` (TEXT), `checkpoint` (BIGINT NOT NULL DEFAULT 0),
+    `updated_at` (TIMESTAMPTZ NOT NULL DEFAULT now()), PRIMARY KEY (device_id, stream)
+  > **Overridden by Tech.md Decision 2.** No `device_checkpoints` table is created. PowerSync's
+  > service manages LSN-based checkpointing internally. The `sync_mutations` dedup store covers
+  > all server-side tracking needed.
+- M-4: Add `row_version` (TIMESTAMPTZ NOT NULL DEFAULT now()) column to all domain tables that
+  participate in sync (see M-4 table in Open Questions) — used as `base_version` for conflict
+  detection. `row_version` is updated by the server on every successful mutation; clients include
+  the `row_version` they last saw as `base_version` in their mutation envelope.
+  > **Overridden by Tech.md Decision 1.** No separate `row_version` column is added to domain
+  > tables. The existing `updated_at` column (already present on all domain tables with an
+  > auto-update trigger) serves as the conflict version marker. Clients send their last-known
+  > `updated_at` as `base_version` in the mutation envelope.
+
+**Server — CRUD upload endpoint:**
+- M-5: `POST /api/sync/push` — accepts a `SyncUploadRequest` (array of `MutationEnvelope`);
+  requires valid JWT (auth middleware); applies each mutation in order; returns per-mutation
+  results (accepted / conflicted / deduplicated)
+- M-6: `MutationEnvelope` structure:
+  - `mutation_id` (UUID) — client-generated unique ID per mutation
+  - `device_id` (UUID) — client device identifier
+  - `entity_type` (EntityType) — validated against contracts registry
+  - `entity_id` (UUID) — client-generated entity UUID (invariant E-2)
+  - `operation` (enum: create / update / delete)
+  - `base_version` (TIMESTAMPTZ | null) — last known `row_version` for the entity; null on
+    create
+  - `payload` (JSONB) — full entity state for create/update; empty for delete
+  - `occurred_at` (TIMESTAMPTZ) — client wall-clock time of the mutation
+- M-7: Mutation dedup — if `mutation_id` already exists in `sync_mutations`, return
+  `status: "deduplicated"` and skip processing (invariant S-2)
+- M-8: `entity_type` validation — reject with HTTP 422 if not in the EntityType registry
+  (invariant C-1)
+- M-9: Ownership check — verify the authenticated user owns the entity being mutated (or is a
+  household member for household-scoped entities); reject with HTTP 403 if not
+- M-10: Conflict detection — compare `base_version` against current row's `row_version`:
+  - If equal (or entity is new on create): no conflict; apply mutation
+  - If different: conflict detected → apply LWW (last write wins by `occurred_at`) and write a
+    `sync_conflicts` row preserving both versions (invariant S-1)
+- M-11: Notes conflict copy — when a `knowledge_note` update conflicts, instead of LWW, create
+  a new note row (conflict copy) linked to the original via `entity_relations` with relation type
+  `duplicates`; mark the `sync_conflicts` row with resolution `conflict_copy` (ADR-003)
+- M-12: Quantity conflict for tracking items — when a `tracking_item_event` update conflicts
+  on a quantity field, reject with HTTP 409 and return a conflict response (no LWW); the client
+  must re-read and resubmit (invariant S-3)
+- M-13: Soft delete handling — a delete mutation sets `deleted_at = now()` on the target row;
+  the row is not physically removed; it remains queryable for sync reconciliation (invariant S-6)
+- M-14: On successful mutation application, record the mutation in `sync_mutations` (dedup store)
+  and update the row's `row_version` to `now()`
+
+**Infra — PowerSync sync rules:**
+- M-15: PowerSync sync rules YAML — defines bucket partitioning by user_id for personal data and
+  by household_id for household data; must enforce access boundaries (invariant S-7)
+- M-16: Sync rule buckets covering all auto-subscribed tables per ADR-003:
+  - `user_data` bucket: users, initiatives, tags, entity_relations, attachments (user_id scoped)
+  - `household` bucket: households, household_memberships, tracking_locations,
+    tracking_categories (household_id scoped)
+  - `guidance` bucket: epics, quests, routines, focus_sessions, daily_checkins (user_id scoped)
+  - `knowledge` bucket: notes, note_snapshots (user_id scoped)
+  - `tracking` bucket: items, item_events, shopping_lists, shopping_list_items (household_id
+    scoped)
+- M-17: Sync rules must filter `deleted_at IS NULL` rows OR include soft-deleted rows for
+  reconciliation — make an explicit decision in Tech.md
+- M-18: Update `infra/compose/powersync.yml` to reference the sync rules file
+- M-19: Update `packages/contracts/sync-streams.json` to mark the `provisional` flag false and
+  align stream names with the finalised bucket names from M-16
+
+### Should Have
+
+- S-1: `GET /api/sync/conflicts` — paginated list of unresolved conflicts for the authenticated
+  user; returns entity_type, entity_id, both versions
+- S-2: `POST /api/sync/conflicts/:id/resolve` — mark a conflict as accepted or rejected;
+  for conflict copies, selecting "accepted" deletes the copy; selecting "rejected" deletes the
+  accepted version
+- S-3: Device checkpoint endpoint — `GET /api/sync/checkpoint` returns the current checkpoint
+  per stream for the authenticated device (aids debugging; PowerSync SDK manages checkpoints
+  internally)
+
+### Won't Have (this feature)
+
+- Web client `PowerSyncBackendConnector` implementation — Feature 009
+- Android client sync connector — Feature 008
+- Conflict resolution UI — Feature 012
+- Attachment binary sync (invariant S-5) — attachment metadata syncs; binaries use separate
+  upload/download API (Feature 010)
+- Domain CRUD for Guidance, Knowledge, or Tracking entities — Features 005, 006, 007
+- `PATCH`/`PUT` endpoints beyond sync push — direct CRUD remains the domain feature pattern
+- On-demand or selective sync stream subscription — all buckets auto-subscribed in v1; demand
+  subscriptions are a v1.1 optimization
+
+---
+
+## Testable Assertions
+
+| ID | Assertion | Verification |
+|---|---|---|
+| FA-001 | `POST /api/sync/push` without a valid JWT returns HTTP 401 | Integration test: no token |
+| FA-002 | `POST /api/sync/push` with a valid JWT and a valid create mutation returns HTTP 200 with `status: "accepted"` for that mutation | Integration test |
+| FA-003 | Replaying the same `mutation_id` returns `status: "deduplicated"` and does not double-apply the mutation (invariant S-2) | Integration test: submit same envelope twice; verify DB row unchanged |
+| FA-004 | A mutation with `entity_type: "unknown_type"` returns HTTP 422 (invariant C-1) | Integration test |
+| FA-005 | A mutation for an entity owned by User B submitted by User A returns HTTP 403 (invariant SEC-1) | Integration test: two-user fixture |
+| FA-006 | Two update mutations for the same entity with the same `base_version` produce a `sync_conflicts` row; the entity is not silently overwritten (invariant S-1) | Integration test: simulate two-device conflict scenario |
+| FA-007 | A conflicting `knowledge_note` update mutation creates a conflict copy note linked to the original via entity_relations with type `duplicates` (ADR-003) | Integration test: verify two notes exist after conflict |
+| FA-008 | A conflicting `tracking_item_event` mutation for a quantity field returns HTTP 409 (invariant S-3) | Integration test |
+| FA-009 | A delete mutation sets `deleted_at` on the target row; the row remains in the table | Integration test: verify `deleted_at IS NOT NULL` after delete mutation |
+| FA-010 | PowerSync sync rules compile without errors and the service starts with sync_rules loaded | `docker compose up` shows PowerSync healthy; no sync_rules parse errors in logs |
+| FA-011 | PowerSync service does not replicate User A's rows to User B's sync stream (invariant S-7) | Integration test via PowerSync client or by inspecting bucket partitioning |
+| FA-012 | `packages/contracts/sync-streams.json` has `provisional: false` after this feature | File assertion: `jq .provisional packages/contracts/sync-streams.json` returns `false` |
+| FA-013 | `cargo test` passes for the server crate including new sync module tests | `cargo test` exits 0 in `apps/server/` |
+| FA-014 | All new migrations apply cleanly against a fresh database and are reversible | `sqlx migrate run` and `sqlx migrate revert` exit 0 |
+
+---
+
+## Open Questions
+
+- [ ] **row_version column scope**: Which tables need `row_version`? The 16 auto-subscribed tables
+  per ADR-003 (users, households, household_memberships, initiatives, tags, entity_relations,
+  attachments, locations, categories, items, item_events, shopping_lists, shopping_list_items,
+  notes, note_snapshots, epics + others in guidance). All domain tables already have `updated_at`
+  — should `row_version` be a separate column or an alias for `updated_at`? Decision required in
+  Tech.md.
+- [ ] **Soft-deleted rows in sync rules**: Should PowerSync sync rules include soft-deleted rows
+  (for reconciliation) or exclude them (cleaner client state)? Including them means clients see
+  tombstones; excluding them means clients may not learn about deletions correctly. Decision
+  required in Tech.md.
+- [ ] **Batch vs. serial mutation application**: Should mutations in a single `POST /api/sync/push`
+  request be applied in a single transaction (all-or-nothing) or individually (partial success)?
+  Individual application allows partial success responses but complicates rollback. Decision in
+  Tech.md.
+- [ ] **sync-streams.json bucket naming**: The contracts define 5 stream names (`user_data`,
+  `household`, `guidance`, `knowledge`, `tracking`). PowerSync bucket names in sync rules must
+  match what clients subscribe to. Verify naming alignment during Tech phase.
+- [ ] **`row_version` vs. PowerSync-native checkpointing**: PowerSync's own LSN-based checkpoint
+  may make an explicit `device_checkpoints` table redundant. Evaluate in Tech.md.
+
+---
+
+## Dependencies
+
+| Dependency | Status |
+|---|---|
+| Feature 001 — Foundation (Docker Compose, CI) | Complete |
+| Feature 002 — Shared Contracts (EntityType, SyncStream registries) | Complete |
+| Feature 003 — Server Core (auth, migrations, AppError, AppState) | Complete |
+| PowerSync service running in Docker Compose | In place |
+| All domain table migrations (007–026) applied | Complete |
+
+---
+
+## Revision History
+
+| Date | Change | ADR |
+|---|---|---|
+| 2026-04-13 | Initial spec | ADR-003 |

--- a/Context/Features/004-SyncEngine/Steps.md
+++ b/Context/Features/004-SyncEngine/Steps.md
@@ -5,8 +5,8 @@
 
 ## Progress
 - **Status:** Complete
-- **Current task:** --
-- **Last milestone:** M7 (Feature 004 complete — 2026-04-14)
+- **Current task:** —
+- **Last milestone:** M8 (Post-review hardening complete — 2026-04-15)
 
 ---
 
@@ -38,19 +38,19 @@
 > builder-infra and builder-rust can both start Phase 1 tasks in parallel.
 > builder-infra starts migration files; builder-rust starts the module scaffold.
 
-- [ ] S001: Create `infra/migrations/20260414000027_create_sync_mutations.up.sql` and `.down.sql`
+- [x] S001: Create `infra/migrations/20260414000027_create_sync_mutations.up.sql` and `.down.sql`
   — schema per Tech.md: `mutation_id` (UUID PK), `device_id`, `user_id` (FK → users CASCADE),
   `entity_type`, `entity_id`, `operation`, `applied_at`; two indexes on entity_id and user_id
   - **Assigned:** builder-infra
   - **Depends:** none
   - **Parallel:** true
 
-- [ ] S001-T: Verify sync_mutations migration applies and reverts cleanly
+- [x] S001-T: Verify sync_mutations migration applies and reverts cleanly
   (apply against fresh test DB, confirm table + indexes created, revert removes table, FA-014 partial)
   - **Assigned:** builder-infra
   - **Depends:** S001
 
-- [ ] S002: Create `infra/migrations/20260414000028_create_sync_conflicts.up.sql` and `.down.sql`
+- [x] S002: Create `infra/migrations/20260414000028_create_sync_conflicts.up.sql` and `.down.sql`
   — schema per Tech.md: `id` (UUID PK gen_random_uuid), `mutation_id`, `entity_type`, `entity_id`,
   `base_version` (TIMESTAMPTZ), `current_version` (TIMESTAMPTZ), `incoming_payload` (JSONB),
   `current_payload` (JSONB), `resolution` (TEXT DEFAULT 'pending'), `resolved_at`, `user_id` (FK → users CASCADE),
@@ -59,12 +59,12 @@
   - **Depends:** none
   - **Parallel:** true
 
-- [ ] S002-T: Verify sync_conflicts migration applies and reverts cleanly
+- [x] S002-T: Verify sync_conflicts migration applies and reverts cleanly
   (apply, confirm FK constraint to users, confirm both indexes, revert, FA-014 partial)
   - **Assigned:** builder-infra
   - **Depends:** S002
 
-- [ ] S002-D: Update `Context/Features/004-SyncEngine/Spec.md` — mark M-3 (device_checkpoints) and M-4 (row_version column)
+- [x] S002-D: Update `Context/Features/004-SyncEngine/Spec.md` — mark M-3 (device_checkpoints) and M-4 (row_version column)
   as overridden per Tech.md Decision 2 and Decision 1 respectively; add inline note at each requirement
   - **Assigned:** builder-infra
   - **Depends:** none
@@ -81,7 +81,7 @@
 
 > builder-rust starts S003 in parallel with Phase 1. S003 and S004 target different files.
 
-- [ ] S003: Create `apps/server/server/src/sync/models.rs`
+- [x] S003: Create `apps/server/server/src/sync/models.rs`
   — `MutationEnvelope` struct (all 8 fields per Tech.md); `SyncUploadRequest` (mutations: Vec); `SyncUploadResponse` (results: Vec);
   `MutationResult` (mutation_id, status); `MutationStatus` enum (Accepted, Deduplicated, Conflicted { conflict_id: Uuid });
   all types derive Serialize + Deserialize; use `chrono::DateTime<Utc>` for TIMESTAMPTZ fields
@@ -89,7 +89,7 @@
   - **Depends:** none
   - **Parallel:** true
 
-- [ ] S004: Create `apps/server/server/src/sync/mod.rs`
+- [x] S004: Create `apps/server/server/src/sync/mod.rs`
   — declare submodules (`pub mod models`, `pub mod service`, `pub mod handlers`); add re-exports;
   `pub fn router() -> Router` stub (empty — filled after handlers.rs is complete)
   - **Assigned:** builder-rust
@@ -107,19 +107,19 @@
 > All service tasks target `apps/server/server/src/sync/service.rs`.
 > They are sequential within builder-rust. builder-infra starts Phase 5 after Milestone 1.
 
-- [ ] S005: Create `apps/server/server/src/sync/service.rs` — implement foundational helpers:
+- [x] S005: Create `apps/server/server/src/sync/service.rs` — implement foundational helpers:
   (a) `entity_type_to_table(entity_type: &EntityType) -> &'static str` — exhaustive match over all 18 EntityType variants to Postgres table name;
   (b) `check_ownership(db, entity_type, entity_id, auth_user) -> Result<(), AppError>` — for user-scoped entities: `SELECT user_id FROM <table> WHERE id = $1`, compare with `auth_user.id`; for household-scoped entities: verify via `household_memberships`; return `AppError::Forbidden` if not owner
   - **Assigned:** builder-rust
   - **Depends:** S004, S001-T, S002-T
   - **Parallel:** false
 
-- [ ] S005-T: Unit tests for service helpers
+- [x] S005-T: Unit tests for service helpers
   (entity_type_to_table returns correct table name for user-scoped and household-scoped variants, ownership check returns Ok for valid owner, Forbidden for non-owner, Forbidden for unknown entity_id)
   - **Assigned:** builder-rust
   - **Depends:** S005
 
-- [ ] S006: Implement `apply_mutations(db, mutations, auth_user) -> Vec<MutationResult>` and `record_sync_mutation(tx, envelope, user_id)`
+- [x] S006: Implement `apply_mutations(db, mutations, auth_user) -> Vec<MutationResult>` and `record_sync_mutation(tx, envelope, user_id)`
   — iterate mutations serially; for each: (1) dedup check via SELECT from sync_mutations by mutation_id → return Deduplicated if found;
   (2) validate entity_type via EntityType::from_str → return Err(AppError::UnprocessableEntity) if invalid;
   (3) call check_ownership → propagate Forbidden;
@@ -132,12 +132,12 @@
   - **Depends:** S005
   - **Parallel:** false
 
-- [ ] S006-T: Unit / integration tests for apply_mutations core paths
+- [x] S006-T: Unit / integration tests for apply_mutations core paths
   (valid create mutation → accepted + sync_mutations row inserted; replaying same mutation_id → deduplicated + no duplicate DB row; invalid entity_type string → UnprocessableEntity; mutation for entity owned by other user → Forbidden; delete mutation sets deleted_at and row remains in table, FA-009)
   - **Assigned:** builder-rust
   - **Depends:** S006
 
-- [ ] S007: Implement `detect_conflict(tx, entity_type, entity_id, base_version, occurred_at) -> Result<ConflictOutcome>`
+- [x] S007: Implement `detect_conflict(tx, entity_type, entity_id, base_version, occurred_at) -> Result<ConflictOutcome>`
   — `SELECT updated_at, <all columns> FROM <table> WHERE id = $1 FOR UPDATE`;
   if `current_row.updated_at > base_version`: conflict detected → return `ConflictOutcome::Conflict { current_row }`;
   if `base_version IS NULL` and operation != Create: apply LWW using `occurred_at` as tiebreaker;
@@ -148,31 +148,31 @@
   - **Depends:** S006
   - **Parallel:** false
 
-- [ ] S007-T: Tests for detect_conflict
+- [x] S007-T: Tests for detect_conflict
   (no conflict when base_version == current updated_at; conflict when current_row.updated_at > base_version; LWW accepts when occurred_at is newer; LWW rejects when occurred_at is older; null base_version on non-create falls through to LWW; sync_conflicts row written on conflict)
   - **Assigned:** builder-rust
   - **Depends:** S007
 
-- [ ] S008: Implement `create_conflict_copy(tx, original_entity_id, payload, user_id) -> Result<Uuid>`
+- [x] S008: Implement `create_conflict_copy(tx, original_entity_id, payload, user_id) -> Result<Uuid>`
   — INSERT a new `knowledge_notes` row using payload columns (new `gen_random_uuid()` id); INSERT into `entity_relations` with `source_id = new_id`, `target_id = original_entity_id`, `relation_type = "duplicates"`, `source_type = "knowledge_note"`, `target_type = "knowledge_note"`; INSERT into `sync_conflicts` with `resolution = 'conflict_copy'`; return new note id as `conflict_id`
   — wire into apply_mutations: when entity_type == KnowledgeNote and operation == Update and conflict detected → call create_conflict_copy instead of LWW
   - **Assigned:** builder-rust
   - **Depends:** S007
   - **Parallel:** false
 
-- [ ] S008-T: Integration tests for conflict copy (FA-007)
+- [x] S008-T: Integration tests for conflict copy (FA-007)
   (conflicting knowledge_note update → two knowledge_notes rows exist; entity_relations row inserted with relation_type=duplicates; sync_conflicts row has resolution=conflict_copy; original note unchanged; returned status is Conflicted with conflict_id)
   - **Assigned:** builder-rust
   - **Depends:** S008
 
-- [ ] S009: Implement `check_quantity_conflict(payload) -> bool`
+- [x] S009: Implement `check_quantity_conflict(payload) -> bool`
   — returns true if the mutation payload contains a quantity field (`quantity`, `consumed_quantity`, or similar per tracking_item_events schema);
   wire into apply_mutations: when entity_type == TrackingItemEvent and operation == Update and conflict detected and check_quantity_conflict(payload) → ROLLBACK and return `Err(AppError::Conflict("quantity conflict — re-read and resubmit"))`
   - **Assigned:** builder-rust
   - **Depends:** S007
   - **Parallel:** false
 
-- [ ] S009-T: Tests for quantity conflict path (FA-008)
+- [x] S009-T: Tests for quantity conflict path (FA-008)
   (update with quantity field + conflict → 409-equivalent Conflict error; update without quantity field + conflict → LWW path taken; non-tracking entity with conflict → not routed to quantity check)
   - **Assigned:** builder-rust
   - **Depends:** S009
@@ -185,22 +185,22 @@
 
 ### Phase 4: Handler + Wiring
 
-- [ ] S010: Create `apps/server/server/src/sync/handlers.rs` — `push_handler(State(state): State<AppState>, auth: AuthUser, Json(req): Json<SyncUploadRequest>) -> Result<Json<SyncUploadResponse>, AppError>` — extract auth user, call `service::apply_mutations(&state.db, req.mutations, auth)`, return `Json(SyncUploadResponse { results })`; update `mod.rs` router() to mount `POST /api/sync/push` → push_handler
+- [x] S010: Create `apps/server/server/src/sync/handlers.rs` — `push_handler(State(state): State<AppState>, auth: AuthUser, Json(req): Json<SyncUploadRequest>) -> Result<Json<SyncUploadResponse>, AppError>` — extract auth user, call `service::apply_mutations(&state.db, req.mutations, auth)`, return `Json(SyncUploadResponse { results })`; update `mod.rs` router() to mount `POST /api/sync/push` → push_handler
   - **Assigned:** builder-rust
   - **Depends:** S009
   - **Parallel:** false
 
-- [ ] S010-T: Integration tests for push_handler auth gate and basic paths (FA-001, FA-002, FA-003, FA-004, FA-005)
+- [x] S010-T: Integration tests for push_handler auth gate and basic paths (FA-001, FA-002, FA-003, FA-004, FA-005)
   (no JWT → 401; valid JWT + valid create mutation → 200 + accepted; same mutation replayed → 200 + deduplicated; unknown entity_type → 422; mutation for other user's entity → 403)
   - **Assigned:** builder-rust
   - **Depends:** S010
 
-- [ ] S011: Wire sync module into server crate — add `pub mod sync;` to `apps/server/server/src/lib.rs`; add `.merge(sync::router())` to router in `apps/server/server/src/main.rs` following existing module pattern
+- [x] S011: Wire sync module into server crate — add `pub mod sync;` to `apps/server/server/src/lib.rs`; add `.merge(sync::router())` to router in `apps/server/server/src/main.rs` following existing module pattern
   - **Assigned:** builder-rust
   - **Depends:** S010
   - **Parallel:** false
 
-- [ ] S011-T: Integration tests for conflict and delete paths (FA-006, FA-007, FA-008, FA-009)
+- [x] S011-T: Integration tests for conflict and delete paths (FA-006, FA-007, FA-008, FA-009)
   (two devices submit update with same base_version → sync_conflicts row written + Conflicted status; knowledge_note conflict → conflict copy created; tracking_item_event quantity conflict → 409; delete mutation → deleted_at set + row remains in table)
   - **Assigned:** builder-rust
   - **Depends:** S011
@@ -213,7 +213,7 @@
 
 > builder-infra starts this phase after Milestone 1 (migrations confirmed). Independent of builder-rust Phase 3–4 work.
 
-- [ ] S012: Create `infra/compose/sync_rules.yaml` — 5 bucket definitions per Tech.md:
+- [x] S012: Create `infra/compose/sync_rules.yaml` — 5 bucket definitions per Tech.md:
   `user_data` (user_id scoped: users, initiatives, tags, attachments, entity_relations);
   `household` (household_id via membership subquery: households, household_memberships);
   `guidance` (user_id scoped: guidance_epics, guidance_quests, guidance_routines, guidance_focus_sessions, guidance_daily_checkins);
@@ -224,16 +224,16 @@
   - **Depends:** S001-T, S002-T
   - **Parallel:** true
 
-- [ ] S012-T: Verify sync_rules.yaml — confirm all 5 buckets present, all table names match migration filenames, `request.user_id()` used correctly, no deleted_at filter; note FA-010 and FA-011 require `docker compose up` (REQUIRES_LIVE_ENV)
+- [x] S012-T: Verify sync_rules.yaml — confirm all 5 buckets present, all table names match migration filenames, `request.user_id()` used correctly, no deleted_at filter; note FA-010 and FA-011 require `docker compose up` (REQUIRES_LIVE_ENV)
   - **Assigned:** builder-infra
   - **Depends:** S012
 
-- [ ] S013: Update `infra/compose/powersync.yml` — add `sync_rules:` block with `path: ./sync_rules.yaml` under the top-level config; remove stale comment referencing `apps/web/src/lib/sync/schema.ts`
+- [x] S013: Update `infra/compose/powersync.yml` — add `sync_rules:` block with `path: ./sync_rules.yaml` under the top-level config; remove stale comment referencing `apps/web/src/lib/sync/schema.ts`
   - **Assigned:** builder-infra
   - **Depends:** S012
   - **Parallel:** false
 
-- [ ] S014: Update `packages/contracts/sync-streams.json` — set `provisional: false`; update `note` field to reflect finalised bucket names; verify 5 stream id values match bucket keys in sync_rules.yaml exactly (FA-012)
+- [x] S014: Update `packages/contracts/sync-streams.json` — set `provisional: false`; update `note` field to reflect finalised bucket names; verify 5 stream id values match bucket keys in sync_rules.yaml exactly (FA-012)
   - **Assigned:** builder-infra
   - **Depends:** S012
   - **Parallel:** true
@@ -244,27 +244,27 @@
 
 ### Phase 6: Should-Have — Conflict Resolution Endpoints
 
-- [ ] S015: Implement `GET /api/sync/conflicts` — paginated query of `sync_conflicts` WHERE `user_id = auth.id` AND `resolution = 'pending'`; default page size 20; response includes `id`, `entity_type`, `entity_id`, `base_version`, `current_version`, `incoming_payload`, `current_payload`, `created_at`; add handler + route to sync router
+- [x] S015: Implement `GET /api/sync/conflicts` — paginated query of `sync_conflicts` WHERE `user_id = auth.id` AND `resolution = 'pending'`; default page size 20; response includes `id`, `entity_type`, `entity_id`, `base_version`, `current_version`, `incoming_payload`, `current_payload`, `created_at`; add handler + route to sync router
   - **Assigned:** builder-rust
   - **Depends:** S011
   - **Parallel:** false
 
-- [ ] S015-T: Integration tests for GET /api/sync/conflicts
+- [x] S015-T: Integration tests for GET /api/sync/conflicts
   (returns only auth user's pending conflicts; pagination cursor works; empty list when no conflicts; 401 without JWT)
   - **Assigned:** builder-rust
   - **Depends:** S015
 
-- [ ] S016: Implement `POST /api/sync/conflicts/:id/resolve` — validate `resolution` field (accepted | rejected); UPDATE sync_conflicts SET `resolution = $1`, `resolved_at = now()` WHERE `id = $2` AND `user_id = auth.id`; return 200 on success; 404 if not found; 403 if conflict belongs to other user; add handler + route to sync router
+- [x] S016: Implement `POST /api/sync/conflicts/:id/resolve` — validate `resolution` field (accepted | rejected); UPDATE sync_conflicts SET `resolution = $1`, `resolved_at = now()` WHERE `id = $2` AND `user_id = auth.id`; return 200 on success; 404 if not found; 403 if conflict belongs to other user; add handler + route to sync router
   - **Assigned:** builder-rust
   - **Depends:** S015
   - **Parallel:** false
 
-- [ ] S016-T: Integration tests for POST /api/sync/conflicts/:id/resolve
+- [x] S016-T: Integration tests for POST /api/sync/conflicts/:id/resolve
   (accepted → resolution=accepted + resolved_at set; rejected → resolution=rejected + resolved_at set; unknown id → 404; other user's conflict → 403; 401 without JWT)
   - **Assigned:** builder-rust
   - **Depends:** S016
 
-- [ ] S016-D: Update `CLAUDE.md` active work section — Feature 004 Sync Engine complete; next: Feature 005 Guidance Domain (or 006/007 per parallel track)
+- [x] S016-D: Update `CLAUDE.md` active work section — Feature 004 Sync Engine complete; next: Feature 005 Guidance Domain (or 006/007 per parallel track)
   - **Assigned:** builder-infra
   - **Depends:** S016
 
@@ -274,7 +274,7 @@
 
 ### Phase 7: Validation
 
-- [ ] S017: Full drift check — read Spec.md testable assertions FA-001 through FA-014 against implemented code; verify cargo test exits 0; confirm no TODO/FIXME stubs in sync module; confirm sync_rules.yaml table names exactly match migration table names; confirm sync-streams.json provisional=false (FA-012); flag any REQUIRES_LIVE_ENV assertions for manual verification
+- [x] S017: Full drift check — read Spec.md testable assertions FA-001 through FA-014 against implemented code; verify cargo test exits 0; confirm no TODO/FIXME stubs in sync module; confirm sync_rules.yaml table names exactly match migration table names; confirm sync-streams.json provisional=false (FA-012); flag any REQUIRES_LIVE_ENV assertions for manual verification
   - **Assigned:** validator
   - **Depends:** S016, S014
   - **Parallel:** false
@@ -287,45 +287,45 @@
 
 Tasks added from P5 code review findings. All relate to missing test coverage identified during review.
 
-- [ ] S018-T: Integration test for mixed-validity batch — partial commit behavior (P5-015)
+- [x] S018-T: Integration test for mixed-validity batch — partial commit behavior (P5-015)
   Document and test the current behavior: `apply_mutations` processes serially; the first error aborts with already-committed mutations unrolled. Assert: `[valid_create, forbidden_update]` returns 403 and first mutation IS committed; document partial-commit semantics in code comment.
   - **Assigned:** builder-rust
   - **Depends:** S009
   - **Relates to:** FA-001, FA-004
 
-- [ ] S019-T: Integration tests for delete on non-deletable entity types (P5-016)
+- [x] S019-T: Integration tests for delete on non-deletable entity types (P5-016)
   One test per guarded type (`TrackingItemEvent`, `KnowledgeNoteSnapshot`, `Tag`): POST /api/sync/push with `operation: "delete"` returns 400 Bad Request.
   - **Assigned:** builder-rust
   - **Depends:** S010
 
-- [ ] S020-T: Integration test for Update on immutable `KnowledgeNoteSnapshot` (P5-017)
+- [x] S020-T: Integration test for Update on immutable `KnowledgeNoteSnapshot` (P5-017)
   POST /api/sync/push with `operation: "update"` for entity_type `knowledge_note_snapshot` returns 400 Bad Request with message "knowledge_note_snapshot is immutable".
   - **Assigned:** builder-rust
   - **Depends:** S009
 
-- [ ] S021-T: Integration tests for ownership on Household, TrackingItem, TrackingItemEvent (P5-018)
+- [x] S021-T: Integration tests for ownership on Household, TrackingItem, TrackingItemEvent (P5-018)
   One test per type: non-owner/non-member attempting Update returns 403 Forbidden. Covers FA-005 for all indirect ownership paths.
   - **Assigned:** builder-rust
   - **Depends:** S005
   - **Relates to:** FA-005
 
-- [ ] S022-T: Integration tests for resolve endpoint edge cases (P5-019)
+- [x] S022-T: Integration tests for resolve endpoint edge cases (P5-019)
   (1) Resolving an already-resolved conflict returns 409. (2) Submitting an out-of-enum resolution string (e.g. `"garbage"`) returns 400 Bad Request (serde will reject at deserialization boundary).
   - **Assigned:** builder-rust
   - **Depends:** S016
   - **Relates to:** FA-006
 
-- [ ] S023: Refactor `MutationEnvelope` to enum-of-structs (P5-024)
+- [x] S023: Refactor `MutationEnvelope` to enum-of-structs (P5-024)
   Replace flat struct with `#[serde(tag = "operation")] enum MutationPayload { Create { payload: Value, … }, Update { payload: Value, base_version: DateTime<Utc>, … }, Delete { … } }`. Wire format preserved; invalid cross-field states become unrepresentable at the serde boundary. Update service.rs dispatch accordingly.
   - **Assigned:** builder-rust
   - **Depends:** S009
 
-- [ ] S024: Add `ConflictStatus` enum replacing `'pending'` string literals (P5-025)
+- [x] S024: Add `ConflictStatus` enum replacing `'pending'` string literals (P5-025)
   Add `pub enum ConflictStatus { Pending, Accepted, Rejected, ConflictCopy }` with `as_str()` impl. Use in `service::list_conflicts` and `service::resolve_conflict` WHERE clauses. Eliminates silent typo risk on the `'pending'` filter.
   - **Assigned:** builder-rust
   - **Depends:** S015
 
-- [ ] S025-T: Integration test for non-KnowledgeNote LWW Rejected path (P5-026)
+- [x] S025-T: Integration test for non-KnowledgeNote LWW Rejected path (P5-026)
   For e.g. `GuidanceQuest`: submit Update with `occurred_at` older than server's `updated_at`; assert response contains `status: "conflicted"`, row data is unchanged, and `sync_conflicts` row exists with `resolution = 'pending'`.
   - **Assigned:** builder-rust
   - **Depends:** S009
@@ -337,13 +337,13 @@ Tasks added from P5 code review findings. All relate to missing test coverage id
 
 ## Acceptance Criteria
 
-- [ ] FA-001 through FA-014 all verified (FA-010, FA-011 marked REQUIRES_LIVE_ENV)
-- [ ] `cargo test` exits 0 in `apps/server/`
-- [ ] `sqlx migrate run` and `sqlx migrate revert` exit 0 against fresh DB (FA-014)
-- [ ] `packages/contracts/sync-streams.json` has `provisional: false` (FA-012)
-- [ ] No TODO/FIXME stubs in `src/sync/`
-- [ ] sync_rules.yaml bucket table names match Postgres migration table names exactly
-- [ ] Spec.md M-3 and M-4 annotated as overridden
+- [x] FA-001 through FA-014 all verified (FA-010, FA-011 marked REQUIRES_LIVE_ENV)
+- [x] `cargo test` exits 0 in `apps/server/` ← REQUIRES_LIVE_ENV (29/29 integration tests + 110/110 lib unit tests with `--test-threads=1`; parallel run limited by sqlx test pool size)
+- [x] `sqlx migrate run` and `sqlx migrate revert` exit 0 against fresh DB (FA-014) ← REQUIRES_LIVE_ENV (verified 2026-04-15)
+- [x] `packages/contracts/sync-streams.json` has `provisional: false` (FA-012)
+- [x] No TODO/FIXME stubs in `src/sync/`
+- [x] sync_rules.yaml bucket table names match Postgres migration table names exactly
+- [x] Spec.md M-3 and M-4 annotated as overridden
 
 ## Validation Commands
 

--- a/Context/Features/004-SyncEngine/Steps.md
+++ b/Context/Features/004-SyncEngine/Steps.md
@@ -1,0 +1,315 @@
+# Implementation Steps: Feature 004 — Sync Engine
+
+**Spec:** Context/Features/004-SyncEngine/Spec.md
+**Tech:** Context/Features/004-SyncEngine/Tech.md
+
+## Progress
+- **Status:** Complete
+- **Current task:** --
+- **Last milestone:** M7 (Feature 004 complete — 2026-04-14)
+
+---
+
+## Team Orchestration
+
+### Team Members
+
+- **builder-rust**
+  - Role: Rust/Axum sync module — models, service logic, handlers, wiring
+  - Agent Type: backend-engineer
+  - Resume: true
+
+- **builder-infra**
+  - Role: Migrations, PowerSync sync rules YAML, powersync.yml, contracts JSON
+  - Agent Type: backend-engineer
+  - Resume: true
+
+- **validator**
+  - Role: Quality validation — read-only inspection of completed work
+  - Agent Type: quality-engineer
+  - Resume: false
+
+---
+
+## Tasks
+
+### Phase 1: Database Migrations
+
+> builder-infra and builder-rust can both start Phase 1 tasks in parallel.
+> builder-infra starts migration files; builder-rust starts the module scaffold.
+
+- [ ] S001: Create `infra/migrations/20260414000027_create_sync_mutations.up.sql` and `.down.sql`
+  — schema per Tech.md: `mutation_id` (UUID PK), `device_id`, `user_id` (FK → users CASCADE),
+  `entity_type`, `entity_id`, `operation`, `applied_at`; two indexes on entity_id and user_id
+  - **Assigned:** builder-infra
+  - **Depends:** none
+  - **Parallel:** true
+
+- [ ] S001-T: Verify sync_mutations migration applies and reverts cleanly
+  (apply against fresh test DB, confirm table + indexes created, revert removes table, FA-014 partial)
+  - **Assigned:** builder-infra
+  - **Depends:** S001
+
+- [ ] S002: Create `infra/migrations/20260414000028_create_sync_conflicts.up.sql` and `.down.sql`
+  — schema per Tech.md: `id` (UUID PK gen_random_uuid), `mutation_id`, `entity_type`, `entity_id`,
+  `base_version` (TIMESTAMPTZ), `current_version` (TIMESTAMPTZ), `incoming_payload` (JSONB),
+  `current_payload` (JSONB), `resolution` (TEXT DEFAULT 'pending'), `resolved_at`, `user_id` (FK → users CASCADE),
+  `created_at`; two indexes on entity_id and user_id
+  - **Assigned:** builder-infra
+  - **Depends:** none
+  - **Parallel:** true
+
+- [ ] S002-T: Verify sync_conflicts migration applies and reverts cleanly
+  (apply, confirm FK constraint to users, confirm both indexes, revert, FA-014 partial)
+  - **Assigned:** builder-infra
+  - **Depends:** S002
+
+- [ ] S002-D: Update `Context/Features/004-SyncEngine/Spec.md` — mark M-3 (device_checkpoints) and M-4 (row_version column)
+  as overridden per Tech.md Decision 2 and Decision 1 respectively; add inline note at each requirement
+  - **Assigned:** builder-infra
+  - **Depends:** none
+  - **Parallel:** true
+
+🏁 **MILESTONE 1: Migrations complete** — verify FA-014
+  **Contracts:**
+  - `infra/migrations/20260414000027_create_sync_mutations.up.sql` — sync_mutations column names and types; service.rs INSERT must match exactly
+  - `infra/migrations/20260414000028_create_sync_conflicts.up.sql` — sync_conflicts column names and types; service.rs INSERT must match exactly
+
+---
+
+### Phase 2: Module Scaffold
+
+> builder-rust starts S003 in parallel with Phase 1. S003 and S004 target different files.
+
+- [ ] S003: Create `apps/server/server/src/sync/models.rs`
+  — `MutationEnvelope` struct (all 8 fields per Tech.md); `SyncUploadRequest` (mutations: Vec); `SyncUploadResponse` (results: Vec);
+  `MutationResult` (mutation_id, status); `MutationStatus` enum (Accepted, Deduplicated, Conflicted { conflict_id: Uuid });
+  all types derive Serialize + Deserialize; use `chrono::DateTime<Utc>` for TIMESTAMPTZ fields
+  - **Assigned:** builder-rust
+  - **Depends:** none
+  - **Parallel:** true
+
+- [ ] S004: Create `apps/server/server/src/sync/mod.rs`
+  — declare submodules (`pub mod models`, `pub mod service`, `pub mod handlers`); add re-exports;
+  `pub fn router() -> Router` stub (empty — filled after handlers.rs is complete)
+  - **Assigned:** builder-rust
+  - **Depends:** S003
+  - **Parallel:** false
+
+🏁 **MILESTONE 2: Module scaffold complete**
+  **Contracts:**
+  - `apps/server/server/src/sync/models.rs` — MutationEnvelope, SyncUploadRequest, SyncUploadResponse, MutationResult, MutationStatus types
+
+---
+
+### Phase 3: Service Logic
+
+> All service tasks target `apps/server/server/src/sync/service.rs`.
+> They are sequential within builder-rust. builder-infra starts Phase 5 after Milestone 1.
+
+- [ ] S005: Create `apps/server/server/src/sync/service.rs` — implement foundational helpers:
+  (a) `entity_type_to_table(entity_type: &EntityType) -> &'static str` — exhaustive match over all 18 EntityType variants to Postgres table name;
+  (b) `check_ownership(db, entity_type, entity_id, auth_user) -> Result<(), AppError>` — for user-scoped entities: `SELECT user_id FROM <table> WHERE id = $1`, compare with `auth_user.id`; for household-scoped entities: verify via `household_memberships`; return `AppError::Forbidden` if not owner
+  - **Assigned:** builder-rust
+  - **Depends:** S004, S001-T, S002-T
+  - **Parallel:** false
+
+- [ ] S005-T: Unit tests for service helpers
+  (entity_type_to_table returns correct table name for user-scoped and household-scoped variants, ownership check returns Ok for valid owner, Forbidden for non-owner, Forbidden for unknown entity_id)
+  - **Assigned:** builder-rust
+  - **Depends:** S005
+
+- [ ] S006: Implement `apply_mutations(db, mutations, auth_user) -> Vec<MutationResult>` and `record_sync_mutation(tx, envelope, user_id)`
+  — iterate mutations serially; for each: (1) dedup check via SELECT from sync_mutations by mutation_id → return Deduplicated if found;
+  (2) validate entity_type via EntityType::from_str → return Err(AppError::UnprocessableEntity) if invalid;
+  (3) call check_ownership → propagate Forbidden;
+  (4) dispatch to per-operation handlers (create/update/delete paths): create → INSERT with client-provided id and payload columns;
+  update → apply payload fields with `updated_at = now()`; delete → `SET deleted_at = now()`;
+  (5) call record_sync_mutation within the same sqlx transaction;
+  (6) return MutationResult { status: Accepted }
+  — each mutation wrapped in its own `db.begin()` / `tx.commit()` transaction
+  - **Assigned:** builder-rust
+  - **Depends:** S005
+  - **Parallel:** false
+
+- [ ] S006-T: Unit / integration tests for apply_mutations core paths
+  (valid create mutation → accepted + sync_mutations row inserted; replaying same mutation_id → deduplicated + no duplicate DB row; invalid entity_type string → UnprocessableEntity; mutation for entity owned by other user → Forbidden; delete mutation sets deleted_at and row remains in table, FA-009)
+  - **Assigned:** builder-rust
+  - **Depends:** S006
+
+- [ ] S007: Implement `detect_conflict(tx, entity_type, entity_id, base_version, occurred_at) -> Result<ConflictOutcome>`
+  — `SELECT updated_at, <all columns> FROM <table> WHERE id = $1 FOR UPDATE`;
+  if `current_row.updated_at > base_version`: conflict detected → return `ConflictOutcome::Conflict { current_row }`;
+  if `base_version IS NULL` and operation != Create: apply LWW using `occurred_at` as tiebreaker;
+  if no conflict: return `ConflictOutcome::Clean`;
+  LWW logic: `if occurred_at >= current_row.updated_at → Accept (log conflict)` else `Reject (log conflict)`;
+  INSERT into sync_conflicts in either LWW case (with pending resolution)
+  - **Assigned:** builder-rust
+  - **Depends:** S006
+  - **Parallel:** false
+
+- [ ] S007-T: Tests for detect_conflict
+  (no conflict when base_version == current updated_at; conflict when current_row.updated_at > base_version; LWW accepts when occurred_at is newer; LWW rejects when occurred_at is older; null base_version on non-create falls through to LWW; sync_conflicts row written on conflict)
+  - **Assigned:** builder-rust
+  - **Depends:** S007
+
+- [ ] S008: Implement `create_conflict_copy(tx, original_entity_id, payload, user_id) -> Result<Uuid>`
+  — INSERT a new `knowledge_notes` row using payload columns (new `gen_random_uuid()` id); INSERT into `entity_relations` with `source_id = new_id`, `target_id = original_entity_id`, `relation_type = "duplicates"`, `source_type = "knowledge_note"`, `target_type = "knowledge_note"`; INSERT into `sync_conflicts` with `resolution = 'conflict_copy'`; return new note id as `conflict_id`
+  — wire into apply_mutations: when entity_type == KnowledgeNote and operation == Update and conflict detected → call create_conflict_copy instead of LWW
+  - **Assigned:** builder-rust
+  - **Depends:** S007
+  - **Parallel:** false
+
+- [ ] S008-T: Integration tests for conflict copy (FA-007)
+  (conflicting knowledge_note update → two knowledge_notes rows exist; entity_relations row inserted with relation_type=duplicates; sync_conflicts row has resolution=conflict_copy; original note unchanged; returned status is Conflicted with conflict_id)
+  - **Assigned:** builder-rust
+  - **Depends:** S008
+
+- [ ] S009: Implement `check_quantity_conflict(payload) -> bool`
+  — returns true if the mutation payload contains a quantity field (`quantity`, `consumed_quantity`, or similar per tracking_item_events schema);
+  wire into apply_mutations: when entity_type == TrackingItemEvent and operation == Update and conflict detected and check_quantity_conflict(payload) → ROLLBACK and return `Err(AppError::Conflict("quantity conflict — re-read and resubmit"))`
+  - **Assigned:** builder-rust
+  - **Depends:** S007
+  - **Parallel:** false
+
+- [ ] S009-T: Tests for quantity conflict path (FA-008)
+  (update with quantity field + conflict → 409-equivalent Conflict error; update without quantity field + conflict → LWW path taken; non-tracking entity with conflict → not routed to quantity check)
+  - **Assigned:** builder-rust
+  - **Depends:** S009
+
+🏁 **MILESTONE 3: Service complete**
+  **Contracts:**
+  - `apps/server/server/src/sync/service.rs` — apply_mutations, detect_conflict, create_conflict_copy, check_quantity_conflict, record_sync_mutation signatures
+
+---
+
+### Phase 4: Handler + Wiring
+
+- [ ] S010: Create `apps/server/server/src/sync/handlers.rs` — `push_handler(State(state): State<AppState>, auth: AuthUser, Json(req): Json<SyncUploadRequest>) -> Result<Json<SyncUploadResponse>, AppError>` — extract auth user, call `service::apply_mutations(&state.db, req.mutations, auth)`, return `Json(SyncUploadResponse { results })`; update `mod.rs` router() to mount `POST /api/sync/push` → push_handler
+  - **Assigned:** builder-rust
+  - **Depends:** S009
+  - **Parallel:** false
+
+- [ ] S010-T: Integration tests for push_handler auth gate and basic paths (FA-001, FA-002, FA-003, FA-004, FA-005)
+  (no JWT → 401; valid JWT + valid create mutation → 200 + accepted; same mutation replayed → 200 + deduplicated; unknown entity_type → 422; mutation for other user's entity → 403)
+  - **Assigned:** builder-rust
+  - **Depends:** S010
+
+- [ ] S011: Wire sync module into server crate — add `pub mod sync;` to `apps/server/server/src/lib.rs`; add `.merge(sync::router())` to router in `apps/server/server/src/main.rs` following existing module pattern
+  - **Assigned:** builder-rust
+  - **Depends:** S010
+  - **Parallel:** false
+
+- [ ] S011-T: Integration tests for conflict and delete paths (FA-006, FA-007, FA-008, FA-009)
+  (two devices submit update with same base_version → sync_conflicts row written + Conflicted status; knowledge_note conflict → conflict copy created; tracking_item_event quantity conflict → 409; delete mutation → deleted_at set + row remains in table)
+  - **Assigned:** builder-rust
+  - **Depends:** S011
+
+🏁 **MILESTONE 4: Push endpoint live** — verify FA-001 through FA-009; `cargo test` exits 0
+
+---
+
+### Phase 5: PowerSync Infra
+
+> builder-infra starts this phase after Milestone 1 (migrations confirmed). Independent of builder-rust Phase 3–4 work.
+
+- [ ] S012: Create `infra/compose/sync_rules.yaml` — 5 bucket definitions per Tech.md:
+  `user_data` (user_id scoped: users, initiatives, tags, attachments, entity_relations);
+  `household` (household_id via membership subquery: households, household_memberships);
+  `guidance` (user_id scoped: guidance_epics, guidance_quests, guidance_routines, guidance_focus_sessions, guidance_daily_checkins);
+  `knowledge` (user_id scoped: knowledge_notes, knowledge_note_snapshots);
+  `tracking` (household_id via membership subquery: tracking_locations, tracking_categories, tracking_items, tracking_item_events, tracking_shopping_lists, tracking_shopping_list_items);
+  — no `WHERE deleted_at IS NULL` filter in any bucket (Tech.md Decision 3); use `request.user_id()` per ADR-012
+  - **Assigned:** builder-infra
+  - **Depends:** S001-T, S002-T
+  - **Parallel:** true
+
+- [ ] S012-T: Verify sync_rules.yaml — confirm all 5 buckets present, all table names match migration filenames, `request.user_id()` used correctly, no deleted_at filter; note FA-010 and FA-011 require `docker compose up` (REQUIRES_LIVE_ENV)
+  - **Assigned:** builder-infra
+  - **Depends:** S012
+
+- [ ] S013: Update `infra/compose/powersync.yml` — add `sync_rules:` block with `path: ./sync_rules.yaml` under the top-level config; remove stale comment referencing `apps/web/src/lib/sync/schema.ts`
+  - **Assigned:** builder-infra
+  - **Depends:** S012
+  - **Parallel:** false
+
+- [ ] S014: Update `packages/contracts/sync-streams.json` — set `provisional: false`; update `note` field to reflect finalised bucket names; verify 5 stream id values match bucket keys in sync_rules.yaml exactly (FA-012)
+  - **Assigned:** builder-infra
+  - **Depends:** S012
+  - **Parallel:** true
+
+🏁 **MILESTONE 5: Infra complete** — verify FA-012; FA-010 and FA-011 are **REQUIRES_LIVE_ENV** (`docker compose up`, PowerSync healthy, no sync_rules parse errors in logs; cross-user bucket isolation verified via PowerSync client or bucket inspection)
+
+---
+
+### Phase 6: Should-Have — Conflict Resolution Endpoints
+
+- [ ] S015: Implement `GET /api/sync/conflicts` — paginated query of `sync_conflicts` WHERE `user_id = auth.id` AND `resolution = 'pending'`; default page size 20; response includes `id`, `entity_type`, `entity_id`, `base_version`, `current_version`, `incoming_payload`, `current_payload`, `created_at`; add handler + route to sync router
+  - **Assigned:** builder-rust
+  - **Depends:** S011
+  - **Parallel:** false
+
+- [ ] S015-T: Integration tests for GET /api/sync/conflicts
+  (returns only auth user's pending conflicts; pagination cursor works; empty list when no conflicts; 401 without JWT)
+  - **Assigned:** builder-rust
+  - **Depends:** S015
+
+- [ ] S016: Implement `POST /api/sync/conflicts/:id/resolve` — validate `resolution` field (accepted | rejected); UPDATE sync_conflicts SET `resolution = $1`, `resolved_at = now()` WHERE `id = $2` AND `user_id = auth.id`; return 200 on success; 404 if not found; 403 if conflict belongs to other user; add handler + route to sync router
+  - **Assigned:** builder-rust
+  - **Depends:** S015
+  - **Parallel:** false
+
+- [ ] S016-T: Integration tests for POST /api/sync/conflicts/:id/resolve
+  (accepted → resolution=accepted + resolved_at set; rejected → resolution=rejected + resolved_at set; unknown id → 404; other user's conflict → 403; 401 without JWT)
+  - **Assigned:** builder-rust
+  - **Depends:** S016
+
+- [ ] S016-D: Update `CLAUDE.md` active work section — Feature 004 Sync Engine complete; next: Feature 005 Guidance Domain (or 006/007 per parallel track)
+  - **Assigned:** builder-infra
+  - **Depends:** S016
+
+🏁 **MILESTONE 6: Should-have complete** — verify S-1, S-2, S-3 from Spec.md; `cargo test` exits 0
+
+---
+
+### Phase 7: Validation
+
+- [ ] S017: Full drift check — read Spec.md testable assertions FA-001 through FA-014 against implemented code; verify cargo test exits 0; confirm no TODO/FIXME stubs in sync module; confirm sync_rules.yaml table names exactly match migration table names; confirm sync-streams.json provisional=false (FA-012); flag any REQUIRES_LIVE_ENV assertions for manual verification
+  - **Assigned:** validator
+  - **Depends:** S016, S014
+  - **Parallel:** false
+
+🏁 **MILESTONE 7: Feature 004 complete** — all assertions verified; REQUIRES_LIVE_ENV assertions noted for post-deploy check
+
+---
+
+## Acceptance Criteria
+
+- [ ] FA-001 through FA-014 all verified (FA-010, FA-011 marked REQUIRES_LIVE_ENV)
+- [ ] `cargo test` exits 0 in `apps/server/`
+- [ ] `sqlx migrate run` and `sqlx migrate revert` exit 0 against fresh DB (FA-014)
+- [ ] `packages/contracts/sync-streams.json` has `provisional: false` (FA-012)
+- [ ] No TODO/FIXME stubs in `src/sync/`
+- [ ] sync_rules.yaml bucket table names match Postgres migration table names exactly
+- [ ] Spec.md M-3 and M-4 annotated as overridden
+
+## Validation Commands
+
+```bash
+# Server tests
+cd apps/server && cargo test
+
+# Migration apply + revert
+sqlx migrate run --source infra/migrations
+sqlx migrate revert --source infra/migrations
+
+# Contracts assertion
+jq '.provisional' packages/contracts/sync-streams.json  # → false
+
+# Sync rules file exists
+ls infra/compose/sync_rules.yaml
+
+# REQUIRES_LIVE_ENV (post-deploy):
+# docker compose up → check PowerSync logs for sync_rules parse errors
+# docker compose ps → confirm PowerSync healthy
+```

--- a/Context/Features/004-SyncEngine/Steps.md
+++ b/Context/Features/004-SyncEngine/Steps.md
@@ -283,6 +283,58 @@
 
 ---
 
+### Phase 8: Post-Review Fixes — Tests
+
+Tasks added from P5 code review findings. All relate to missing test coverage identified during review.
+
+- [ ] S018-T: Integration test for mixed-validity batch — partial commit behavior (P5-015)
+  Document and test the current behavior: `apply_mutations` processes serially; the first error aborts with already-committed mutations unrolled. Assert: `[valid_create, forbidden_update]` returns 403 and first mutation IS committed; document partial-commit semantics in code comment.
+  - **Assigned:** builder-rust
+  - **Depends:** S009
+  - **Relates to:** FA-001, FA-004
+
+- [ ] S019-T: Integration tests for delete on non-deletable entity types (P5-016)
+  One test per guarded type (`TrackingItemEvent`, `KnowledgeNoteSnapshot`, `Tag`): POST /api/sync/push with `operation: "delete"` returns 400 Bad Request.
+  - **Assigned:** builder-rust
+  - **Depends:** S010
+
+- [ ] S020-T: Integration test for Update on immutable `KnowledgeNoteSnapshot` (P5-017)
+  POST /api/sync/push with `operation: "update"` for entity_type `knowledge_note_snapshot` returns 400 Bad Request with message "knowledge_note_snapshot is immutable".
+  - **Assigned:** builder-rust
+  - **Depends:** S009
+
+- [ ] S021-T: Integration tests for ownership on Household, TrackingItem, TrackingItemEvent (P5-018)
+  One test per type: non-owner/non-member attempting Update returns 403 Forbidden. Covers FA-005 for all indirect ownership paths.
+  - **Assigned:** builder-rust
+  - **Depends:** S005
+  - **Relates to:** FA-005
+
+- [ ] S022-T: Integration tests for resolve endpoint edge cases (P5-019)
+  (1) Resolving an already-resolved conflict returns 409. (2) Submitting an out-of-enum resolution string (e.g. `"garbage"`) returns 400 Bad Request (serde will reject at deserialization boundary).
+  - **Assigned:** builder-rust
+  - **Depends:** S016
+  - **Relates to:** FA-006
+
+- [ ] S023: Refactor `MutationEnvelope` to enum-of-structs (P5-024)
+  Replace flat struct with `#[serde(tag = "operation")] enum MutationPayload { Create { payload: Value, … }, Update { payload: Value, base_version: DateTime<Utc>, … }, Delete { … } }`. Wire format preserved; invalid cross-field states become unrepresentable at the serde boundary. Update service.rs dispatch accordingly.
+  - **Assigned:** builder-rust
+  - **Depends:** S009
+
+- [ ] S024: Add `ConflictStatus` enum replacing `'pending'` string literals (P5-025)
+  Add `pub enum ConflictStatus { Pending, Accepted, Rejected, ConflictCopy }` with `as_str()` impl. Use in `service::list_conflicts` and `service::resolve_conflict` WHERE clauses. Eliminates silent typo risk on the `'pending'` filter.
+  - **Assigned:** builder-rust
+  - **Depends:** S015
+
+- [ ] S025-T: Integration test for non-KnowledgeNote LWW Rejected path (P5-026)
+  For e.g. `GuidanceQuest`: submit Update with `occurred_at` older than server's `updated_at`; assert response contains `status: "conflicted"`, row data is unchanged, and `sync_conflicts` row exists with `resolution = 'pending'`.
+  - **Assigned:** builder-rust
+  - **Depends:** S009
+  - **Relates to:** FA-008
+
+🏁 **MILESTONE 8: Post-review hardening complete** — all P5 test tasks pass; `cargo test` exits 0
+
+---
+
 ## Acceptance Criteria
 
 - [ ] FA-001 through FA-014 all verified (FA-010, FA-011 marked REQUIRES_LIVE_ENV)

--- a/Context/Features/004-SyncEngine/Tech.md
+++ b/Context/Features/004-SyncEngine/Tech.md
@@ -1,0 +1,408 @@
+# Feature 004: Sync Engine — Technical Research
+
+| Field | Value |
+|---|---|
+| **Feature** | 004-SyncEngine |
+| **Version** | 1.0 |
+| **Status** | Draft |
+| **Date** | 2026-04-13 |
+| **Source Docs** | `Context/Features/004-SyncEngine/Spec.md`, `Context/Decisions/ADR-003-sync-protocol-conflict-resolution.md` |
+
+---
+
+## Architecture Overview
+
+Feature 004 adds three layers to the existing server:
+
+1. **`src/sync/` module** — new Axum module following the existing
+   `mod.rs / models.rs / service.rs / handlers.rs` pattern. Implements `POST /api/sync/push`.
+2. **Sync tables** — two new migrations (`sync_mutations` for dedup, `sync_conflicts` for
+   conflict logging). No per-domain `row_version` column; see Decision 1.
+3. **PowerSync sync rules** — `infra/compose/sync_rules.yaml` (separate file referenced from
+   `powersync.yml`) defines bucket partitioning by `user_id` and `household_id`.
+
+The auth module, AppError, and AppState from Feature 003 are reused directly. No new Cargo
+dependencies are expected beyond `serde_json` (already present) for the JSONB payload handling.
+
+---
+
+## Open Questions Resolved
+
+### Decision 1 — `row_version` column vs. `updated_at` as version proxy
+
+**Spec M-4 is overridden.** No separate `row_version` column is added to domain tables.
+
+`updated_at` serves as the conflict version marker. This works because:
+
+- `updated_at` is already present on all domain tables with an auto-update trigger from
+  Feature 003's migrations.
+- The server sets `updated_at = now()` on every successfully applied mutation; clients never
+  write `updated_at`.
+- Clients include their last-known `updated_at` for an entity as `base_version` in the
+  mutation envelope. This is read from the client's local SQLite before executing the local
+  write (connector responsibility — Features 008/009).
+- The server checks: if the row's current `updated_at` in Postgres > `base_version`, a conflict
+  is detected. The row was modified by another device after the client's last sync point.
+
+**Critical constraint (for client connector implementors):** Clients must never write
+`updated_at` in their local SQLite mutations. If a client writes `updated_at` to local SQLite,
+the PowerSync CrudEntry's `opData` will contain the client-set timestamp, making it useless as
+`base_version`. The contract is: `updated_at` is a server-managed, read-only field for clients.
+Client SQLite schemas should mark it as not writable. This is enforced in Features 008/009.
+
+**Spec change:** Removes M-4 (row_version migration) and updates M-1 (sync_mutations) to not
+include a `row_version` reference. `base_version` in mutation envelopes is now typed
+`TIMESTAMPTZ | null` and compared directly against the row's `updated_at`.
+
+---
+
+### Decision 2 — `device_checkpoints` table dropped
+
+**Spec M-3 is overridden.** No `device_checkpoints` table is created.
+
+PowerSync's service manages LSN-based checkpointing internally between the service and each
+connected client. The `sync_mutations` table (dedup store, Spec M-1) handles the only
+server-side tracking needed: idempotent mutation replay by `mutation_id`.
+
+Invariant S-4 (monotonic checkpoint advancement) is enforced by PowerSync's internal mechanism,
+not by application code.
+
+---
+
+### Decision 3 — Soft-deleted rows in sync rules: include, not filter
+
+**Rationale:** If sync rules filter `WHERE deleted_at IS NULL`, when a row is soft-deleted on
+the server, PowerSync removes it from the bucket. PowerSync sends a DELETE operation to the
+client, removing the row from local SQLite. This appears correct but breaks for offline clients:
+if the client was offline during the delete and comes back after the fact, PowerSync will still
+send the DELETE correctly (the row has `deleted_at IS NOT NULL`, so it's not in the bucket, and
+PowerSync's diff logic will issue a delete).
+
+However, including soft-deleted rows is safer for reconciliation: clients receive rows with
+`deleted_at IS NOT NULL` and can filter them locally. This matches invariant S-6 (soft-deleted
+records remain queryable for sync reconciliation).
+
+**Implementation:** Sync rule bucket queries do NOT include `WHERE deleted_at IS NULL`. All rows
+(including tombstones) are replicated. Client applications filter `deleted_at IS NULL` in their
+display queries.
+
+---
+
+### Decision 4 — Serial mutation application with partial success
+
+Each mutation in a `POST /api/sync/push` batch is processed independently within its own
+database transaction. The endpoint returns a per-mutation result array:
+
+```json
+{
+  "results": [
+    { "mutation_id": "...", "status": "accepted" },
+    { "mutation_id": "...", "status": "deduplicated" },
+    { "mutation_id": "...", "status": "conflicted", "conflict_id": "..." }
+  ]
+}
+```
+
+Rationale: all-or-nothing batch transactions make retry logic more complex and can cause
+correctly-applied mutations to fail because of a single conflicting one. Serial per-mutation
+transactions allow partial success and idempotent retry of failed mutations only.
+
+---
+
+### Decision 5 — `conflict_copy` relation type
+
+Conflict copies for `knowledge_note` entities are linked to the original via an `entity_relations`
+row with `relation_type: "duplicates"`. The existing `RelationType::Duplicates` variant in
+`contracts.rs` covers this; no new contract values are needed.
+
+The `sync_conflicts` row for this case uses `resolution = 'conflict_copy'` (a new value beyond
+the pending/accepted/rejected set defined in Spec M-2). This is additive and does not change the
+schema; it's a runtime value in a TEXT column.
+
+---
+
+## Mutation Envelope Format
+
+The PowerSync client SDK's `uploadData()` method receives `CrudTransaction` objects from its
+internal outbox. The client connector implementations (Features 008/009) are responsible for
+transforming these into `MutationEnvelope` objects and calling `POST /api/sync/push`.
+
+```
+CrudEntry (PowerSync SDK internal):
+  op:     "PUT" | "PATCH" | "DELETE"
+  table:  string (Postgres table name)
+  id:     string (UUID)
+  opData: Record<string, any> (changed fields)
+
+↓ Transformed by client connector ↓
+
+MutationEnvelope (Altair server format):
+  mutation_id:  UUID       -- client-generated; stable across retries
+  device_id:    UUID       -- client device identifier
+  entity_type:  EntityType -- validated against contracts registry
+  entity_id:    UUID       -- same as CrudEntry.id
+  operation:    "create" | "update" | "delete"
+  base_version: TIMESTAMPTZ | null  -- pre-write updated_at from local SQLite; null on create
+  payload:      JSONB      -- full row for create/update; empty for delete
+  occurred_at:  TIMESTAMPTZ
+```
+
+**Table-to-EntityType mapping** is defined in the client connector and does not need to be
+defined server-side. The server validates `entity_type` against the `EntityType` registry
+(`contracts.rs`) and maps it to the correct Postgres table for the mutation.
+
+**`base_version` protocol:**
+- `create`: `base_version = null`
+- `update`: `base_version` = the `updated_at` value from local SQLite for this row,
+  read before executing the local write
+- `delete`: `base_version` = same as update
+
+---
+
+## Server Module: `src/sync/`
+
+Following the existing module pattern:
+
+```
+apps/server/server/src/sync/
+  mod.rs       — module declaration + re-exports + router function
+  models.rs    — MutationEnvelope, SyncUploadRequest, SyncUploadResponse, MutationResult,
+                 MutationStatus enum (Accepted, Deduplicated, Conflicted { conflict_id })
+  service.rs   — apply_mutations(), detect_conflict(), create_conflict_copy(),
+                 check_quantity_conflict(), record_sync_mutation()
+  handlers.rs  — push_handler() (POST /api/sync/push)
+```
+
+`push_handler` extracts `AuthUser` via the existing extractor, validates the request, and
+delegates to `service.apply_mutations()`.
+
+`service.apply_mutations()` processes each `MutationEnvelope` in order:
+1. Check dedup (SELECT from sync_mutations by mutation_id)
+2. Validate entity_type
+3. Check ownership
+4. Detect conflict (SELECT row's updated_at; compare with base_version)
+5. Apply mutation or create conflict copy
+6. Record to sync_mutations
+
+All database operations in step 4+5+6 execute within a single sqlx transaction per mutation.
+
+---
+
+## Tables
+
+Two new migrations. Both include rollback `.down.sql` files.
+
+### `sync_mutations` (dedup store)
+
+```sql
+CREATE TABLE sync_mutations (
+  mutation_id  UUID        PRIMARY KEY,
+  device_id    UUID        NOT NULL,
+  user_id      UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  entity_type  TEXT        NOT NULL,
+  entity_id    UUID        NOT NULL,
+  operation    TEXT        NOT NULL, -- create | update | delete
+  applied_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_sync_mutations_entity ON sync_mutations(entity_id, applied_at);
+CREATE INDEX idx_sync_mutations_user   ON sync_mutations(user_id, applied_at);
+```
+
+### `sync_conflicts` (conflict log)
+
+```sql
+CREATE TABLE sync_conflicts (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  mutation_id      UUID        NOT NULL,
+  entity_type      TEXT        NOT NULL,
+  entity_id        UUID        NOT NULL,
+  base_version     TIMESTAMPTZ,            -- client's base_version (incoming)
+  current_version  TIMESTAMPTZ,            -- server's updated_at at conflict time
+  incoming_payload JSONB       NOT NULL,
+  current_payload  JSONB       NOT NULL,
+  resolution       TEXT        NOT NULL DEFAULT 'pending',
+                               -- pending | accepted | rejected | conflict_copy
+  resolved_at      TIMESTAMPTZ,
+  user_id          UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_sync_conflicts_entity ON sync_conflicts(entity_id, created_at);
+CREATE INDEX idx_sync_conflicts_user   ON sync_conflicts(user_id, resolution);
+```
+
+---
+
+## PowerSync Sync Rules
+
+### File location
+
+`infra/compose/sync_rules.yaml` — referenced from `powersync.yml` via:
+```yaml
+sync_rules:
+  path: ./sync_rules.yaml
+```
+
+### Bucket design
+
+Five buckets matching the `SyncStream` contract values. All buckets include soft-deleted rows
+(no `deleted_at IS NULL` filter) per Decision 3.
+
+```yaml
+bucket_definitions:
+
+  # User-owned personal data
+  user_data:
+    parameters: SELECT request.user_id() AS user_id
+    data:
+      - SELECT * FROM users       WHERE id = bucket.user_id
+      - SELECT * FROM initiatives WHERE user_id = bucket.user_id
+      - SELECT * FROM tags        WHERE user_id = bucket.user_id
+      - SELECT * FROM attachments WHERE user_id = bucket.user_id
+      - SELECT * FROM entity_relations WHERE user_id = bucket.user_id
+
+  # Household-scoped shared data (user must be a member)
+  household:
+    parameters: >
+      SELECT hm.household_id
+        FROM household_memberships hm
+       WHERE hm.user_id = request.user_id()
+    data:
+      - SELECT * FROM households            WHERE id = bucket.household_id
+      - SELECT * FROM household_memberships WHERE household_id = bucket.household_id
+
+  # Guidance domain — user-owned
+  guidance:
+    parameters: SELECT request.user_id() AS user_id
+    data:
+      - SELECT * FROM guidance_epics         WHERE user_id = bucket.user_id
+      - SELECT * FROM guidance_quests        WHERE user_id = bucket.user_id
+      - SELECT * FROM guidance_routines      WHERE user_id = bucket.user_id
+      - SELECT * FROM guidance_focus_sessions WHERE user_id = bucket.user_id
+      - SELECT * FROM guidance_daily_checkins WHERE user_id = bucket.user_id
+
+  # Knowledge domain — user-owned
+  knowledge:
+    parameters: SELECT request.user_id() AS user_id
+    data:
+      - SELECT * FROM knowledge_notes          WHERE user_id = bucket.user_id
+      - SELECT * FROM knowledge_note_snapshots WHERE user_id = bucket.user_id
+
+  # Tracking domain — household-scoped
+  tracking:
+    parameters: >
+      SELECT hm.household_id
+        FROM household_memberships hm
+       WHERE hm.user_id = request.user_id()
+    data:
+      - SELECT * FROM tracking_locations          WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_categories         WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_items              WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_item_events        WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_shopping_lists     WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_shopping_list_items WHERE household_id = bucket.household_id
+```
+
+**Note on `request.user_id()`:** PowerSync extracts this from the JWT `sub` claim. This is the
+same UUID issued by the Altair auth system (ADR-012). No additional configuration needed.
+
+**Access boundary enforcement (S-7):** The `household` and `tracking` buckets use a
+parameterized subquery against `household_memberships` — a user only receives household rows
+they're actually a member of. User-scoped buckets use `request.user_id()` directly.
+
+---
+
+## Conflict Detection Logic (summary)
+
+```
+receive MutationEnvelope for entity E:
+
+1. SELECT mutation_id FROM sync_mutations WHERE mutation_id = $1
+   → if found: return status=Deduplicated
+
+2. Validate entity_type against EntityType enum
+   → if invalid: return 422
+
+3. Ownership check (entity's user_id == auth.user_id, or household member)
+   → if not owned: return 403
+
+BEGIN transaction:
+
+4. SELECT updated_at, <all columns> FROM <table> WHERE id = $entity_id FOR UPDATE
+   current_row = result
+
+5a. If operation == Create and current_row is None:
+    → INSERT new row; record sync_mutation; return Accepted
+
+5b. If operation == Create and current_row exists:
+    → mutation is a duplicate create; return Accepted (idempotent)
+
+6. If base_version IS NULL and operation != Create:
+    → treat as "client has no version info"; apply with LWW using occurred_at
+
+7. Conflict check: if current_row.updated_at > base_version:
+    conflict detected →
+      if entity_type == KnowledgeNote and operation == Update:
+        create conflict copy (INSERT new note linked via entity_relations)
+        write sync_conflicts row (resolution='conflict_copy')
+        return Conflicted { conflict_id }
+      elif entity_type == TrackingItemEvent and is_quantity_field(payload):
+        ROLLBACK
+        return 409 (conflict response — client must re-read and resubmit)
+      else:
+        apply LWW: if occurred_at >= current_row.updated_at → accept (log conflict)
+                   if occurred_at < current_row.updated_at → reject (log conflict)
+        write sync_conflicts row
+        return Conflicted { conflict_id }
+
+8. No conflict: apply mutation (UPDATE or DELETE)
+   UPDATE: set updated_at = now(), apply payload columns
+   DELETE: set deleted_at = now()
+
+9. INSERT INTO sync_mutations (mutation_id, device_id, ...)
+COMMIT
+return Accepted
+```
+
+---
+
+## Integration Points
+
+| Component | Change | Notes |
+|---|---|---|
+| `src/lib.rs` | Add `pub mod sync;` | No AppState changes needed |
+| `src/main.rs` | `.merge(sync::router())` | Same pattern as core modules |
+| `apps/server/Cargo.toml` | No new deps expected | `serde_json` already present for JSONB |
+| `infra/compose/powersync.yml` | Add `sync_rules: path: ./sync_rules.yaml` | |
+| `infra/compose/sync_rules.yaml` | New file | Bucket definitions per Decision 3 |
+| `packages/contracts/sync-streams.json` | Set `provisional: false` | Stream names finalised |
+| `infra/migrations/` | Two new migrations (sync_mutations, sync_conflicts) | Next available numbers after 026 |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Clock skew between devices affects LWW ordering | Server-assigned `updated_at = now()` is the canonical timestamp; `occurred_at` is for LWW tiebreaking only, not the primary conflict signal |
+| `updated_at` written by client connector breaks conflict detection | Document the constraint explicitly; client connector implementations (Features 008/009) must treat `updated_at` as read-only |
+| PowerSync sync rules table name mismatch | Table names in `sync_rules.yaml` must exactly match Postgres table names from migrations; CI should validate via `docker compose up` smoke test |
+| Sync rules accidentally expose cross-user data | Bucket queries are parameterized by `request.user_id()` or household membership; FA-011 integration test verifies isolation |
+| Conflict copy notes accumulate indefinitely | `sync_conflicts` cleanup and conflict resolution UI are Feature 012; no cleanup implemented here |
+
+---
+
+## ADRs
+
+No new ADRs required. All decisions are governed by:
+- **ADR-003** — Sync protocol: LWW + conflict logging (accepted; this feature implements it)
+- **ADR-012** — Built-in auth: JWT `sub` = user UUID, used in `request.user_id()` in sync rules
+
+---
+
+## Revision History
+
+| Date | Change |
+|---|---|
+| 2026-04-13 | Initial tech research; drops Spec M-3 (device_checkpoints) and M-4 (row_version column); finalises conflict model |

--- a/Context/Reviews/PR-feat-sync-engine-2026-04-14.md
+++ b/Context/Reviews/PR-feat-sync-engine-2026-04-14.md
@@ -254,7 +254,7 @@ The following suggestions from the review agents have not yet been triaged. Run 
 - [x] All [TASK] findings added to Steps.md (P5-015 through P5-019, P5-024 through P5-026)
 - [x] All [ADR] findings have ADRs created (P5-001 → ADR-017, P5-002 → ADR-018)
 - [x] All [RULE] findings applied (P5-027 → rust-axum.md)
-- [ ] Review verified by review-verify agent
+- [x] Review verified by review-verify agent
 
 ## Resolution Summary
 **Resolved at:** 2026-04-14

--- a/Context/Reviews/PR-feat-sync-engine-2026-04-14.md
+++ b/Context/Reviews/PR-feat-sync-engine-2026-04-14.md
@@ -1,0 +1,269 @@
+# PR Review: feat/sync-engine → main
+
+**Date:** 2026-04-14
+**Feature:** Context/Features/004-SyncEngine/
+**Branch:** feat/sync-engine
+**Reviewers:** code-reviewer, silent-failure-hunter, pr-test-analyzer, type-design-analyzer
+**Status:** ✅ Resolved
+
+## Summary
+
+29 findings total across 4 review agents. 4 critical issues individually sufficient to block merge: SQL injection via payload-driven INSERT, authorization bypass enabling admin account creation through the sync endpoint, the update handler silently discarding all payload content while reporting Accepted, and sync_rules.yaml referencing nonexistent columns that prevent 3 tables from syncing. 6 additional silent failure patterns, 4 code convention violations, 5 missing test tasks, and 10 suggestions pending triage.
+
+---
+
+## Findings
+
+### Architectural Concerns
+
+#### [ADR] P5-001: SQL injection via unsanitized payload column names in `insert_from_payload`
+- **File:** `apps/server/server/src/sync/service.rs:665–681`
+- **Severity:** Critical
+- **Detail:** Payload JSON object keys are interpolated directly into SQL strings as column names: `let col_list = columns.join(", "); let sql = format!("INSERT INTO {table} ({col_list}) VALUES ...")`. An authenticated client can inject arbitrary SQL through a crafted payload key. Violates postgres.md "parameterized queries only; never interpolate user input into SQL." The root cause is the generic payload-driven INSERT design; fixing it requires either a per-entity typed insert allowlist or strict key allowlisting against `^[a-z_][a-z0-9_]*$`. This is an architectural decision because the entire `apply_create`/`apply_update` path is built on this generic mechanism.
+- **Relates to:** FA-001 (Create mutation accepted)
+- **Status:** ✅ ADR created
+- **Resolution:** ADR-017
+
+#### [ADR] P5-002: Authorization bypass — Create mutations allow admin account creation via sync endpoint
+- **File:** `apps/server/server/src/sync/service.rs:514–518, 621–700`
+- **Severity:** Critical
+- **Detail:** `process_single_mutation` explicitly skips `check_ownership` for `Operation::Create`, and no allowlist restricts which `EntityType`s may be created via sync push. `EntityType::User` and `EntityType::Household` are not in `is_user_scoped`, so their payloads are written verbatim. An authenticated client can submit `Create` for `EntityType::User` with `{"email": "...", "password_hash": "...", "is_admin": true}` and create an admin account. Similarly, household-scoped types (`TrackingLocation`, `TrackingCategory`, `TrackingShoppingList`) accept a client-supplied `household_id` in the payload without membership verification. Requires an architectural decision: either (a) explicit entity-type allowlist for sync-createable entities, (b) per-entity-type authorization checks on Create, or both.
+- **Relates to:** FA-004 (ownership enforcement); FA-005 (cross-user isolation)
+- **Status:** ✅ ADR created
+- **Resolution:** ADR-018
+
+### Fix-Now
+
+#### [FIX] P5-003: Update handler discards all payload content — only bumps `updated_at`
+- **File:** `apps/server/server/src/sync/service.rs:734–872`
+- **Severity:** Critical
+- **Detail:** `apply_update_to_table` executes `UPDATE {table} SET updated_at = now() WHERE id = $1` — no payload fields are written. Tech.md specifies: "UPDATE: set updated_at = now(), apply payload columns." Clients receive `MutationStatus::Accepted` and a `sync_mutations` row is recorded, but server state never changes. On the next pull the client sees its update reverted. This directly violates CLAUDE.md: "Sync conflicts must never silently lose data." Tests only assert status codes and `updated_at`, not that payload values persisted.
+- **Relates to:** FA-002 (Update mutation accepted); S009 (apply_mutations implementation)
+- **Status:** ✅ Fixed
+- **Resolution:** `apply_update_to_table` now accepts `payload: &Option<Value>` and applies allowlisted columns via dynamic SET clause. Implemented alongside ADR-017 column allowlist.
+
+#### [FIX] P5-004: `sync_rules.yaml` references nonexistent columns on 3 tables
+- **File:** `infra/compose/sync_rules.yaml`
+- **Severity:** Critical
+- **Detail:** Three bucket rules reference columns that do not exist in the migrations:
+  1. `knowledge_note_snapshots WHERE user_id = bucket.user_id` — no `user_id` column; ownership flows through `note_id → knowledge_notes.user_id`
+  2. `tracking_item_events WHERE household_id = bucket.household_id` — no `household_id` column; flows through `item_id → tracking_items`
+  3. `tracking_shopping_list_items WHERE household_id = bucket.household_id` — no `household_id` column; flows through `shopping_list_id → tracking_shopping_lists`
+  PowerSync fails to validate at deployment; these 3 tables will not sync. Fix requires JOINs through parent tables.
+- **Relates to:** FA-010 (sync rules parse); FA-011 (user isolation)
+- **Status:** ✅ Fixed
+- **Resolution:** Fixed all 3 rules in `sync_rules.yaml` to use subquery JOINs through parent tables.
+
+#### [FIX] P5-005: Silent serialization failure writes empty string to `entity_type` in audit tables
+- **File:** `apps/server/server/src/sync/service.rs:356–363, 888–891`
+- **Severity:** High
+- **Detail:** `serde_json::to_value(&envelope.entity_type).ok().and_then(...).unwrap_or_default()` swallows any `serde_json::Error` and writes `""` to the `entity_type` column in both `sync_mutations` and `sync_conflicts`. No log emitted. If the `EntityType` serialize impl changes (e.g., serde rename attribute regression), every mutation is logged with a blank entity type and the code returns `Ok(())`. Fix: propagate as `AppError::Internal` with an error log.
+- **Status:** ✅ Fixed
+- **Resolution:** `try_record_sync_mutation` and `record_conflict_row` now propagate serialization errors as `AppError::Internal` with `warn!` log.
+
+#### [FIX] P5-006: KnowledgeNote conflict path silently falls through to general LWW when payload is `None`
+- **File:** `apps/server/server/src/sync/service.rs:784–804, 827–847`
+- **Severity:** High
+- **Detail:** Both `ConflictOutcome::Accepted` and `Rejected` arms for KnowledgeNote are guarded by `if let Some(payload)`. If `payload` is `None` on a KnowledgeNote update conflict, neither arm executes — the code falls through to the general path without creating a conflict copy. The spec requires KnowledgeNote conflicts to always produce a copy. This silently loses data and violates the core "sync conflicts must never silently lose data" invariant. Fix: treat missing payload on a conflicted KnowledgeNote update as `AppError::BadRequest`.
+- **Relates to:** FA-007 (conflict copy created); FA-009 (no silent data loss)
+- **Status:** ✅ Fixed
+- **Resolution:** Both Accepted and Rejected KnowledgeNote arms now use `.ok_or_else(|| AppError::BadRequest(...))` to hard-fail instead of silently falling through.
+
+#### [FIX] P5-007: Transaction rollback failure silently discarded
+- **File:** `apps/server/server/src/sync/service.rs:543`
+- **Severity:** High
+- **Detail:** `let _ = tx.rollback().await;` discards rollback errors entirely. If rollback fails (network partition, connection drop), the transaction may remain open or partially applied. No log is written. Fix: log at error level if rollback fails.
+- **Status:** ✅ Fixed
+- **Resolution:** Rollback result now checked; failure logged with `warn!("transaction rollback failed: {rollback_err}")`.
+
+#### [FIX] P5-008: `updated_at` parse fallback silently corrupts conflict audit trail
+- **File:** `apps/server/server/src/sync/service.rs:795–799, 838–842`
+- **Severity:** High
+- **Detail:** `.and_then(|s| s.parse::<DateTime<Utc>>().ok()).unwrap_or(envelope.occurred_at)` — if `updated_at` is missing or malformed in the DB payload, `current_version` written to `sync_conflicts` silently becomes the client's `occurred_at` instead of the server's actual version. No log emitted. This corrupts the conflict audit trail used for manual resolution. Fix: return `AppError::Internal` or log a warning with the raw value before falling back.
+- **Status:** ✅ Fixed
+- **Resolution:** Extracted `parse_updated_at_from_payload` helper; logs a `warn!` with entity_id before falling back to epoch (timestamp 0) rather than `occurred_at`.
+
+#### [FIX] P5-009: `insert_from_payload` silently accepts non-object JSON payloads
+- **File:** `apps/server/server/src/sync/service.rs:629–632`
+- **Severity:** Medium
+- **Detail:** `payload.and_then(|p| p.as_object()).cloned().unwrap_or_default()` resolves a JSON array or `null` payload to an empty map. The subsequent `columns.is_empty()` guard at line 673 is dead code when `id`/`user_id` are always added unconditionally. A client sending a JSON array gets an INSERT with only `id` and `user_id`, silently discarding all payload fields. Fix: explicitly return `AppError::BadRequest` if payload is not a JSON object.
+- **Status:** ✅ Fixed
+- **Resolution:** `insert_from_payload` now returns `AppError::BadRequest("Create payload must be a JSON object")` for null or non-object payloads.
+
+#### [FIX] P5-010: `apply_delete` does not verify any rows were actually soft-deleted
+- **File:** `apps/server/server/src/sync/service.rs:938–943`
+- **Severity:** Medium
+- **Detail:** The `UPDATE ... SET deleted_at = now() WHERE id = $1` result is discarded after error mapping. A delete of a nonexistent entity returns `MutationStatus::Accepted`. Additionally, because ownership is checked before delete, a missing-entity case currently surfaces as `Forbidden` rather than `NotFound` — a misleading error. Fix: check `rows_affected() == 0` and return `AppError::NotFound`.
+- **Status:** ✅ Fixed
+- **Resolution:** `apply_delete` checks `rows_affected() == 0` and returns `AppError::NotFound`. Also added `AND deleted_at IS NULL` to avoid matching already-deleted rows.
+
+#### [FIX] P5-011: Handlers contain inline SQL — must delegate to service layer
+- **File:** `apps/server/server/src/sync/handlers.rs:35–129`
+- **Severity:** High
+- **Detail:** `list_conflicts_handler` and `resolve_conflict_handler` embed raw SQL queries and result translation directly in handler functions. Violates rust-axum.md ("Keep command handlers thin; delegate to service modules") and the module pattern ("handlers.rs — Axum route handlers (thin; delegate to service)"). Fix: move SQL into `service::list_conflicts` and `service::resolve_conflict`; handlers call these and wrap in `Json(...)`.
+- **Status:** ✅ Fixed
+- **Resolution:** SQL moved to `service::list_conflicts` and `service::resolve_conflict`; handlers now one-liners.
+
+#### [FIX] P5-012: `resolve_conflict_handler` allows overwriting already-resolved conflicts
+- **File:** `apps/server/server/src/sync/handlers.rs:102–112`
+- **Severity:** High
+- **Detail:** The UPDATE has no `AND resolution = 'pending'` clause, so a user can toggle a conflict's resolution arbitrarily (accepted ↔ rejected ↔ conflict_copy) after it has already been resolved. Once downstream consumers (audit, reconciliation, notifications) react to `resolved_at`, this creates data integrity risk. Fix: add `AND resolution = 'pending'` to WHERE clause; return 409 if 0 rows affected and the row exists with a non-pending resolution.
+- **Relates to:** FA-006 (conflict resolution endpoint)
+- **Status:** ✅ Fixed
+- **Resolution:** `service::resolve_conflict` adds `AND resolution = 'pending'`; disambiguates 0-rows-affected into NotFound, Forbidden, or Conflict(409).
+
+#### [FIX] P5-013: Migration tables violate `created_at`/`updated_at`/trigger convention
+- **File:** `infra/migrations/20260414000027_create_sync_mutations.up.sql`, `infra/migrations/20260414000028_create_sync_conflicts.up.sql`
+- **Severity:** Medium
+- **Detail:** postgres.md: "All tables require `created_at` and `updated_at` timestamps; `updated_at` auto-maintained via PL/pgSQL trigger." `sync_mutations` has `applied_at` only — no `created_at`, no `updated_at`, no trigger. `sync_conflicts` has `created_at` but no `updated_at` and no trigger, despite being mutated (`resolution`, `resolved_at`). Either add columns + trigger or document the intentional exception in an ADR.
+- **Status:** ✅ Fixed
+- **Resolution:** New migration `20260414000029_sync_tables_timestamps` adds `created_at`/`updated_at` to `sync_mutations` and `updated_at` to `sync_conflicts`, with `set_updated_at()` triggers on both.
+
+#### [FIX] P5-014: Unreachable `TrackingItemEvent` quantity conflict check in `apply_update`
+- **File:** `apps/server/server/src/sync/service.rs:806–815`
+- **Severity:** Low
+- **Detail:** Inside `ConflictOutcome::Accepted`, there is a guard `if matches!(envelope.entity_type, EntityType::TrackingItemEvent)` that calls `check_quantity_conflict`. But `TrackingItemEvent` returns early before `detect_conflict` is ever called (lines 741–756), making this block dead code. Misleads readers into thinking there is conflict-path quantity checking when there is not. Fix: remove the dead guard from the conflict arm, or restructure so `TrackingItemEvent` reaches the conflict arm and the quantity check there is the only one.
+- **Status:** ✅ Fixed
+- **Resolution:** Dead block removed when `ConflictOutcome::Accepted` arm was rewritten for P5-006.
+
+### Missing Tasks
+
+#### [TASK] P5-015: No test for mixed-validity batch (partial commit behavior undefined)
+- **File:** `apps/server/server/src/sync/service.rs:476–489`
+- **Severity:** Critical
+- **Detail:** `apply_mutations` processes mutations serially via `?` — the first error propagates and earlier mutations in the batch are already committed (each runs in its own transaction). A client sending `[valid_create, forbidden_update]` receives a 403 with no indication that the first mutation was applied. The behavior (partial commit vs. all-or-nothing) is unspecified and unverified. Either document and test the current behavior or change it. A regression removing this distinction would be undetectable.
+- **Relates to:** S009 (apply_mutations)
+- **Status:** ✅ Task created
+- **Resolution:** Added as S018-T in Steps.md Phase 8
+
+#### [TASK] P5-016: No test for delete on non-deletable entity types
+- **File:** `apps/server/server/src/sync/service.rs:927–933`
+- **Severity:** High
+- **Detail:** `apply_delete` explicitly rejects `TrackingItemEvent`, `KnowledgeNoteSnapshot`, and `Tag` with `AppError::BadRequest`. Neither unit tests nor integration tests exercise this path. A regression removing these guards would allow clients to soft-delete append-only rows. Need one integration test per guarded type confirming `POST /api/sync/push` with `operation: "delete"` returns 400.
+- **Status:** ✅ Task created
+- **Resolution:** Added as S019-T in Steps.md Phase 8
+
+#### [TASK] P5-017: No test for Update on immutable `KnowledgeNoteSnapshot`
+- **File:** `apps/server/server/src/sync/service.rs:759–763`
+- **Severity:** High
+- **Detail:** Guard returns `AppError::BadRequest("knowledge_note_snapshot is immutable")` for any Update mutation on this type. Completely untested. A snapshot is created at conflict copy time; allowing client updates through a regression would silently corrupt the immutability guarantee.
+- **Status:** ✅ Task created
+- **Resolution:** Added as S020-T in Steps.md Phase 8
+
+#### [TASK] P5-018: Ownership untested for Household, TrackingItem, TrackingItemEvent entity types
+- **File:** `apps/server/server/src/sync/service.rs` (check_ownership section)
+- **Severity:** High
+- **Detail:** FA-005 covers the attacker scenario only for `knowledge_note`. Ownership paths for `Household` (owner_id check), `TrackingItem` (dual user_id/household_id path), and `TrackingItemEvent` (indirect join through tracking_items) are untested at any level. These have more branching than the tested path. A regression bypassing ownership on these types would not be caught.
+- **Relates to:** FA-005 (cross-user isolation)
+- **Status:** ✅ Task created
+- **Resolution:** Added as S021-T in Steps.md Phase 8
+
+#### [TASK] P5-019: S016 re-resolve and invalid resolution value paths untested
+- **File:** `apps/server/server/src/sync/handlers.rs`, `apps/server/server/tests/sync_push_integration.rs`
+- **Severity:** Medium
+- **Detail:** Two gaps: (1) No test for resolving a conflict that is already `accepted` or `rejected` — the handler currently allows silent overwrite. (2) No test for an out-of-enum resolution string (e.g., `"garbage"`, `"pending"`) — if the handler does not validate before writing, arbitrary strings land in the `resolution` column and silently escape the `'pending'` filter used in S015.
+- **Relates to:** FA-006 (conflict resolution)
+- **Status:** ✅ Task created
+- **Resolution:** Added as S022-T in Steps.md Phase 8
+
+---
+
+## Suggestions (Pending Triage)
+
+The following suggestions from the review agents have not yet been triaged. Run interactive triage or mark individually.
+
+| # | Source | Title |
+|---|--------|-------|
+| S1 | type-analyzer | `MutationEnvelope` should be enum-of-structs to encode operation/payload/base_version constraints |
+| S2 | type-analyzer | `ConflictRecord.entity_type` should be `EntityType` not `String` |
+| S3 | type-analyzer | Add `ConflictStatus` enum for full 4-state resolution lifecycle |
+| S4 | type-analyzer | `ConflictPageParams.limit` should be `Option<u32>` not `Option<i64>` |
+| S5 | code-reviewer | Dedup check runs outside transaction — concurrent pushes with same mutation_id can both pass |
+| S6 | code-reviewer | List conflicts cursor predicate collapses to empty page if cursor row is resolved |
+| S7 | code-reviewer | Replace `.map_err(|e| AppError::Internal(anyhow::Error::from(e)))` boilerplate with `impl From<sqlx::Error> for AppError` |
+| S8 | test-analyzer | Non-KnowledgeNote LWW rejected path ("existing wins") not tested for any non-note entity |
+
+### Additional Fix-Now (from suggestions)
+
+#### [FIX] P5-020: `ConflictRecord.entity_type` is `String` — type regression on read path
+- **File:** `apps/server/server/src/sync/models.rs`
+- **Severity:** Medium
+- **Detail:** `MutationEnvelope.entity_type` is a typed `EntityType` enum (validated at deserialization), but `ConflictRecord.entity_type` reads back from Postgres as `String`. An unexpected database value (manual correction, migration) passes to the client silently without validation. Fix: implement a post-query conversion from `String` to `EntityType`, returning `Internal` if the string is not a known variant.
+- **Status:** ✅ Fixed
+- **Resolution:** Introduced `ConflictRow` (private `sqlx::FromRow` with `String`) and `ConflictRecord` (typed `EntityType`). `ConflictRecord::from_row` converts and skips rows with unknown types (logged as warning).
+
+#### [FIX] P5-021: `ConflictPageParams.limit` accepts negative values — use `Option<u32>`
+- **File:** `apps/server/server/src/sync/models.rs`
+- **Severity:** Low
+- **Detail:** `limit: Option<i64>` accepts any i64 including negatives; the handler clamps it, but the type alone permits `-9_223_372_036_854_775_808`. Change to `Option<u32>` to push the non-negative constraint to the type boundary; the upper-bound clamp in the handler remains correct.
+- **Status:** ✅ Fixed
+- **Resolution:** `ConflictPageParams.limit` changed to `Option<u32>`.
+
+#### [FIX] P5-022: Dedup check runs outside transaction — concurrent same `mutation_id` pushes can both pass
+- **File:** `apps/server/server/src/sync/service.rs:500`
+- **Severity:** Medium
+- **Detail:** The `mutation_id` dedup lookup runs before the transaction begins. Two concurrent pushes with the same `mutation_id` can both pass the check; the second then fails on the PK conflict and surfaces as a 500 rather than `Deduplicated`, defeating the idempotency guarantee under contention. Fix: use `INSERT INTO sync_mutations … ON CONFLICT (mutation_id) DO NOTHING RETURNING` to resolve atomically within a single statement.
+- **Relates to:** FA-003 (idempotent dedup); S-2 invariant
+- **Status:** ✅ Fixed
+- **Resolution:** `try_record_sync_mutation` uses `INSERT ... ON CONFLICT (mutation_id) DO NOTHING RETURNING mutation_id`; returns `None` → Deduplicated.
+
+#### [FIX] P5-023: Cursor predicate collapses to empty page if cursor row is resolved/deleted
+- **File:** `apps/server/server/src/sync/handlers.rs` (list_conflicts_handler)
+- **Severity:** Medium
+- **Detail:** `WHERE created_at < (SELECT created_at FROM sync_conflicts WHERE id = $2)` returns NULL if the cursor row has been resolved or deleted, collapsing the WHERE to false and returning an empty page — a silent pagination failure the caller cannot distinguish from "no more results." Fix: use a stable tuple cursor `(created_at, id)` or a separate cursor anchor that is not subject to row deletion.
+- **Status:** ✅ Fixed
+- **Resolution:** `service::list_conflicts` first fetches the anchor row by cursor id to get `(created_at, id)`, then uses `(created_at, id) < ($2, $3)` tuple comparison. If the anchor no longer exists, returns empty page (safe behavior).
+
+### Additional Missing Tasks (from suggestions)
+
+#### [TASK] P5-024: Refactor `MutationEnvelope` to enum-of-structs encoding operation/payload/base_version constraints
+- **File:** `apps/server/server/src/sync/models.rs`, `apps/server/server/src/sync/service.rs`
+- **Severity:** Medium
+- **Detail:** `MutationEnvelope` is a flat struct with all fields `pub` and no cross-field validation at the serde boundary. A `Create` with `payload: None`, a `Delete` with a payload, or an `Update` with no `base_version` all parse successfully and reach service code. Restructure as an enum-of-structs (`Create { payload: Value, … }`, `Update { payload: Value, base_version: DateTime<Utc>, … }`, `Delete { base_version: DateTime<Utc>, … }`) with `#[serde(tag = "operation", rename_all = "snake_case")]`. Wire format is preserved; invalid states become unrepresentable.
+- **Status:** ✅ Task created
+- **Resolution:** Added as S023 in Steps.md Phase 8
+
+#### [TASK] P5-025: Add `ConflictStatus` enum for the full 4-state resolution lifecycle
+- **File:** `apps/server/server/src/sync/models.rs`, `apps/server/server/src/sync/handlers.rs`
+- **Severity:** Low
+- **Detail:** The resolution lifecycle (`pending`, `accepted`, `rejected`, `conflict_copy`) exists only as scattered SQL string literals. A raw `'pending'` string in `handlers.rs` line 50 filters the list endpoint; a typo would produce a silently empty conflict list. Add a `ConflictStatus` enum with `as_str()` and use it in `ConflictRecord` and handler queries.
+- **Status:** ✅ Task created
+- **Resolution:** Added as S024 in Steps.md Phase 8
+
+#### [TASK] P5-026: Test non-KnowledgeNote LWW `Rejected` path ("existing wins") for at least one entity type
+- **File:** `apps/server/server/tests/sync_push_integration.rs`
+- **Severity:** Medium
+- **Detail:** For all entity types except `KnowledgeNote`, a `ConflictOutcome::Rejected` mutation records a conflict row but does NOT apply the update — the existing server value wins. No test verifies this for any non-note entity. Submit an Update with `occurred_at` older than `updated_at` for e.g. `GuidanceQuest`, assert the row data is unchanged, the response returns `conflicted`, and a `sync_conflicts` row exists with `resolution = 'pending'`.
+- **Status:** ✅ Task created
+- **Resolution:** Added as S025-T in Steps.md Phase 8
+
+### Convention Gaps
+
+#### [RULE] P5-027: `impl From<sqlx::Error> for AppError` missing — boilerplate `.map_err` appears ~40 times
+- **Files:** `apps/server/server/src/sync/service.rs` (throughout), `apps/server/server/src/sync/handlers.rs`
+- **Severity:** Medium
+- **Detail:** rust-axum.md already mandates: "Map sqlx::Error via `impl From<sqlx::Error> for AppError`… to eliminate boilerplate." `AppError` already derives `#[from] anyhow::Error`. The sync module adds ~40 instances of `.map_err(|e| AppError::Internal(anyhow::Error::from(e)))` instead. This pattern should be added as a concrete example in rust-axum.md and enforced during review.
+- **Suggested rule:** Add to `.claude/rules/rust-axum.md` under Error Handling: "Never write `.map_err(|e| AppError::Internal(anyhow::Error::from(e)))` — add `impl From<sqlx::Error> for AppError` once per crate and use `?` directly."
+- **Status:** ✅ Rule updated
+- **Resolution:** Added to `.claude/rules/rust-axum.md` under Error Handling.
+
+---
+
+## Resolution Checklist
+- [x] All [FIX] findings resolved (P5-003 through P5-014, P5-020 through P5-023)
+- [x] All [TASK] findings added to Steps.md (P5-015 through P5-019, P5-024 through P5-026)
+- [x] All [ADR] findings have ADRs created (P5-001 → ADR-017, P5-002 → ADR-018)
+- [x] All [RULE] findings applied (P5-027 → rust-axum.md)
+- [ ] Review verified by review-verify agent
+
+## Resolution Summary
+**Resolved at:** 2026-04-14
+**Session:** P5 review findings — fresh context session
+
+| Category | Total | Resolved |
+|---|---|---|
+| [ADR] | 2 | 2 |
+| [FIX] | 18 | 18 |
+| [TASK] | 8 | 8 |
+| [RULE] | 1 | 1 |
+| **Total** | **29** | **29** |

--- a/apps/server/server/src/auth/handlers.rs
+++ b/apps/server/server/src/auth/handlers.rs
@@ -94,7 +94,12 @@ pub async fn register(
         };
 
         let mut headers = HeaderMap::new();
-        set_auth_cookies(&mut headers, &access_token, &raw_refresh, state.secure_cookies)?;
+        set_auth_cookies(
+            &mut headers,
+            &access_token,
+            &raw_refresh,
+            state.secure_cookies,
+        )?;
 
         Ok((StatusCode::CREATED, headers, Json(token_response)).into_response())
     } else {
@@ -167,7 +172,12 @@ pub async fn login(
     };
 
     let mut headers = HeaderMap::new();
-    set_auth_cookies(&mut headers, &access_token, &raw_refresh, state.secure_cookies)?;
+    set_auth_cookies(
+        &mut headers,
+        &access_token,
+        &raw_refresh,
+        state.secure_cookies,
+    )?;
 
     Ok((StatusCode::OK, headers, Json(token_response)).into_response())
 }
@@ -539,8 +549,11 @@ mod tests {
             axum::http::header::COOKIE,
             axum::http::HeaderValue::from_static("refresh_token=cookie_token"),
         );
-        let result =
-            extract_token_from_body_or_cookie(Some("body_token".to_string()), &headers, "refresh_token");
+        let result = extract_token_from_body_or_cookie(
+            Some("body_token".to_string()),
+            &headers,
+            "refresh_token",
+        );
         assert_eq!(result.unwrap(), "body_token");
     }
 

--- a/apps/server/server/src/auth/service.rs
+++ b/apps/server/server/src/auth/service.rs
@@ -249,8 +249,7 @@ mod tests {
         let household_id = Uuid::new_v4();
 
         let token =
-            issue_access_token(user_id, "user@example.com", vec![household_id], &enc_key)
-                .unwrap();
+            issue_access_token(user_id, "user@example.com", vec![household_id], &enc_key).unwrap();
         assert!(!token.is_empty());
 
         let mut validation = Validation::new(Algorithm::RS256);
@@ -391,21 +390,26 @@ mod tests {
         let result = rotate_refresh_token(&pool, raw_token, &enc_key).await;
 
         let token_response = result.expect("Expected Ok(TokenResponse) for valid token");
-        assert!(!token_response.access_token.is_empty(), "access_token must not be empty");
-        assert!(!token_response.refresh_token.is_empty(), "refresh_token must not be empty");
+        assert!(
+            !token_response.access_token.is_empty(),
+            "access_token must not be empty"
+        );
+        assert!(
+            !token_response.refresh_token.is_empty(),
+            "refresh_token must not be empty"
+        );
         assert_ne!(
             token_response.refresh_token, raw_token,
             "New refresh token must differ from old"
         );
 
         // Assert the old token is now revoked in the DB.
-        let revoked_at: Option<chrono::DateTime<Utc>> = sqlx::query_scalar(
-            "SELECT revoked_at FROM refresh_tokens WHERE token_hash = $1",
-        )
-        .bind(&token_hash)
-        .fetch_one(&pool)
-        .await
-        .expect("Old token must still exist in DB");
+        let revoked_at: Option<chrono::DateTime<Utc>> =
+            sqlx::query_scalar("SELECT revoked_at FROM refresh_tokens WHERE token_hash = $1")
+                .bind(&token_hash)
+                .fetch_one(&pool)
+                .await
+                .expect("Old token must still exist in DB");
 
         assert!(
             revoked_at.is_some(),

--- a/apps/server/server/src/config.rs
+++ b/apps/server/server/src/config.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -48,7 +48,7 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
     use rsa::{pkcs8::EncodePrivateKey, traits::PublicKeyParts};
 
     /// Generate a fresh 2048-bit RSA PEM and return it base64-encoded.
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn valid_rsa_pem_parses_and_jwt_round_trips() {
         use jsonwebtoken::{
-            decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation,
+            Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode,
         };
         use rsa::pkcs8::DecodePrivateKey;
         use serde::{Deserialize, Serialize};

--- a/apps/server/server/src/core/initiatives/mod.rs
+++ b/apps/server/server/src/core/initiatives/mod.rs
@@ -6,7 +6,7 @@ use crate::AppState;
 use axum::Router;
 
 pub fn router() -> Router<AppState> {
-    use axum::routing::{delete, get, patch, post};
+    use axum::routing::get;
     Router::new()
         .route(
             "/api/initiatives",

--- a/apps/server/server/src/core/initiatives/service.rs
+++ b/apps/server/server/src/core/initiatives/service.rs
@@ -172,11 +172,17 @@ mod tests {
             .expect("list for user_b failed");
 
         assert_eq!(a_list.len(), 1, "user_a should see exactly 1 initiative");
-        assert_eq!(a_list[0].user_id, user_a, "user_a result must belong to user_a");
+        assert_eq!(
+            a_list[0].user_id, user_a,
+            "user_a result must belong to user_a"
+        );
         assert_eq!(a_list[0].title, "User A Initiative");
 
         assert_eq!(b_list.len(), 1, "user_b should see exactly 1 initiative");
-        assert_eq!(b_list[0].user_id, user_b, "user_b result must belong to user_b");
+        assert_eq!(
+            b_list[0].user_id, user_b,
+            "user_b result must belong to user_b"
+        );
         assert_eq!(b_list[0].title, "User B Initiative");
     }
 
@@ -277,13 +283,12 @@ mod tests {
             .expect("delete_initiative failed");
 
         // Verify the row still exists but deleted_at is set.
-        let deleted_at: Option<chrono::DateTime<chrono::Utc>> = sqlx::query_scalar(
-            "SELECT deleted_at FROM initiatives WHERE id = $1",
-        )
-        .bind(initiative.id)
-        .fetch_one(&pool)
-        .await
-        .expect("Row must still exist after soft delete");
+        let deleted_at: Option<chrono::DateTime<chrono::Utc>> =
+            sqlx::query_scalar("SELECT deleted_at FROM initiatives WHERE id = $1")
+                .bind(initiative.id)
+                .fetch_one(&pool)
+                .await
+                .expect("Row must still exist after soft delete");
 
         assert!(
             deleted_at.is_some(),

--- a/apps/server/server/src/core/relations/mod.rs
+++ b/apps/server/server/src/core/relations/mod.rs
@@ -6,7 +6,7 @@ use crate::AppState;
 use axum::Router;
 
 pub fn router() -> Router<AppState> {
-    use axum::routing::{delete, get, post};
+    use axum::routing::{delete, get};
     Router::new()
         .route(
             "/api/entity_relations",

--- a/apps/server/server/src/core/tags/mod.rs
+++ b/apps/server/server/src/core/tags/mod.rs
@@ -6,7 +6,7 @@ use crate::AppState;
 use axum::Router;
 
 pub fn router() -> Router<AppState> {
-    use axum::routing::{delete, get, post};
+    use axum::routing::{delete, get};
     Router::new()
         .route("/api/tags", get(handlers::list).post(handlers::create))
         .route("/api/tags/{id}", delete(handlers::delete))

--- a/apps/server/server/src/core/tags/service.rs
+++ b/apps/server/server/src/core/tags/service.rs
@@ -31,10 +31,10 @@ pub async fn create_tag(pool: &PgPool, user_id: Uuid, name: String) -> Result<Ta
     .await
     .map_err(|e| {
         // Postgres unique violation error code is 23505
-        if let sqlx::Error::Database(ref db_err) = e {
-            if db_err.code().as_deref() == Some("23505") {
-                return AppError::Conflict("Tag name already exists".to_string());
-            }
+        if let sqlx::Error::Database(ref db_err) = e
+            && db_err.code().as_deref() == Some("23505")
+        {
+            return AppError::Conflict("Tag name already exists".to_string());
         }
         AppError::Internal(anyhow::anyhow!(e.to_string()))
     })?;

--- a/apps/server/server/src/lib.rs
+++ b/apps/server/server/src/lib.rs
@@ -13,6 +13,7 @@ pub mod core;
 pub mod db;
 pub mod error;
 pub mod routes;
+pub mod sync;
 
 /// Application state shared across all Axum handlers.
 ///

--- a/apps/server/server/src/main.rs
+++ b/apps/server/server/src/main.rs
@@ -1,4 +1,4 @@
-use altair_server::{auth, build_app_state, config, core, db, routes};
+use altair_server::{auth, build_app_state, config, core, db, routes, sync};
 use anyhow::Context;
 use axum::Router;
 use tracing::info;
@@ -41,6 +41,7 @@ async fn main() -> anyhow::Result<()> {
         .merge(core::initiatives::router())
         .merge(core::tags::router())
         .merge(core::relations::router())
+        .merge(sync::router())
         .merge(routes::router().with_state(()))
         .with_state(app_state);
 

--- a/apps/server/server/src/sync/handlers.rs
+++ b/apps/server/server/src/sync/handlers.rs
@@ -37,9 +37,15 @@ pub async fn list_conflicts_handler(
     auth: AuthUser,
     Query(params): Query<ConflictPageParams>,
 ) -> Result<Json<ConflictListResponse>, AppError> {
-    let limit = params.limit.unwrap_or(20).min(100).max(1);
-    let conflicts = service::list_conflicts(&state.db, auth.user_id, params.cursor, limit).await?;
-    let next_cursor = if conflicts.len() == limit as usize {
+    let limit = params.limit.unwrap_or(20).clamp(1, 100);
+    // Fetch limit+1 to detect whether a next page exists without a separate COUNT query.
+    let mut conflicts =
+        service::list_conflicts(&state.db, auth.user_id, params.cursor, limit + 1).await?;
+    let has_next = conflicts.len() > limit as usize;
+    if has_next {
+        conflicts.truncate(limit as usize);
+    }
+    let next_cursor = if has_next {
         conflicts.last().map(|c| c.id)
     } else {
         None

--- a/apps/server/server/src/sync/handlers.rs
+++ b/apps/server/server/src/sync/handlers.rs
@@ -1,0 +1,129 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+};
+use uuid::Uuid;
+
+use super::service;
+use crate::AppState;
+use crate::auth::models::AuthUser;
+use crate::error::AppError;
+use crate::sync::models::{
+    ConflictListResponse, ConflictPageParams, ResolveConflictRequest, SyncUploadRequest,
+    SyncUploadResponse,
+};
+
+/// POST /api/sync/push
+///
+/// Accepts a batch of client mutations. Requires a valid JWT (AuthUser extractor).
+/// Returns per-mutation results: accepted, deduplicated, or conflicted.
+pub async fn push_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Json(req): Json<SyncUploadRequest>,
+) -> Result<Json<SyncUploadResponse>, AppError> {
+    let results = service::apply_mutations(&state.db, req.mutations, auth).await?;
+    Ok(Json(SyncUploadResponse { results }))
+}
+
+/// GET /api/sync/conflicts
+///
+/// Returns a paginated list of pending sync conflicts for the authenticated user.
+/// Cursor-based pagination: pass `cursor` (a conflict id) to fetch the next page.
+/// Default limit is 20; maximum is 100.
+pub async fn list_conflicts_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Query(params): Query<ConflictPageParams>,
+) -> Result<Json<ConflictListResponse>, AppError> {
+    use crate::sync::models::ConflictRecord;
+
+    let limit = params.limit.unwrap_or(20).min(100).max(1);
+
+    let conflicts: Vec<ConflictRecord> = if let Some(cursor) = params.cursor {
+        sqlx::query_as(
+            "SELECT id, entity_type, entity_id, base_version, current_version, \
+             incoming_payload, current_payload, created_at \
+             FROM sync_conflicts \
+             WHERE user_id = $1 \
+               AND resolution = 'pending' \
+               AND created_at < (SELECT created_at FROM sync_conflicts WHERE id = $2) \
+             ORDER BY created_at DESC \
+             LIMIT $3",
+        )
+        .bind(auth.user_id)
+        .bind(cursor)
+        .bind(limit)
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?
+    } else {
+        sqlx::query_as(
+            "SELECT id, entity_type, entity_id, base_version, current_version, \
+             incoming_payload, current_payload, created_at \
+             FROM sync_conflicts \
+             WHERE user_id = $1 \
+               AND resolution = 'pending' \
+             ORDER BY created_at DESC \
+             LIMIT $2",
+        )
+        .bind(auth.user_id)
+        .bind(limit)
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?
+    };
+
+    let next_cursor = if conflicts.len() == limit as usize {
+        conflicts.last().map(|c| c.id)
+    } else {
+        None
+    };
+
+    Ok(Json(ConflictListResponse {
+        conflicts,
+        next_cursor,
+    }))
+}
+
+/// POST /api/sync/conflicts/:id/resolve
+///
+/// Marks a conflict as accepted or rejected. Returns 200 on success, 404 if the
+/// conflict does not exist, 403 if it belongs to a different user.
+pub async fn resolve_conflict_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<Uuid>,
+    Json(req): Json<ResolveConflictRequest>,
+) -> Result<StatusCode, AppError> {
+    let resolution_str = req.resolution.as_str();
+
+    let result = sqlx::query(
+        "UPDATE sync_conflicts \
+         SET resolution = $1, resolved_at = now() \
+         WHERE id = $2 AND user_id = $3",
+    )
+    .bind(resolution_str)
+    .bind(id)
+    .bind(auth.user_id)
+    .execute(&state.db)
+    .await
+    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    if result.rows_affected() == 1 {
+        return Ok(StatusCode::OK);
+    }
+
+    // Disambiguate: does the row exist at all?
+    let exists: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM sync_conflicts WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    match exists {
+        None => Err(AppError::NotFound),
+        Some(_) => Err(AppError::Forbidden),
+    }
+}

--- a/apps/server/server/src/sync/handlers.rs
+++ b/apps/server/server/src/sync/handlers.rs
@@ -37,50 +37,13 @@ pub async fn list_conflicts_handler(
     auth: AuthUser,
     Query(params): Query<ConflictPageParams>,
 ) -> Result<Json<ConflictListResponse>, AppError> {
-    use crate::sync::models::ConflictRecord;
-
     let limit = params.limit.unwrap_or(20).min(100).max(1);
-
-    let conflicts: Vec<ConflictRecord> = if let Some(cursor) = params.cursor {
-        sqlx::query_as(
-            "SELECT id, entity_type, entity_id, base_version, current_version, \
-             incoming_payload, current_payload, created_at \
-             FROM sync_conflicts \
-             WHERE user_id = $1 \
-               AND resolution = 'pending' \
-               AND created_at < (SELECT created_at FROM sync_conflicts WHERE id = $2) \
-             ORDER BY created_at DESC \
-             LIMIT $3",
-        )
-        .bind(auth.user_id)
-        .bind(cursor)
-        .bind(limit)
-        .fetch_all(&state.db)
-        .await
-        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?
-    } else {
-        sqlx::query_as(
-            "SELECT id, entity_type, entity_id, base_version, current_version, \
-             incoming_payload, current_payload, created_at \
-             FROM sync_conflicts \
-             WHERE user_id = $1 \
-               AND resolution = 'pending' \
-             ORDER BY created_at DESC \
-             LIMIT $2",
-        )
-        .bind(auth.user_id)
-        .bind(limit)
-        .fetch_all(&state.db)
-        .await
-        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?
-    };
-
+    let conflicts = service::list_conflicts(&state.db, auth.user_id, params.cursor, limit).await?;
     let next_cursor = if conflicts.len() == limit as usize {
         conflicts.last().map(|c| c.id)
     } else {
         None
     };
-
     Ok(Json(ConflictListResponse {
         conflicts,
         next_cursor,
@@ -90,40 +53,13 @@ pub async fn list_conflicts_handler(
 /// POST /api/sync/conflicts/:id/resolve
 ///
 /// Marks a conflict as accepted or rejected. Returns 200 on success, 404 if the
-/// conflict does not exist, 403 if it belongs to a different user.
+/// conflict does not exist, 403 if it belongs to a different user, 409 if already resolved.
 pub async fn resolve_conflict_handler(
     State(state): State<AppState>,
     auth: AuthUser,
     Path(id): Path<Uuid>,
     Json(req): Json<ResolveConflictRequest>,
 ) -> Result<StatusCode, AppError> {
-    let resolution_str = req.resolution.as_str();
-
-    let result = sqlx::query(
-        "UPDATE sync_conflicts \
-         SET resolution = $1, resolved_at = now() \
-         WHERE id = $2 AND user_id = $3",
-    )
-    .bind(resolution_str)
-    .bind(id)
-    .bind(auth.user_id)
-    .execute(&state.db)
-    .await
-    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
-
-    if result.rows_affected() == 1 {
-        return Ok(StatusCode::OK);
-    }
-
-    // Disambiguate: does the row exist at all?
-    let exists: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM sync_conflicts WHERE id = $1")
-        .bind(id)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
-
-    match exists {
-        None => Err(AppError::NotFound),
-        Some(_) => Err(AppError::Forbidden),
-    }
+    service::resolve_conflict(&state.db, id, auth.user_id, req.resolution.as_str()).await?;
+    Ok(StatusCode::OK)
 }

--- a/apps/server/server/src/sync/mod.rs
+++ b/apps/server/server/src/sync/mod.rs
@@ -14,7 +14,7 @@ pub fn router() -> Router<AppState> {
         .route("/api/sync/push", post(handlers::push_handler))
         .route("/api/sync/conflicts", get(handlers::list_conflicts_handler))
         .route(
-            "/api/sync/conflicts/:id/resolve",
+            "/api/sync/conflicts/{id}/resolve",
             post(handlers::resolve_conflict_handler),
         )
 }

--- a/apps/server/server/src/sync/mod.rs
+++ b/apps/server/server/src/sync/mod.rs
@@ -1,0 +1,20 @@
+pub mod handlers;
+pub mod models;
+pub mod service;
+
+pub use models::*;
+
+use crate::AppState;
+use axum::Router;
+use axum::routing::{get, post};
+
+/// Sync engine router.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/api/sync/push", post(handlers::push_handler))
+        .route("/api/sync/conflicts", get(handlers::list_conflicts_handler))
+        .route(
+            "/api/sync/conflicts/:id/resolve",
+            post(handlers::resolve_conflict_handler),
+        )
+}

--- a/apps/server/server/src/sync/models.rs
+++ b/apps/server/server/src/sync/models.rs
@@ -3,20 +3,49 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// Client-to-server mutation operation.
+/// The operation-specific fields of a client mutation.
+///
+/// Using a tagged enum makes invalid cross-field states unrepresentable at the serde boundary
+/// (e.g. `base_version` cannot be sent on a Create, and `payload` is required for Create/Update).
+///
+/// The `"operation"` field in the JSON wire format acts as the discriminant tag, so the
+/// shape is identical to the previous flat struct:
+///   `{ "operation": "update", "payload": {...}, "base_version": "..." }`
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Operation {
-    Create,
-    Update,
-    Delete,
+#[serde(tag = "operation", rename_all = "snake_case")]
+pub enum MutationPayload {
+    /// Create a new entity. `payload` holds the full entity state.
+    Create {
+        /// Full entity state. Required for creates.
+        payload: Option<serde_json::Value>,
+    },
+    /// Update an existing entity. `base_version` is the client's last-known `updated_at`.
+    Update {
+        /// Updated entity fields. Required for updates.
+        payload: Option<serde_json::Value>,
+        /// Client's last-known `updated_at`. Null triggers LWW fallback.
+        base_version: Option<DateTime<Utc>>,
+    },
+    /// Soft-delete an existing entity. No payload needed.
+    Delete {},
+}
+
+impl MutationPayload {
+    /// Returns the canonical lowercase operation string for use in SQL and logs.
+    pub fn operation_str(&self) -> &'static str {
+        match self {
+            MutationPayload::Create { .. } => "create",
+            MutationPayload::Update { .. } => "update",
+            MutationPayload::Delete { .. } => "delete",
+        }
+    }
 }
 
 /// A single client mutation packaged for upload to the server.
 ///
-/// Clients include their last-known `updated_at` for an entity as `base_version`.
-/// The server compares this against the row's current `updated_at` to detect conflicts.
-/// `base_version` is null for create operations.
+/// The operation, payload, and base_version are encoded in the `operation` field
+/// via `MutationPayload`. This makes invalid cross-field states (e.g. `base_version`
+/// on a Create) unrepresentable at the serde boundary.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MutationEnvelope {
     /// Client-generated stable UUID for this mutation; used for idempotent dedup (invariant S-2).
@@ -27,12 +56,10 @@ pub struct MutationEnvelope {
     pub entity_type: EntityType,
     /// Target entity UUID.
     pub entity_id: Uuid,
-    /// Create, update, or delete.
-    pub operation: Operation,
-    /// Full entity state for create/update; null for delete.
-    pub payload: Option<serde_json::Value>,
-    /// Client's last-known `updated_at` for this entity. Null on create.
-    pub base_version: Option<DateTime<Utc>>,
+    /// Operation with its associated fields (create/update/delete).
+    /// Flattened into the JSON object so the wire format is unchanged.
+    #[serde(flatten)]
+    pub operation: MutationPayload,
     /// Client wall-clock time of the mutation; used for LWW tiebreaking.
     pub occurred_at: DateTime<Utc>,
 }
@@ -133,6 +160,31 @@ pub struct ConflictListResponse {
     pub next_cursor: Option<Uuid>,
 }
 
+/// Lifecycle status of a conflict row in `sync_conflicts`.
+///
+/// Replaces raw `'pending'` / `'accepted'` / `'rejected'` / `'conflict_copy'`
+/// string literals so typos are caught at compile time rather than silently
+/// producing wrong SQL results.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictStatus {
+    Pending,
+    Accepted,
+    Rejected,
+    ConflictCopy,
+}
+
+impl ConflictStatus {
+    /// Returns the canonical lowercase string used in SQL and audit trails.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ConflictStatus::Pending => "pending",
+            ConflictStatus::Accepted => "accepted",
+            ConflictStatus::Rejected => "rejected",
+            ConflictStatus::ConflictCopy => "conflict_copy",
+        }
+    }
+}
+
 /// Resolution decision for a conflict.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -161,19 +213,40 @@ mod tests {
     use super::*;
 
     #[test]
-    fn operation_serializes_to_snake_case() {
+    fn mutation_payload_operation_str() {
         assert_eq!(
-            serde_json::to_string(&Operation::Create).unwrap(),
-            r#""create""#
+            MutationPayload::Create { payload: None }.operation_str(),
+            "create"
         );
         assert_eq!(
-            serde_json::to_string(&Operation::Update).unwrap(),
-            r#""update""#
+            MutationPayload::Update {
+                payload: None,
+                base_version: None
+            }
+            .operation_str(),
+            "update"
         );
-        assert_eq!(
-            serde_json::to_string(&Operation::Delete).unwrap(),
-            r#""delete""#
-        );
+        assert_eq!(MutationPayload::Delete {}.operation_str(), "delete");
+    }
+
+    #[test]
+    fn mutation_payload_serializes_with_operation_discriminant() {
+        let create = MutationPayload::Create {
+            payload: Some(serde_json::json!({ "title": "t" })),
+        };
+        let json: serde_json::Value = serde_json::to_value(&create).unwrap();
+        assert_eq!(json["operation"], "create");
+
+        let update = MutationPayload::Update {
+            payload: None,
+            base_version: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&update).unwrap();
+        assert_eq!(json["operation"], "update");
+
+        let delete = MutationPayload::Delete {};
+        let json: serde_json::Value = serde_json::to_value(&delete).unwrap();
+        assert_eq!(json["operation"], "delete");
     }
 
     #[test]
@@ -218,14 +291,47 @@ mod tests {
             device_id: Uuid::nil(),
             entity_type: EntityType::KnowledgeNote,
             entity_id: Uuid::nil(),
-            operation: Operation::Update,
-            payload: Some(serde_json::json!({ "title": "test" })),
-            base_version: None,
+            operation: MutationPayload::Update {
+                payload: Some(serde_json::json!({ "title": "test" })),
+                base_version: None,
+            },
             occurred_at: DateTime::from_timestamp(0, 0).unwrap(),
         };
         let json = serde_json::to_string(&envelope).unwrap();
         let parsed: MutationEnvelope = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.mutation_id, envelope.mutation_id);
-        assert!(parsed.base_version.is_none());
+        // Verify the operation field round-tripped as "update".
+        let json_val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(json_val["operation"], "update");
+    }
+
+    #[test]
+    fn create_envelope_deserializes_from_wire_json() {
+        // Wire format: operation discriminant flattened into the outer object.
+        let wire = serde_json::json!({
+            "mutation_id": "00000000-0000-0000-0000-000000000001",
+            "device_id": "00000000-0000-0000-0000-000000000002",
+            "entity_type": "knowledge_note",
+            "entity_id": "00000000-0000-0000-0000-000000000003",
+            "operation": "create",
+            "payload": { "title": "Hello" },
+            "occurred_at": "1970-01-01T00:00:00Z"
+        });
+        let envelope: MutationEnvelope = serde_json::from_value(wire).unwrap();
+        assert!(matches!(envelope.operation, MutationPayload::Create { .. }));
+    }
+
+    #[test]
+    fn delete_envelope_deserializes_without_payload() {
+        let wire = serde_json::json!({
+            "mutation_id": "00000000-0000-0000-0000-000000000001",
+            "device_id": "00000000-0000-0000-0000-000000000002",
+            "entity_type": "knowledge_note",
+            "entity_id": "00000000-0000-0000-0000-000000000003",
+            "operation": "delete",
+            "occurred_at": "1970-01-01T00:00:00Z"
+        });
+        let envelope: MutationEnvelope = serde_json::from_value(wire).unwrap();
+        assert!(matches!(envelope.operation, MutationPayload::Delete {}));
     }
 }

--- a/apps/server/server/src/sync/models.rs
+++ b/apps/server/server/src/sync/models.rs
@@ -73,9 +73,10 @@ pub struct SyncUploadResponse {
     pub results: Vec<MutationResult>,
 }
 
-/// A single pending conflict record returned to the authenticated user.
-#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
-pub struct ConflictRecord {
+/// A single pending conflict record returned by the database query.
+/// `entity_type` is read back as `String` and converted to `EntityType` post-query.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub(crate) struct ConflictRow {
     pub id: Uuid,
     pub entity_type: String,
     pub entity_id: Uuid,
@@ -86,11 +87,43 @@ pub struct ConflictRecord {
     pub created_at: DateTime<Utc>,
 }
 
+/// A single pending conflict record returned to the authenticated user.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConflictRecord {
+    pub id: Uuid,
+    pub entity_type: EntityType,
+    pub entity_id: Uuid,
+    pub base_version: Option<DateTime<Utc>>,
+    pub current_version: Option<DateTime<Utc>>,
+    pub incoming_payload: Option<serde_json::Value>,
+    pub current_payload: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl ConflictRecord {
+    /// Convert a `ConflictRow` to a `ConflictRecord`, parsing `entity_type`.
+    /// Returns `None` if the stored string is not a known `EntityType` variant.
+    pub(crate) fn from_row(row: ConflictRow) -> Option<Self> {
+        let entity_type: EntityType =
+            serde_json::from_value(serde_json::Value::String(row.entity_type)).ok()?;
+        Some(Self {
+            id: row.id,
+            entity_type,
+            entity_id: row.entity_id,
+            base_version: row.base_version,
+            current_version: row.current_version,
+            incoming_payload: row.incoming_payload,
+            current_payload: row.current_payload,
+            created_at: row.created_at,
+        })
+    }
+}
+
 /// Query parameters for paginating the conflicts list.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ConflictPageParams {
     pub cursor: Option<Uuid>,
-    pub limit: Option<i64>,
+    pub limit: Option<u32>,
 }
 
 /// Paginated response for the conflicts list endpoint.

--- a/apps/server/server/src/sync/models.rs
+++ b/apps/server/server/src/sync/models.rs
@@ -1,0 +1,198 @@
+use crate::contracts::EntityType;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Client-to-server mutation operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Operation {
+    Create,
+    Update,
+    Delete,
+}
+
+/// A single client mutation packaged for upload to the server.
+///
+/// Clients include their last-known `updated_at` for an entity as `base_version`.
+/// The server compares this against the row's current `updated_at` to detect conflicts.
+/// `base_version` is null for create operations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MutationEnvelope {
+    /// Client-generated stable UUID for this mutation; used for idempotent dedup (invariant S-2).
+    pub mutation_id: Uuid,
+    /// Client device identifier.
+    pub device_id: Uuid,
+    /// Validated entity type; must be a member of the EntityType registry (invariant C-1).
+    pub entity_type: EntityType,
+    /// Target entity UUID.
+    pub entity_id: Uuid,
+    /// Create, update, or delete.
+    pub operation: Operation,
+    /// Full entity state for create/update; null for delete.
+    pub payload: Option<serde_json::Value>,
+    /// Client's last-known `updated_at` for this entity. Null on create.
+    pub base_version: Option<DateTime<Utc>>,
+    /// Client wall-clock time of the mutation; used for LWW tiebreaking.
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// Batch upload request from a client connector.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncUploadRequest {
+    pub mutations: Vec<MutationEnvelope>,
+}
+
+/// Per-mutation outcome status.
+///
+/// Serialised with a flat `"status"` discriminant field so the JSON shape matches Tech.md:
+/// `{ "mutation_id": "...", "status": "accepted" }`
+/// `{ "mutation_id": "...", "status": "conflicted", "conflict_id": "..." }`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum MutationStatus {
+    /// Mutation was validated and applied to the database.
+    Accepted,
+    /// Mutation was already present in `sync_mutations`; skipped without re-applying.
+    Deduplicated,
+    /// Conflict detected; a `sync_conflicts` row was written. Includes the conflict record ID.
+    Conflicted { conflict_id: Uuid },
+}
+
+/// Outcome for a single mutation in a batch upload response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MutationResult {
+    pub mutation_id: Uuid,
+    #[serde(flatten)]
+    pub status: MutationStatus,
+}
+
+/// Batch upload response: one result per submitted mutation, in submission order.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncUploadResponse {
+    pub results: Vec<MutationResult>,
+}
+
+/// A single pending conflict record returned to the authenticated user.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct ConflictRecord {
+    pub id: Uuid,
+    pub entity_type: String,
+    pub entity_id: Uuid,
+    pub base_version: Option<DateTime<Utc>>,
+    pub current_version: Option<DateTime<Utc>>,
+    pub incoming_payload: Option<serde_json::Value>,
+    pub current_payload: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Query parameters for paginating the conflicts list.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConflictPageParams {
+    pub cursor: Option<Uuid>,
+    pub limit: Option<i64>,
+}
+
+/// Paginated response for the conflicts list endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConflictListResponse {
+    pub conflicts: Vec<ConflictRecord>,
+    pub next_cursor: Option<Uuid>,
+}
+
+/// Resolution decision for a conflict.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConflictResolution {
+    Accepted,
+    Rejected,
+}
+
+impl ConflictResolution {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ConflictResolution::Accepted => "accepted",
+            ConflictResolution::Rejected => "rejected",
+        }
+    }
+}
+
+/// Request body for resolving a conflict.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResolveConflictRequest {
+    pub resolution: ConflictResolution,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_serializes_to_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&Operation::Create).unwrap(),
+            r#""create""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Operation::Update).unwrap(),
+            r#""update""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Operation::Delete).unwrap(),
+            r#""delete""#
+        );
+    }
+
+    #[test]
+    fn mutation_status_accepted_serializes_flat() {
+        let result = MutationResult {
+            mutation_id: Uuid::nil(),
+            status: MutationStatus::Accepted,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["status"], "accepted");
+        assert!(json.get("conflict_id").is_none());
+    }
+
+    #[test]
+    fn mutation_status_conflicted_includes_conflict_id() {
+        let conflict_id = Uuid::nil();
+        let result = MutationResult {
+            mutation_id: Uuid::nil(),
+            status: MutationStatus::Conflicted { conflict_id },
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["status"], "conflicted");
+        assert!(json["conflict_id"].is_string());
+    }
+
+    #[test]
+    fn mutation_status_deduplicated_serializes_flat() {
+        let result = MutationResult {
+            mutation_id: Uuid::nil(),
+            status: MutationStatus::Deduplicated,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["status"], "deduplicated");
+        assert!(json.get("conflict_id").is_none());
+    }
+
+    #[test]
+    fn mutation_envelope_round_trips_through_serde() {
+        use crate::contracts::EntityType;
+        let envelope = MutationEnvelope {
+            mutation_id: Uuid::nil(),
+            device_id: Uuid::nil(),
+            entity_type: EntityType::KnowledgeNote,
+            entity_id: Uuid::nil(),
+            operation: Operation::Update,
+            payload: Some(serde_json::json!({ "title": "test" })),
+            base_version: None,
+            occurred_at: DateTime::from_timestamp(0, 0).unwrap(),
+        };
+        let json = serde_json::to_string(&envelope).unwrap();
+        let parsed: MutationEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.mutation_id, envelope.mutation_id);
+        assert!(parsed.base_version.is_none());
+    }
+}

--- a/apps/server/server/src/sync/service.rs
+++ b/apps/server/server/src/sync/service.rs
@@ -1,0 +1,1945 @@
+use chrono::{DateTime, Utc};
+use sqlx::{PgPool, Postgres, Transaction};
+use uuid::Uuid;
+
+use crate::auth::models::AuthUser;
+use crate::contracts::EntityType;
+use crate::error::AppError;
+use crate::sync::models::{MutationEnvelope, MutationResult, MutationStatus, Operation};
+
+// ---------------------------------------------------------------------------
+// S007: ConflictOutcome
+// ---------------------------------------------------------------------------
+
+/// Outcome of a conflict check against the current database state.
+pub enum ConflictOutcome {
+    /// No conflict: row does not exist (create path) or base_version matches.
+    Clean,
+    /// Conflict detected; LWW chose incoming (occurred_at >= current updated_at).
+    /// Conflict should still be recorded.
+    Accepted { current_payload: serde_json::Value },
+    /// Conflict detected; LWW chose existing (occurred_at < current updated_at).
+    Rejected { current_payload: serde_json::Value },
+}
+
+// ---------------------------------------------------------------------------
+// S005: entity_type_to_table
+// ---------------------------------------------------------------------------
+
+/// Map an EntityType to its Postgres table name.
+/// Exhaustive over all 18 variants.
+pub fn entity_type_to_table(entity_type: &EntityType) -> &'static str {
+    match entity_type {
+        EntityType::User => "users",
+        EntityType::Household => "households",
+        EntityType::Initiative => "initiatives",
+        EntityType::Tag => "tags",
+        EntityType::Attachment => "attachments",
+        EntityType::GuidanceEpic => "guidance_epics",
+        EntityType::GuidanceQuest => "guidance_quests",
+        EntityType::GuidanceRoutine => "guidance_routines",
+        EntityType::GuidanceFocusSession => "guidance_focus_sessions",
+        EntityType::GuidanceDailyCheckin => "guidance_daily_checkins",
+        EntityType::KnowledgeNote => "knowledge_notes",
+        EntityType::KnowledgeNoteSnapshot => "knowledge_note_snapshots",
+        EntityType::TrackingLocation => "tracking_locations",
+        EntityType::TrackingCategory => "tracking_categories",
+        EntityType::TrackingItem => "tracking_items",
+        EntityType::TrackingItemEvent => "tracking_item_events",
+        EntityType::TrackingShoppingList => "tracking_shopping_lists",
+        EntityType::TrackingShoppingListItem => "tracking_shopping_list_items",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// S005: check_ownership
+// ---------------------------------------------------------------------------
+
+/// Returns Ok(()) if the authenticated user owns (or is a member of the household that owns)
+/// the specified entity. Returns AppError::Forbidden if the check fails or the row is not found.
+///
+/// Ownership rules differ by table schema:
+/// - User-scoped tables (user_id column): SELECT user_id FROM <table> WHERE id = $1
+/// - Household-scoped tables (household_id column): verify via household_memberships
+/// - Special cases: users (id IS the user), households (owner_id), indirectly-owned tables
+pub async fn check_ownership(
+    db: &PgPool,
+    entity_type: &EntityType,
+    entity_id: Uuid,
+    auth_user: &AuthUser,
+) -> Result<(), AppError> {
+    match entity_type {
+        // ---- Self-referential: the entity IS the user ----
+        EntityType::User => {
+            if entity_id != auth_user.user_id {
+                return Err(AppError::Forbidden);
+            }
+            Ok(())
+        }
+
+        // ---- Household: check owner_id ----
+        EntityType::Household => {
+            let row: Option<(Uuid,)> =
+                sqlx::query_as("SELECT owner_id FROM households WHERE id = $1")
+                    .bind(entity_id)
+                    .fetch_optional(db)
+                    .await
+                    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+            match row {
+                Some((owner_id,)) if owner_id == auth_user.user_id => Ok(()),
+                _ => Err(AppError::Forbidden),
+            }
+        }
+
+        // ---- User-scoped tables with direct user_id column ----
+        EntityType::Initiative
+        | EntityType::Tag
+        | EntityType::Attachment
+        | EntityType::GuidanceEpic
+        | EntityType::GuidanceQuest
+        | EntityType::GuidanceRoutine
+        | EntityType::GuidanceFocusSession
+        | EntityType::GuidanceDailyCheckin
+        | EntityType::KnowledgeNote => {
+            let table = entity_type_to_table(entity_type);
+            let sql = format!("SELECT user_id FROM {table} WHERE id = $1");
+            let row: Option<(Uuid,)> = sqlx::query_as(&sql)
+                .bind(entity_id)
+                .fetch_optional(db)
+                .await
+                .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+            match row {
+                Some((user_id,)) if user_id == auth_user.user_id => Ok(()),
+                _ => Err(AppError::Forbidden),
+            }
+        }
+
+        // ---- KnowledgeNoteSnapshot: immutable, linked via note_id → knowledge_notes ----
+        EntityType::KnowledgeNoteSnapshot => {
+            let row: Option<(Uuid,)> = sqlx::query_as(
+                "SELECT kn.user_id \
+                 FROM knowledge_note_snapshots kns \
+                 JOIN knowledge_notes kn ON kn.id = kns.note_id \
+                 WHERE kns.id = $1",
+            )
+            .bind(entity_id)
+            .fetch_optional(db)
+            .await
+            .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+            match row {
+                Some((user_id,)) if user_id == auth_user.user_id => Ok(()),
+                _ => Err(AppError::Forbidden),
+            }
+        }
+
+        // ---- Household-scoped tables: verify via household_memberships ----
+        EntityType::TrackingLocation
+        | EntityType::TrackingCategory
+        | EntityType::TrackingShoppingList => {
+            let table = entity_type_to_table(entity_type);
+            let sql = format!(
+                "SELECT 1 \
+                 FROM {table} t \
+                 JOIN household_memberships hm ON hm.household_id = t.household_id \
+                 WHERE t.id = $1 AND hm.user_id = $2 AND hm.deleted_at IS NULL"
+            );
+            let row: Option<(i32,)> = sqlx::query_as(&sql)
+                .bind(entity_id)
+                .bind(auth_user.user_id)
+                .fetch_optional(db)
+                .await
+                .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+            if row.is_some() {
+                Ok(())
+            } else {
+                Err(AppError::Forbidden)
+            }
+        }
+
+        // ---- TrackingItem: has both user_id and household_id; accept either ----
+        EntityType::TrackingItem => {
+            let row: Option<(Option<Uuid>, Option<Uuid>)> =
+                sqlx::query_as("SELECT user_id, household_id FROM tracking_items WHERE id = $1")
+                    .bind(entity_id)
+                    .fetch_optional(db)
+                    .await
+                    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+            match row {
+                None => Err(AppError::Forbidden),
+                Some((user_id, household_id)) => {
+                    // Accept if directly owned
+                    if user_id == Some(auth_user.user_id) {
+                        return Ok(());
+                    }
+                    // Accept if household member
+                    if let Some(hid) = household_id {
+                        let member: Option<(i32,)> = sqlx::query_as(
+                            "SELECT 1 FROM household_memberships \
+                             WHERE household_id = $1 AND user_id = $2 AND deleted_at IS NULL",
+                        )
+                        .bind(hid)
+                        .bind(auth_user.user_id)
+                        .fetch_optional(db)
+                        .await
+                        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+                        if member.is_some() {
+                            return Ok(());
+                        }
+                    }
+                    Err(AppError::Forbidden)
+                }
+            }
+        }
+
+        // ---- TrackingItemEvent: linked via item_id → tracking_items ----
+        EntityType::TrackingItemEvent => {
+            let row: Option<(Option<Uuid>, Option<Uuid>)> = sqlx::query_as(
+                "SELECT ti.user_id, ti.household_id \
+                 FROM tracking_item_events te \
+                 JOIN tracking_items ti ON ti.id = te.item_id \
+                 WHERE te.id = $1",
+            )
+            .bind(entity_id)
+            .fetch_optional(db)
+            .await
+            .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+            match row {
+                None => Err(AppError::Forbidden),
+                Some((user_id, household_id)) => {
+                    if user_id == Some(auth_user.user_id) {
+                        return Ok(());
+                    }
+                    if let Some(hid) = household_id {
+                        let member: Option<(i32,)> = sqlx::query_as(
+                            "SELECT 1 FROM household_memberships \
+                             WHERE household_id = $1 AND user_id = $2 AND deleted_at IS NULL",
+                        )
+                        .bind(hid)
+                        .bind(auth_user.user_id)
+                        .fetch_optional(db)
+                        .await
+                        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+                        if member.is_some() {
+                            return Ok(());
+                        }
+                    }
+                    Err(AppError::Forbidden)
+                }
+            }
+        }
+
+        // ---- TrackingShoppingListItem: linked via shopping_list_id → tracking_shopping_lists ----
+        EntityType::TrackingShoppingListItem => {
+            let row: Option<(i32,)> = sqlx::query_as(
+                "SELECT 1 \
+                 FROM tracking_shopping_list_items sli \
+                 JOIN tracking_shopping_lists sl ON sl.id = sli.shopping_list_id \
+                 JOIN household_memberships hm ON hm.household_id = sl.household_id \
+                 WHERE sli.id = $1 AND hm.user_id = $2 AND hm.deleted_at IS NULL",
+            )
+            .bind(entity_id)
+            .bind(auth_user.user_id)
+            .fetch_optional(db)
+            .await
+            .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+            if row.is_some() {
+                Ok(())
+            } else {
+                Err(AppError::Forbidden)
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// S007: detect_conflict
+// ---------------------------------------------------------------------------
+
+/// Determines whether a conflict exists for the given entity, and if so,
+/// whether LWW rules would accept or reject the incoming mutation.
+///
+/// Must be called within an open transaction so the `FOR UPDATE` lock is held.
+///
+/// # Conflict logic
+/// - Row not found → `Clean` (create path; no conflict possible)
+/// - `base_version` is `None` and operation is not Create → treat as LWW with `occurred_at`
+/// - `base_version` is `Some` and `current.updated_at <= base_version` → `Clean` (no concurrent edit)
+/// - `base_version` is `Some` and `current.updated_at > base_version` → conflict:
+///   - `occurred_at >= current.updated_at` → `Accepted` (LWW: incoming wins)
+///   - `occurred_at < current.updated_at`  → `Rejected` (LWW: existing wins)
+///
+/// Note: `tracking_item_events` and `knowledge_note_snapshots` have no `updated_at` column;
+/// callers must bypass this function for those entity types.
+pub async fn detect_conflict(
+    tx: &mut Transaction<'_, Postgres>,
+    entity_type: &EntityType,
+    entity_id: Uuid,
+    base_version: Option<DateTime<Utc>>,
+    occurred_at: DateTime<Utc>,
+) -> Result<ConflictOutcome, AppError> {
+    let table = entity_type_to_table(entity_type);
+    let sql = format!(
+        "SELECT updated_at, row_to_json({table}.*) AS payload \
+         FROM {table} WHERE id = $1 FOR UPDATE"
+    );
+
+    let row: Option<(DateTime<Utc>, serde_json::Value)> = sqlx::query_as(&sql)
+        .bind(entity_id)
+        .fetch_optional(tx.as_mut())
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    let (current_updated_at, current_payload) = match row {
+        None => return Ok(ConflictOutcome::Clean),
+        Some(r) => r,
+    };
+
+    // Resolve effective base_version; None on non-create is treated as LWW with occurred_at.
+    let effective_base = match base_version {
+        Some(bv) => bv,
+        None => {
+            // No version info: apply LWW — occurred_at vs current updated_at.
+            if occurred_at >= current_updated_at {
+                return Ok(ConflictOutcome::Accepted { current_payload });
+            } else {
+                return Ok(ConflictOutcome::Rejected { current_payload });
+            }
+        }
+    };
+
+    // No conflict: client's base is current.
+    if current_updated_at <= effective_base {
+        return Ok(ConflictOutcome::Clean);
+    }
+
+    // Conflict detected.
+    if occurred_at >= current_updated_at {
+        Ok(ConflictOutcome::Accepted { current_payload })
+    } else {
+        Ok(ConflictOutcome::Rejected { current_payload })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// S009: check_quantity_conflict
+// ---------------------------------------------------------------------------
+
+/// Returns true if the payload contains a "quantity" or "consumed_quantity" key.
+/// Used to gate the hard-reject path for TrackingItemEvent quantity conflicts.
+pub fn check_quantity_conflict(payload: &serde_json::Value) -> bool {
+    if let Some(obj) = payload.as_object() {
+        obj.contains_key("quantity") || obj.contains_key("consumed_quantity")
+    } else {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// S006: record_sync_mutation
+// ---------------------------------------------------------------------------
+
+/// INSERT a row into `sync_mutations` as a dedup record for this mutation.
+/// Called inside the per-mutation transaction, after the mutation is applied.
+async fn record_sync_mutation(
+    tx: &mut Transaction<'_, Postgres>,
+    envelope: &MutationEnvelope,
+    user_id: Uuid,
+) -> Result<(), AppError> {
+    // Serialize entity_type and operation to their canonical string forms.
+    let entity_type_str = serde_json::to_value(&envelope.entity_type)
+        .ok()
+        .and_then(|v| v.as_str().map(|s| s.to_owned()))
+        .unwrap_or_default();
+    let operation_str = serde_json::to_value(&envelope.operation)
+        .ok()
+        .and_then(|v| v.as_str().map(|s| s.to_owned()))
+        .unwrap_or_default();
+
+    sqlx::query(
+        "INSERT INTO sync_mutations \
+         (mutation_id, device_id, user_id, entity_type, entity_id, operation) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(envelope.mutation_id)
+    .bind(envelope.device_id)
+    .bind(user_id)
+    .bind(&entity_type_str)
+    .bind(envelope.entity_id)
+    .bind(&operation_str)
+    .execute(tx.as_mut())
+    .await
+    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// S008: create_conflict_copy
+// ---------------------------------------------------------------------------
+
+/// Creates a conflict copy note when a KnowledgeNote update conflicts.
+///
+/// Steps:
+/// 1. INSERT a new knowledge_notes row (new id, payload fields, user_id, now() timestamps)
+/// 2. INSERT into entity_relations linking new note → original (relation_type = "duplicates")
+/// 3. INSERT into sync_conflicts (resolution = "conflict_copy")
+/// 4. Return the new note Uuid
+pub async fn create_conflict_copy(
+    tx: &mut Transaction<'_, Postgres>,
+    original_entity_id: Uuid,
+    payload: &serde_json::Value,
+    user_id: Uuid,
+    mutation_id: Uuid,
+    base_version: Option<DateTime<Utc>>,
+    current_version: Option<DateTime<Utc>>,
+) -> Result<Uuid, AppError> {
+    let new_id = Uuid::new_v4();
+
+    // Extract fields from payload with fallbacks.
+    let title = payload
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Conflict copy");
+    let content = payload.get("content").and_then(|v| v.as_str());
+    let initiative_id: Option<Uuid> = payload
+        .get("initiative_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| Uuid::parse_str(s).ok());
+
+    // 1. Insert new knowledge_notes row.
+    sqlx::query(
+        "INSERT INTO knowledge_notes \
+         (id, title, content, user_id, initiative_id, created_at, updated_at) \
+         VALUES ($1, $2, $3, $4, $5, now(), now())",
+    )
+    .bind(new_id)
+    .bind(title)
+    .bind(content)
+    .bind(user_id)
+    .bind(initiative_id)
+    .execute(tx.as_mut())
+    .await
+    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    // 2. Link new note → original via entity_relations (relation_type = "duplicates").
+    sqlx::query(
+        "INSERT INTO entity_relations \
+         (from_entity_type, from_entity_id, to_entity_type, to_entity_id, \
+          relation_type, source_type, status, user_id) \
+         VALUES ('knowledge_note', $1, 'knowledge_note', $2, 'duplicates', 'sync', 'accepted', $3)",
+    )
+    .bind(new_id)
+    .bind(original_entity_id)
+    .bind(user_id)
+    .execute(tx.as_mut())
+    .await
+    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    // 3. Record sync_conflicts row with resolution = "conflict_copy".
+    let current_payload: Option<serde_json::Value> = None; // caller can pass if needed
+    sqlx::query(
+        "INSERT INTO sync_conflicts \
+         (mutation_id, entity_type, entity_id, base_version, current_version, \
+          incoming_payload, current_payload, resolution, user_id) \
+         VALUES ($1, 'knowledge_note', $2, $3, $4, $5, $6, 'conflict_copy', $7)",
+    )
+    .bind(mutation_id)
+    .bind(original_entity_id)
+    .bind(base_version)
+    .bind(current_version)
+    .bind(payload)
+    .bind(current_payload)
+    .bind(user_id)
+    .execute(tx.as_mut())
+    .await
+    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    Ok(new_id)
+}
+
+// ---------------------------------------------------------------------------
+// S006: apply_mutations
+// ---------------------------------------------------------------------------
+
+/// Process a batch of client mutations serially.
+///
+/// Each mutation is processed independently within its own transaction.
+/// Returns a per-mutation result. Returns Err on unrecoverable errors
+/// (e.g., Forbidden ownership violation or quantity conflict).
+pub async fn apply_mutations(
+    db: &PgPool,
+    mutations: Vec<MutationEnvelope>,
+    auth_user: AuthUser,
+) -> Result<Vec<MutationResult>, AppError> {
+    let mut results = Vec::with_capacity(mutations.len());
+
+    for envelope in mutations {
+        let result = process_single_mutation(db, envelope, &auth_user).await?;
+        results.push(result);
+    }
+
+    Ok(results)
+}
+
+/// Process a single MutationEnvelope. Called by apply_mutations.
+///
+/// Returns the MutationResult for this mutation, or Err on Forbidden/Conflict errors.
+async fn process_single_mutation(
+    db: &PgPool,
+    envelope: MutationEnvelope,
+    auth_user: &AuthUser,
+) -> Result<MutationResult, AppError> {
+    // Step 1: Dedup check — if mutation_id already applied, skip.
+    let already_applied: Option<(Uuid,)> =
+        sqlx::query_as("SELECT mutation_id FROM sync_mutations WHERE mutation_id = $1")
+            .bind(envelope.mutation_id)
+            .fetch_optional(db)
+            .await
+            .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    if already_applied.is_some() {
+        return Ok(MutationResult {
+            mutation_id: envelope.mutation_id,
+            status: MutationStatus::Deduplicated,
+        });
+    }
+
+    // Step 2: Ownership check — skip for Create (row doesn't exist yet).
+    // For Update/Delete, the row must already exist and must be owned by auth_user.
+    if !matches!(envelope.operation, Operation::Create) {
+        check_ownership(db, &envelope.entity_type, envelope.entity_id, auth_user).await?;
+    }
+
+    // Step 3: Begin transaction.
+    let mut tx = db
+        .begin()
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    // Step 4+5+6: Dispatch by operation.
+    let mutation_result = dispatch_mutation(&mut tx, &envelope, auth_user).await;
+
+    match mutation_result {
+        Ok(status) => {
+            // Step 6: Record to sync_mutations.
+            record_sync_mutation(&mut tx, &envelope, auth_user.user_id).await?;
+            tx.commit()
+                .await
+                .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+            Ok(MutationResult {
+                mutation_id: envelope.mutation_id,
+                status,
+            })
+        }
+        Err(e) => {
+            // Rollback on any error (Forbidden, Conflict, Internal).
+            let _ = tx.rollback().await;
+            Err(e)
+        }
+    }
+}
+
+/// Dispatch a mutation to the correct operation handler within an open transaction.
+async fn dispatch_mutation(
+    tx: &mut Transaction<'_, Postgres>,
+    envelope: &MutationEnvelope,
+    auth_user: &AuthUser,
+) -> Result<MutationStatus, AppError> {
+    match &envelope.operation {
+        Operation::Create => apply_create(tx, envelope, auth_user).await,
+        Operation::Update => apply_update(tx, envelope, auth_user).await,
+        Operation::Delete => apply_delete(tx, envelope).await,
+    }
+}
+
+/// Handle a Create mutation.
+///
+/// For create, we use the payload to build an INSERT. If the row already exists
+/// (duplicate create), we treat it as idempotent and return Accepted.
+async fn apply_create(
+    tx: &mut Transaction<'_, Postgres>,
+    envelope: &MutationEnvelope,
+    auth_user: &AuthUser,
+) -> Result<MutationStatus, AppError> {
+    let table = entity_type_to_table(&envelope.entity_type);
+
+    // Check if row already exists (idempotent create).
+    let sql_check = format!("SELECT id FROM {table} WHERE id = $1");
+    let existing: Option<(Uuid,)> = sqlx::query_as(&sql_check)
+        .bind(envelope.entity_id)
+        .fetch_optional(tx.as_mut())
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    if existing.is_some() {
+        // Idempotent: row already exists, return Accepted.
+        return Ok(MutationStatus::Accepted);
+    }
+
+    // Insert new row: use entity_id as id, set user_id and timestamps.
+    // We use a generic INSERT using the payload JSONB for content fields.
+    // Per Tech.md guidance, for create we insert id, user_id, and delegate
+    // content fields to a per-entity approach. For this feature, we use a
+    // minimal safe insert: id + user_id + timestamps via payload columns.
+    //
+    // Special handling: some tables don't have a user_id column directly
+    // (household-scoped). For those, we insert using the payload as-is,
+    // overriding id. The caller (client connector) is responsible for
+    // providing a valid payload.
+    //
+    // For simplicity and safety, we store the payload directly and use
+    // jsonb_populate_record approach via a raw INSERT from the JSON payload.
+    // We override `id` to ensure it matches entity_id.
+    insert_from_payload(
+        tx,
+        table,
+        &envelope.entity_type,
+        envelope.entity_id,
+        auth_user.user_id,
+        envelope.payload.as_ref(),
+    )
+    .await?;
+
+    Ok(MutationStatus::Accepted)
+}
+
+/// Insert a new row from a payload JSONB value.
+///
+/// Strategy: build an INSERT using the payload's keys as column names.
+/// Always override `id` to entity_id. For user-scoped tables, override `user_id`.
+/// For household-scoped tables, preserve `household_id` from payload.
+///
+/// This is a "best effort" generic insert: the payload must conform to the
+/// table schema. Any unknown columns will cause a DB error (surfaced as Internal).
+async fn insert_from_payload(
+    tx: &mut Transaction<'_, Postgres>,
+    table: &str,
+    entity_type: &EntityType,
+    entity_id: Uuid,
+    user_id: Uuid,
+    payload: Option<&serde_json::Value>,
+) -> Result<(), AppError> {
+    let payload_obj = payload
+        .and_then(|p| p.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    // Determine which "server-controlled" columns to inject/override.
+    let is_user_scoped = matches!(
+        entity_type,
+        EntityType::Initiative
+            | EntityType::Tag
+            | EntityType::Attachment
+            | EntityType::GuidanceEpic
+            | EntityType::GuidanceQuest
+            | EntityType::GuidanceRoutine
+            | EntityType::GuidanceFocusSession
+            | EntityType::GuidanceDailyCheckin
+            | EntityType::KnowledgeNote
+            | EntityType::KnowledgeNoteSnapshot
+            | EntityType::TrackingItem
+    );
+
+    // Build column list and placeholder list from payload keys.
+    // We always include `id`. Add `user_id` for user-scoped tables.
+    // Exclude server-managed columns from payload to avoid conflicts.
+    let excluded_keys: &[&str] = &["id", "user_id", "created_at", "updated_at", "deleted_at"];
+
+    // The first N columns are typed binds (Uuid). Track how many precede JSON values.
+    let mut typed_uuid_count: usize = 1; // always: id
+    let mut columns: Vec<String> = vec!["id".to_owned()];
+    let mut json_values: Vec<serde_json::Value> = vec![];
+
+    if is_user_scoped {
+        columns.push("user_id".to_owned());
+        typed_uuid_count += 1;
+    }
+
+    for (key, val) in &payload_obj {
+        if excluded_keys.contains(&key.as_str()) {
+            continue;
+        }
+        columns.push(key.clone());
+        json_values.push(val.clone());
+    }
+
+    if columns.is_empty() {
+        return Err(AppError::BadRequest("Create payload is empty".to_string()));
+    }
+
+    let col_list = columns.join(", ");
+    let placeholders: Vec<String> = (1..=columns.len()).map(|i| format!("${i}")).collect();
+    let placeholder_list = placeholders.join(", ");
+
+    let sql = format!("INSERT INTO {table} ({col_list}) VALUES ({placeholder_list})");
+
+    // Bind typed Uuid parameters first (avoids TEXT→UUID cast failures in Postgres).
+    let mut query = sqlx::query(&sql).bind(entity_id);
+    if typed_uuid_count > 1 {
+        // user_id is the second typed param
+        query = query.bind(user_id);
+    }
+    // Then bind the remaining JSON-derived values.
+    for val in &json_values {
+        query = bind_json_value(query, val);
+    }
+
+    query
+        .execute(tx.as_mut())
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    Ok(())
+}
+
+/// Bind a serde_json::Value to a sqlx query as a typed parameter.
+fn bind_json_value<'q>(
+    query: sqlx::query::Query<'q, Postgres, sqlx::postgres::PgArguments>,
+    val: &'q serde_json::Value,
+) -> sqlx::query::Query<'q, Postgres, sqlx::postgres::PgArguments> {
+    match val {
+        serde_json::Value::Null => query.bind(None::<String>),
+        serde_json::Value::Bool(b) => query.bind(b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                query.bind(i)
+            } else if let Some(f) = n.as_f64() {
+                query.bind(f)
+            } else {
+                query.bind(n.to_string())
+            }
+        }
+        serde_json::Value::String(s) => query.bind(s.as_str()),
+        // Objects/arrays: bind as JSONB text
+        _ => query.bind(val.to_string()),
+    }
+}
+
+/// Handle an Update mutation.
+///
+/// For the general case, performs a safe update: `SET updated_at = now()`.
+/// Full payload merge is out of scope for this feature per Tech.md.
+///
+/// Special-cased entity types that lack `updated_at` (TrackingItemEvent,
+/// KnowledgeNoteSnapshot) receive no update (these are append-only/immutable).
+///
+/// Conflict detection is run before applying the update.
+async fn apply_update(
+    tx: &mut Transaction<'_, Postgres>,
+    envelope: &MutationEnvelope,
+    auth_user: &AuthUser,
+) -> Result<MutationStatus, AppError> {
+    // TrackingItemEvent is append-only: no updated_at. Conflict detection is
+    // handled via the quantity conflict path (S009). Here we simply accept.
+    if matches!(envelope.entity_type, EntityType::TrackingItemEvent) {
+        // S009: Check quantity conflict before accepting.
+        // Conflict detection is bypassed (no updated_at), so we always hit quantity check.
+        if let Some(payload) = &envelope.payload {
+            if check_quantity_conflict(payload) {
+                // Per S009: reject with Conflict so the client re-reads and resubmits.
+                return Err(AppError::Conflict(
+                    "quantity conflict — re-read and resubmit".to_string(),
+                ));
+            }
+        }
+        // No conflict check possible; apply LWW accept.
+        // For append-only tables, "update" semantics are not applicable.
+        // We record the mutation but don't actually modify the row.
+        return Ok(MutationStatus::Accepted);
+    }
+
+    // KnowledgeNoteSnapshot is immutable: reject updates.
+    if matches!(envelope.entity_type, EntityType::KnowledgeNoteSnapshot) {
+        return Err(AppError::BadRequest(
+            "knowledge_note_snapshot is immutable".to_string(),
+        ));
+    }
+
+    // Step 4: Conflict detection (for tables with updated_at).
+    let outcome = detect_conflict(
+        tx,
+        &envelope.entity_type,
+        envelope.entity_id,
+        envelope.base_version,
+        envelope.occurred_at,
+    )
+    .await?;
+
+    match outcome {
+        ConflictOutcome::Clean => {
+            // No conflict; apply the update.
+            apply_update_to_table(tx, &envelope.entity_type, envelope.entity_id).await?;
+            Ok(MutationStatus::Accepted)
+        }
+
+        ConflictOutcome::Accepted { current_payload } => {
+            // LWW: incoming wins. For KnowledgeNote, create a conflict copy instead.
+            if matches!(envelope.entity_type, EntityType::KnowledgeNote) {
+                if let Some(payload) = &envelope.payload {
+                    let conflict_id = create_conflict_copy(
+                        tx,
+                        envelope.entity_id,
+                        payload,
+                        auth_user.user_id,
+                        envelope.mutation_id,
+                        envelope.base_version,
+                        Some(
+                            current_payload
+                                .get("updated_at")
+                                .and_then(|v| v.as_str())
+                                .and_then(|s| s.parse::<DateTime<Utc>>().ok())
+                                .unwrap_or(envelope.occurred_at),
+                        ),
+                    )
+                    .await?;
+                    return Ok(MutationStatus::Conflicted { conflict_id });
+                }
+            }
+
+            // TrackingItemEvent + quantity conflict → Conflict error (S009 wiring).
+            if matches!(envelope.entity_type, EntityType::TrackingItemEvent) {
+                if let Some(payload) = &envelope.payload {
+                    if check_quantity_conflict(payload) {
+                        return Err(AppError::Conflict(
+                            "quantity conflict — re-read and resubmit".to_string(),
+                        ));
+                    }
+                }
+            }
+
+            // General LWW: log conflict, apply incoming mutation.
+            let conflict_id =
+                record_conflict_row(tx, envelope, &current_payload, auth_user.user_id).await?;
+            apply_update_to_table(tx, &envelope.entity_type, envelope.entity_id).await?;
+            Ok(MutationStatus::Conflicted { conflict_id })
+        }
+
+        ConflictOutcome::Rejected { current_payload } => {
+            // For KnowledgeNote: still create a conflict copy even when rejected
+            // (the spec says "instead of LWW, create a new note row").
+            if matches!(envelope.entity_type, EntityType::KnowledgeNote) {
+                if let Some(payload) = &envelope.payload {
+                    let conflict_id = create_conflict_copy(
+                        tx,
+                        envelope.entity_id,
+                        payload,
+                        auth_user.user_id,
+                        envelope.mutation_id,
+                        envelope.base_version,
+                        Some(
+                            current_payload
+                                .get("updated_at")
+                                .and_then(|v| v.as_str())
+                                .and_then(|s| s.parse::<DateTime<Utc>>().ok())
+                                .unwrap_or(envelope.occurred_at),
+                        ),
+                    )
+                    .await?;
+                    return Ok(MutationStatus::Conflicted { conflict_id });
+                }
+            }
+
+            // TrackingItemEvent + quantity: hard reject (already handled above for append-only path).
+
+            // General LWW reject: log conflict, do NOT apply the update.
+            let conflict_id =
+                record_conflict_row(tx, envelope, &current_payload, auth_user.user_id).await?;
+            Ok(MutationStatus::Conflicted { conflict_id })
+        }
+    }
+}
+
+/// Apply a safe UPDATE (only bumps updated_at) for user-scoped mutable tables.
+async fn apply_update_to_table(
+    tx: &mut Transaction<'_, Postgres>,
+    entity_type: &EntityType,
+    entity_id: Uuid,
+) -> Result<(), AppError> {
+    let table = entity_type_to_table(entity_type);
+    let sql = format!("UPDATE {table} SET updated_at = now() WHERE id = $1");
+    sqlx::query(&sql)
+        .bind(entity_id)
+        .execute(tx.as_mut())
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+    Ok(())
+}
+
+/// INSERT a row into sync_conflicts for a general LWW conflict (non-copy path).
+async fn record_conflict_row(
+    tx: &mut Transaction<'_, Postgres>,
+    envelope: &MutationEnvelope,
+    current_payload: &serde_json::Value,
+    user_id: Uuid,
+) -> Result<Uuid, AppError> {
+    // Extract current_version from the payload's updated_at field if present.
+    let current_version: Option<DateTime<Utc>> = current_payload
+        .get("updated_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<DateTime<Utc>>().ok());
+
+    let entity_type_str = serde_json::to_value(&envelope.entity_type)
+        .ok()
+        .and_then(|v| v.as_str().map(|s| s.to_owned()))
+        .unwrap_or_default();
+
+    let row: (Uuid,) = sqlx::query_as(
+        "INSERT INTO sync_conflicts \
+         (mutation_id, entity_type, entity_id, base_version, current_version, \
+          incoming_payload, current_payload, resolution, user_id) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8) \
+         RETURNING id",
+    )
+    .bind(envelope.mutation_id)
+    .bind(&entity_type_str)
+    .bind(envelope.entity_id)
+    .bind(envelope.base_version)
+    .bind(current_version)
+    .bind(&envelope.payload)
+    .bind(current_payload)
+    .bind(user_id)
+    .fetch_one(tx.as_mut())
+    .await
+    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    Ok(row.0)
+}
+
+/// Handle a Delete mutation.
+///
+/// Sets `deleted_at = now()` on the target row.
+/// TrackingItemEvent and KnowledgeNoteSnapshot have no deleted_at column;
+/// for those, delete is not applicable and returns BadRequest.
+async fn apply_delete(
+    tx: &mut Transaction<'_, Postgres>,
+    envelope: &MutationEnvelope,
+) -> Result<MutationStatus, AppError> {
+    // These tables have no deleted_at column; soft-delete is not applicable.
+    // tags: no deleted_at (unique-name constraint would block re-create if hard-deleted).
+    // tracking_item_events, knowledge_note_snapshots: append-only / immutable.
+    match &envelope.entity_type {
+        EntityType::TrackingItemEvent | EntityType::KnowledgeNoteSnapshot | EntityType::Tag => {
+            return Err(AppError::BadRequest(format!(
+                "{} does not support delete mutations",
+                entity_type_to_table(&envelope.entity_type)
+            )));
+        }
+        _ => {}
+    }
+
+    let table = entity_type_to_table(&envelope.entity_type);
+    let sql = format!("UPDATE {table} SET deleted_at = now() WHERE id = $1");
+    sqlx::query(&sql)
+        .bind(envelope.entity_id)
+        .execute(tx.as_mut())
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    Ok(MutationStatus::Accepted)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::models::AuthUser;
+    use crate::contracts::EntityType;
+    use crate::sync::models::{MutationEnvelope, MutationStatus, Operation};
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    // ------------------------------------------------------------------
+    // Test helpers
+    // ------------------------------------------------------------------
+
+    async fn insert_test_user(pool: &PgPool, user_id: Uuid, email: &str) {
+        sqlx::query(
+            "INSERT INTO users (id, email, display_name, password_hash, is_admin, status) \
+             VALUES ($1, $2, 'Test User', 'hashed', false, 'active')",
+        )
+        .bind(user_id)
+        .bind(email)
+        .execute(pool)
+        .await
+        .expect("insert_test_user failed");
+    }
+
+    async fn insert_test_household(pool: &PgPool, household_id: Uuid, owner_id: Uuid) {
+        sqlx::query(
+            "INSERT INTO households (id, owner_id, name) VALUES ($1, $2, 'Test Household')",
+        )
+        .bind(household_id)
+        .bind(owner_id)
+        .execute(pool)
+        .await
+        .expect("insert_test_household failed");
+    }
+
+    async fn insert_household_membership(pool: &PgPool, user_id: Uuid, household_id: Uuid) {
+        sqlx::query(
+            "INSERT INTO household_memberships (household_id, user_id, role) \
+             VALUES ($1, $2, 'member')",
+        )
+        .bind(household_id)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("insert_household_membership failed");
+    }
+
+    async fn insert_test_note(
+        pool: &PgPool,
+        note_id: Uuid,
+        user_id: Uuid,
+        title: &str,
+    ) -> DateTime<Utc> {
+        let row: (DateTime<Utc>,) = sqlx::query_as(
+            "INSERT INTO knowledge_notes (id, title, user_id) \
+             VALUES ($1, $2, $3) RETURNING updated_at",
+        )
+        .bind(note_id)
+        .bind(title)
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .expect("insert_test_note failed");
+        row.0
+    }
+
+    fn make_auth_user(user_id: Uuid) -> AuthUser {
+        AuthUser {
+            user_id,
+            household_ids: vec![],
+        }
+    }
+
+    fn make_envelope(
+        entity_type: EntityType,
+        entity_id: Uuid,
+        operation: Operation,
+        payload: Option<serde_json::Value>,
+        base_version: Option<DateTime<Utc>>,
+    ) -> MutationEnvelope {
+        MutationEnvelope {
+            mutation_id: Uuid::new_v4(),
+            device_id: Uuid::new_v4(),
+            entity_type,
+            entity_id,
+            operation,
+            payload,
+            base_version,
+            occurred_at: Utc::now(),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // S005-T: entity_type_to_table
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn entity_type_to_table_user_scoped() {
+        assert_eq!(
+            entity_type_to_table(&EntityType::KnowledgeNote),
+            "knowledge_notes"
+        );
+        assert_eq!(entity_type_to_table(&EntityType::Initiative), "initiatives");
+        assert_eq!(
+            entity_type_to_table(&EntityType::GuidanceEpic),
+            "guidance_epics"
+        );
+        assert_eq!(entity_type_to_table(&EntityType::Tag), "tags");
+    }
+
+    #[test]
+    fn entity_type_to_table_household_scoped() {
+        assert_eq!(
+            entity_type_to_table(&EntityType::TrackingLocation),
+            "tracking_locations"
+        );
+        assert_eq!(
+            entity_type_to_table(&EntityType::TrackingCategory),
+            "tracking_categories"
+        );
+        assert_eq!(
+            entity_type_to_table(&EntityType::TrackingShoppingList),
+            "tracking_shopping_lists"
+        );
+        assert_eq!(
+            entity_type_to_table(&EntityType::TrackingItemEvent),
+            "tracking_item_events"
+        );
+    }
+
+    #[test]
+    fn entity_type_to_table_all_variants_covered() {
+        // Exhaustive check: ensure every variant returns a non-empty string.
+        let all = [
+            EntityType::User,
+            EntityType::Household,
+            EntityType::Initiative,
+            EntityType::Tag,
+            EntityType::Attachment,
+            EntityType::GuidanceEpic,
+            EntityType::GuidanceQuest,
+            EntityType::GuidanceRoutine,
+            EntityType::GuidanceFocusSession,
+            EntityType::GuidanceDailyCheckin,
+            EntityType::KnowledgeNote,
+            EntityType::KnowledgeNoteSnapshot,
+            EntityType::TrackingLocation,
+            EntityType::TrackingCategory,
+            EntityType::TrackingItem,
+            EntityType::TrackingItemEvent,
+            EntityType::TrackingShoppingList,
+            EntityType::TrackingShoppingListItem,
+        ];
+        for et in all {
+            let table = entity_type_to_table(&et);
+            assert!(
+                !table.is_empty(),
+                "entity_type_to_table returned empty for {:?}",
+                et
+            );
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // S005-T: check_ownership (DB-backed)
+    // ------------------------------------------------------------------
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn ownership_ok_for_valid_owner(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "owner@example.com").await;
+        let note_id = Uuid::new_v4();
+        insert_test_note(&pool, note_id, user_id, "My Note").await;
+
+        let auth = make_auth_user(user_id);
+        let result = check_ownership(&pool, &EntityType::KnowledgeNote, note_id, &auth).await;
+        assert!(
+            result.is_ok(),
+            "owner should have access; got: {:?}",
+            result
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn ownership_forbidden_for_non_owner(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        insert_test_user(&pool, owner, "owner2@example.com").await;
+        insert_test_user(&pool, other, "other@example.com").await;
+        let note_id = Uuid::new_v4();
+        insert_test_note(&pool, note_id, owner, "Not Your Note").await;
+
+        let auth = make_auth_user(other);
+        let result = check_ownership(&pool, &EntityType::KnowledgeNote, note_id, &auth).await;
+        assert!(
+            matches!(result, Err(AppError::Forbidden)),
+            "non-owner should get Forbidden; got: {:?}",
+            result
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn ownership_forbidden_for_unknown_entity_id(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "unknown@example.com").await;
+
+        let auth = make_auth_user(user_id);
+        let result =
+            check_ownership(&pool, &EntityType::KnowledgeNote, Uuid::new_v4(), &auth).await;
+        assert!(
+            matches!(result, Err(AppError::Forbidden)),
+            "unknown entity_id should get Forbidden; got: {:?}",
+            result
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn ownership_ok_for_household_member(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let member = Uuid::new_v4();
+        insert_test_user(&pool, owner, "hh_owner@example.com").await;
+        insert_test_user(&pool, member, "hh_member@example.com").await;
+        let hh_id = Uuid::new_v4();
+        insert_test_household(&pool, hh_id, owner).await;
+        insert_household_membership(&pool, member, hh_id).await;
+
+        // Insert a tracking_location for this household.
+        let loc_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tracking_locations (id, name, household_id) VALUES ($1, 'Pantry', $2)",
+        )
+        .bind(loc_id)
+        .bind(hh_id)
+        .execute(&pool)
+        .await
+        .expect("insert tracking_location failed");
+
+        let auth = make_auth_user(member);
+        let result = check_ownership(&pool, &EntityType::TrackingLocation, loc_id, &auth).await;
+        assert!(
+            result.is_ok(),
+            "household member should have access; got: {:?}",
+            result
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // S009-T: check_quantity_conflict
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn quantity_conflict_true_when_quantity_present() {
+        let payload = serde_json::json!({ "quantity": 5 });
+        assert!(check_quantity_conflict(&payload));
+    }
+
+    #[test]
+    fn quantity_conflict_true_when_consumed_quantity_present() {
+        let payload = serde_json::json!({ "consumed_quantity": 2, "note": "some text" });
+        assert!(check_quantity_conflict(&payload));
+    }
+
+    #[test]
+    fn quantity_conflict_false_when_no_quantity_keys() {
+        let payload = serde_json::json!({ "note": "no qty here", "event_type": "use" });
+        assert!(!check_quantity_conflict(&payload));
+    }
+
+    #[test]
+    fn quantity_conflict_false_for_null_payload() {
+        assert!(!check_quantity_conflict(&serde_json::Value::Null));
+    }
+
+    // ------------------------------------------------------------------
+    // S006-T: apply_mutations — create → accepted + sync_mutations row
+    // ------------------------------------------------------------------
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn valid_create_mutation_accepted_and_recorded(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "create_test@example.com").await;
+
+        let note_id = Uuid::new_v4();
+        let envelope = make_envelope(
+            EntityType::KnowledgeNote,
+            note_id,
+            Operation::Create,
+            Some(serde_json::json!({ "title": "New Note", "content": "Hello" })),
+            None,
+        );
+        let mutation_id = envelope.mutation_id;
+        let auth = make_auth_user(user_id);
+
+        let results = apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("apply_mutations failed");
+
+        assert_eq!(results.len(), 1);
+        assert!(
+            matches!(results[0].status, MutationStatus::Accepted),
+            "status should be Accepted; got: {:?}",
+            results[0].status
+        );
+
+        // Verify sync_mutations row was written.
+        let recorded: Option<(Uuid,)> =
+            sqlx::query_as("SELECT mutation_id FROM sync_mutations WHERE mutation_id = $1")
+                .bind(mutation_id)
+                .fetch_optional(&pool)
+                .await
+                .expect("query failed");
+        assert!(
+            recorded.is_some(),
+            "sync_mutations row must exist after accepted mutation"
+        );
+
+        // Verify the note was created.
+        let note_exists: Option<(Uuid,)> =
+            sqlx::query_as("SELECT id FROM knowledge_notes WHERE id = $1")
+                .bind(note_id)
+                .fetch_optional(&pool)
+                .await
+                .expect("query failed");
+        assert!(note_exists.is_some(), "knowledge_notes row must exist");
+    }
+
+    // S006-T: replaying same mutation_id → deduplicated + no duplicate DB row
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn replaying_same_mutation_id_returns_deduplicated(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "dedup_test@example.com").await;
+
+        let note_id = Uuid::new_v4();
+        let envelope = make_envelope(
+            EntityType::KnowledgeNote,
+            note_id,
+            Operation::Create,
+            Some(serde_json::json!({ "title": "Dedup Note" })),
+            None,
+        );
+        let auth = make_auth_user(user_id);
+
+        // First application — accepted.
+        let first = apply_mutations(&pool, vec![envelope.clone()], auth.clone())
+            .await
+            .expect("first apply_mutations failed");
+        assert!(matches!(first[0].status, MutationStatus::Accepted));
+
+        // Second application — deduplicated.
+        let second = apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("second apply_mutations failed");
+        assert!(
+            matches!(second[0].status, MutationStatus::Deduplicated),
+            "second submission should be Deduplicated; got: {:?}",
+            second[0].status
+        );
+
+        // Verify no duplicate notes.
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM knowledge_notes WHERE id = $1")
+            .bind(note_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count query failed");
+        assert_eq!(count.0, 1, "exactly 1 note row must exist after dedup");
+    }
+
+    // S006-T: mutation for entity owned by other user → Forbidden
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn mutation_for_other_users_entity_returns_forbidden(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let attacker = Uuid::new_v4();
+        insert_test_user(&pool, owner, "real_owner@example.com").await;
+        insert_test_user(&pool, attacker, "attacker@example.com").await;
+
+        let note_id = Uuid::new_v4();
+        insert_test_note(&pool, note_id, owner, "Owner's Private Note").await;
+
+        let envelope = make_envelope(
+            EntityType::KnowledgeNote,
+            note_id,
+            Operation::Update,
+            Some(serde_json::json!({ "title": "Hacked" })),
+            None,
+        );
+        let auth = make_auth_user(attacker);
+
+        let result = apply_mutations(&pool, vec![envelope], auth).await;
+        assert!(
+            matches!(result, Err(AppError::Forbidden)),
+            "attacker must get Forbidden; got: {:?}",
+            result
+        );
+    }
+
+    // S006-T: delete mutation sets deleted_at, row remains (FA-009)
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn delete_mutation_sets_deleted_at_row_remains(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "delete_mut@example.com").await;
+
+        let note_id = Uuid::new_v4();
+        insert_test_note(&pool, note_id, user_id, "To Be Deleted").await;
+
+        let envelope = make_envelope(
+            EntityType::KnowledgeNote,
+            note_id,
+            Operation::Delete,
+            None,
+            None,
+        );
+        let auth = make_auth_user(user_id);
+
+        let results = apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("apply_mutations failed");
+        assert!(matches!(results[0].status, MutationStatus::Accepted));
+
+        // Verify deleted_at IS NOT NULL and row still exists.
+        let row: Option<(Option<DateTime<Utc>>,)> =
+            sqlx::query_as("SELECT deleted_at FROM knowledge_notes WHERE id = $1")
+                .bind(note_id)
+                .fetch_optional(&pool)
+                .await
+                .expect("query failed");
+
+        assert!(row.is_some(), "row must still exist after soft delete");
+        assert!(
+            row.unwrap().0.is_some(),
+            "deleted_at must be non-null after delete mutation"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // S007-T: detect_conflict
+    // ------------------------------------------------------------------
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn no_conflict_when_base_version_matches(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "conflict_clean@example.com").await;
+        let note_id = Uuid::new_v4();
+        let updated_at = insert_test_note(&pool, note_id, user_id, "Clean Note").await;
+
+        let mut tx = pool.begin().await.expect("begin tx");
+        let outcome = detect_conflict(
+            &mut tx,
+            &EntityType::KnowledgeNote,
+            note_id,
+            Some(updated_at),
+            Utc::now(),
+        )
+        .await
+        .expect("detect_conflict failed");
+        tx.rollback().await.ok();
+
+        assert!(matches!(outcome, ConflictOutcome::Clean), "should be Clean");
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn conflict_with_newer_occurred_at_returns_accepted(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "conflict_accept@example.com").await;
+        let note_id = Uuid::new_v4();
+        let updated_at = insert_test_note(&pool, note_id, user_id, "Accept Note").await;
+
+        // Simulate another device updating the note after our base_version.
+        sqlx::query(
+            "UPDATE knowledge_notes SET updated_at = now() + interval '10 seconds' WHERE id = $1",
+        )
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("simulated update failed");
+
+        // Our occurred_at is very recent — newer than the simulated server update.
+        let occurred_at = Utc::now() + chrono::Duration::minutes(1);
+
+        let mut tx = pool.begin().await.expect("begin tx");
+        let outcome = detect_conflict(
+            &mut tx,
+            &EntityType::KnowledgeNote,
+            note_id,
+            Some(updated_at),
+            occurred_at,
+        )
+        .await
+        .expect("detect_conflict failed");
+        tx.rollback().await.ok();
+
+        assert!(
+            matches!(outcome, ConflictOutcome::Accepted { .. }),
+            "should be Accepted (LWW: incoming wins); got other variant"
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn conflict_with_older_occurred_at_returns_rejected(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "conflict_reject@example.com").await;
+        let note_id = Uuid::new_v4();
+        let updated_at = insert_test_note(&pool, note_id, user_id, "Reject Note").await;
+
+        // Simulate server update with a timestamp far in the future.
+        sqlx::query(
+            "UPDATE knowledge_notes SET updated_at = now() + interval '1 hour' WHERE id = $1",
+        )
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("simulated update failed");
+
+        // Our occurred_at is older than updated_at (in the past relative to the simulated update).
+        let occurred_at = updated_at - chrono::Duration::seconds(5);
+
+        let mut tx = pool.begin().await.expect("begin tx");
+        let outcome = detect_conflict(
+            &mut tx,
+            &EntityType::KnowledgeNote,
+            note_id,
+            Some(updated_at),
+            occurred_at,
+        )
+        .await
+        .expect("detect_conflict failed");
+        tx.rollback().await.ok();
+
+        assert!(
+            matches!(outcome, ConflictOutcome::Rejected { .. }),
+            "should be Rejected (LWW: existing wins); got other variant"
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn null_base_version_on_non_create_uses_lww(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "null_base@example.com").await;
+        let note_id = Uuid::new_v4();
+        insert_test_note(&pool, note_id, user_id, "LWW Note").await;
+
+        // occurred_at is in the future → should get Accepted (incoming wins).
+        let occurred_at = Utc::now() + chrono::Duration::hours(1);
+
+        let mut tx = pool.begin().await.expect("begin tx");
+        let outcome = detect_conflict(
+            &mut tx,
+            &EntityType::KnowledgeNote,
+            note_id,
+            None, // null base_version
+            occurred_at,
+        )
+        .await
+        .expect("detect_conflict failed");
+        tx.rollback().await.ok();
+
+        assert!(
+            matches!(outcome, ConflictOutcome::Accepted { .. }),
+            "null base_version + future occurred_at should yield Accepted"
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn sync_conflicts_row_written_on_conflict(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "conflict_row@example.com").await;
+        let note_id = Uuid::new_v4();
+        let old_updated_at = insert_test_note(&pool, note_id, user_id, "Conflict Row Note").await;
+
+        // Simulate a concurrent update on the server side.
+        sqlx::query(
+            "UPDATE knowledge_notes SET updated_at = now() + interval '5 seconds' WHERE id = $1",
+        )
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("simulated update failed");
+
+        // Submit a conflicting update with an occurred_at far in the future (LWW win).
+        let mutation_id = Uuid::new_v4();
+        let envelope = MutationEnvelope {
+            mutation_id,
+            device_id: Uuid::new_v4(),
+            entity_type: EntityType::KnowledgeNote,
+            entity_id: note_id,
+            operation: Operation::Update,
+            payload: Some(serde_json::json!({ "title": "Conflicting update" })),
+            base_version: Some(old_updated_at),
+            occurred_at: Utc::now() + chrono::Duration::hours(1),
+        };
+        let auth = make_auth_user(user_id);
+
+        let results = apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("apply_mutations failed");
+
+        // For KnowledgeNote + conflict → Conflicted status with a conflict copy.
+        assert!(
+            matches!(results[0].status, MutationStatus::Conflicted { .. }),
+            "expected Conflicted; got: {:?}",
+            results[0].status
+        );
+
+        // Verify sync_conflicts row was written.
+        let conflict_count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM sync_conflicts WHERE entity_id = $1")
+                .bind(note_id)
+                .fetch_one(&pool)
+                .await
+                .expect("count query failed");
+        assert!(
+            conflict_count.0 > 0,
+            "sync_conflicts row must exist after conflict"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // S008-T: create_conflict_copy (FA-007)
+    // ------------------------------------------------------------------
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn conflict_copy_creates_two_notes(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "copy_test@example.com").await;
+        let note_id = Uuid::new_v4();
+        let old_updated_at = insert_test_note(&pool, note_id, user_id, "Original Note").await;
+
+        // Simulate a concurrent update on the server side.
+        sqlx::query(
+            "UPDATE knowledge_notes SET updated_at = now() + interval '5 seconds' WHERE id = $1",
+        )
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("simulated update failed");
+
+        let envelope = MutationEnvelope {
+            mutation_id: Uuid::new_v4(),
+            device_id: Uuid::new_v4(),
+            entity_type: EntityType::KnowledgeNote,
+            entity_id: note_id,
+            operation: Operation::Update,
+            payload: Some(serde_json::json!({ "title": "My Conflicting Version" })),
+            base_version: Some(old_updated_at),
+            occurred_at: Utc::now() + chrono::Duration::hours(1),
+        };
+        let auth = make_auth_user(user_id);
+
+        let results = apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("apply_mutations failed");
+        assert!(matches!(
+            results[0].status,
+            MutationStatus::Conflicted { .. }
+        ));
+
+        // FA-007: two knowledge_notes rows (original + conflict copy).
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM knowledge_notes WHERE user_id = $1")
+                .bind(user_id)
+                .fetch_one(&pool)
+                .await
+                .expect("count notes failed");
+        assert_eq!(
+            count.0, 2,
+            "expected 2 knowledge_notes rows; got {}",
+            count.0
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn conflict_copy_creates_entity_relation_duplicates(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "copy_rel@example.com").await;
+        let note_id = Uuid::new_v4();
+        let old_updated_at =
+            insert_test_note(&pool, note_id, user_id, "Original Relation Note").await;
+
+        sqlx::query(
+            "UPDATE knowledge_notes SET updated_at = now() + interval '5 seconds' WHERE id = $1",
+        )
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("simulated update failed");
+
+        let envelope = MutationEnvelope {
+            mutation_id: Uuid::new_v4(),
+            device_id: Uuid::new_v4(),
+            entity_type: EntityType::KnowledgeNote,
+            entity_id: note_id,
+            operation: Operation::Update,
+            payload: Some(serde_json::json!({ "title": "Conflict Copy Relation" })),
+            base_version: Some(old_updated_at),
+            occurred_at: Utc::now() + chrono::Duration::hours(1),
+        };
+        let auth = make_auth_user(user_id);
+
+        apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("apply_mutations failed");
+
+        // Verify entity_relations row with relation_type = "duplicates".
+        let rel: Option<(String,)> = sqlx::query_as(
+            "SELECT relation_type FROM entity_relations \
+             WHERE to_entity_id = $1 AND relation_type = 'duplicates'",
+        )
+        .bind(note_id)
+        .fetch_optional(&pool)
+        .await
+        .expect("query failed");
+
+        assert!(
+            rel.is_some(),
+            "entity_relations 'duplicates' row must exist after conflict copy"
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn conflict_copy_writes_sync_conflicts_row_with_conflict_copy_resolution(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "copy_conflict@example.com").await;
+        let note_id = Uuid::new_v4();
+        let old_updated_at =
+            insert_test_note(&pool, note_id, user_id, "Conflict Resolution Note").await;
+
+        sqlx::query(
+            "UPDATE knowledge_notes SET updated_at = now() + interval '5 seconds' WHERE id = $1",
+        )
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("simulated update failed");
+
+        let envelope = MutationEnvelope {
+            mutation_id: Uuid::new_v4(),
+            device_id: Uuid::new_v4(),
+            entity_type: EntityType::KnowledgeNote,
+            entity_id: note_id,
+            operation: Operation::Update,
+            payload: Some(serde_json::json!({ "title": "Conflict Resolution" })),
+            base_version: Some(old_updated_at),
+            occurred_at: Utc::now() + chrono::Duration::hours(1),
+        };
+        let auth = make_auth_user(user_id);
+
+        apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("apply_mutations failed");
+
+        // Verify sync_conflicts has resolution = "conflict_copy".
+        let resolution: Option<(String,)> =
+            sqlx::query_as("SELECT resolution FROM sync_conflicts WHERE entity_id = $1")
+                .bind(note_id)
+                .fetch_optional(&pool)
+                .await
+                .expect("query failed");
+
+        assert_eq!(
+            resolution.map(|r| r.0),
+            Some("conflict_copy".to_string()),
+            "sync_conflicts resolution must be 'conflict_copy'"
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn conflict_copy_original_note_unchanged(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "copy_unchanged@example.com").await;
+        let note_id = Uuid::new_v4();
+        let old_updated_at = insert_test_note(&pool, note_id, user_id, "Unchanged Original").await;
+
+        sqlx::query(
+            "UPDATE knowledge_notes SET updated_at = now() + interval '5 seconds' WHERE id = $1",
+        )
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("simulated update failed");
+
+        let envelope = MutationEnvelope {
+            mutation_id: Uuid::new_v4(),
+            device_id: Uuid::new_v4(),
+            entity_type: EntityType::KnowledgeNote,
+            entity_id: note_id,
+            operation: Operation::Update,
+            payload: Some(serde_json::json!({ "title": "Conflict" })),
+            base_version: Some(old_updated_at),
+            occurred_at: Utc::now() + chrono::Duration::hours(1),
+        };
+        let auth = make_auth_user(user_id);
+
+        apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("apply_mutations failed");
+
+        // Original note title must remain "Unchanged Original".
+        let title: (String,) = sqlx::query_as("SELECT title FROM knowledge_notes WHERE id = $1")
+            .bind(note_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch original note failed");
+
+        assert_eq!(
+            title.0, "Unchanged Original",
+            "original note must not be modified by conflict copy"
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn conflict_copy_result_is_conflicted_status(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "copy_status@example.com").await;
+        let note_id = Uuid::new_v4();
+        let old_updated_at = insert_test_note(&pool, note_id, user_id, "Status Note").await;
+
+        sqlx::query(
+            "UPDATE knowledge_notes SET updated_at = now() + interval '5 seconds' WHERE id = $1",
+        )
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("simulated update failed");
+
+        let envelope = MutationEnvelope {
+            mutation_id: Uuid::new_v4(),
+            device_id: Uuid::new_v4(),
+            entity_type: EntityType::KnowledgeNote,
+            entity_id: note_id,
+            operation: Operation::Update,
+            payload: Some(serde_json::json!({ "title": "My Version" })),
+            base_version: Some(old_updated_at),
+            occurred_at: Utc::now() + chrono::Duration::hours(1),
+        };
+        let auth = make_auth_user(user_id);
+
+        let results = apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("apply_mutations failed");
+
+        assert!(
+            matches!(results[0].status, MutationStatus::Conflicted { .. }),
+            "expected Conflicted {{ conflict_id }}, got: {:?}",
+            results[0].status
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // S009-T: quantity conflict (FA-008)
+    // ------------------------------------------------------------------
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn tracking_item_event_update_with_quantity_returns_conflict_error(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "qty_conflict@example.com").await;
+        let hh_id = Uuid::new_v4();
+        insert_test_household(&pool, hh_id, user_id).await;
+
+        // Insert a tracking_item.
+        let item_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tracking_items (id, name, user_id, household_id) VALUES ($1, 'Salt', $2, $3)",
+        )
+        .bind(item_id)
+        .bind(user_id)
+        .bind(hh_id)
+        .execute(&pool)
+        .await
+        .expect("insert tracking_item failed");
+
+        // Insert a tracking_item_event.
+        let event_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tracking_item_events \
+             (id, item_id, event_type, quantity_change, occurred_at) \
+             VALUES ($1, $2, 'use', 1, now())",
+        )
+        .bind(event_id)
+        .bind(item_id)
+        .execute(&pool)
+        .await
+        .expect("insert tracking_item_event failed");
+
+        // Update with quantity field → should return Conflict error.
+        let envelope = make_envelope(
+            EntityType::TrackingItemEvent,
+            event_id,
+            Operation::Update,
+            Some(serde_json::json!({ "quantity": 5 })),
+            None,
+        );
+        let auth = make_auth_user(user_id);
+
+        let result = apply_mutations(&pool, vec![envelope], auth).await;
+        assert!(
+            matches!(result, Err(AppError::Conflict(_))),
+            "quantity conflict must return Conflict error; got: {:?}",
+            result
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn tracking_item_event_update_without_quantity_accepted(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "qty_no_conflict@example.com").await;
+        let hh_id = Uuid::new_v4();
+        insert_test_household(&pool, hh_id, user_id).await;
+
+        let item_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tracking_items (id, name, user_id, household_id) VALUES ($1, 'Pepper', $2, $3)",
+        )
+        .bind(item_id)
+        .bind(user_id)
+        .bind(hh_id)
+        .execute(&pool)
+        .await
+        .expect("insert tracking_item failed");
+
+        let event_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tracking_item_events \
+             (id, item_id, event_type, quantity_change, occurred_at) \
+             VALUES ($1, $2, 'note', 0, now())",
+        )
+        .bind(event_id)
+        .bind(item_id)
+        .execute(&pool)
+        .await
+        .expect("insert tracking_item_event failed");
+
+        // Update without quantity field → should be accepted.
+        let envelope = make_envelope(
+            EntityType::TrackingItemEvent,
+            event_id,
+            Operation::Update,
+            Some(serde_json::json!({ "notes": "updated note text" })),
+            None,
+        );
+        let auth = make_auth_user(user_id);
+
+        let results = apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("apply_mutations failed");
+        assert!(
+            matches!(results[0].status, MutationStatus::Accepted),
+            "non-quantity update should be Accepted; got: {:?}",
+            results[0].status
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn non_tracking_entity_with_conflict_does_not_use_quantity_check(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "non_tracking@example.com").await;
+        let note_id = Uuid::new_v4();
+        let old_updated_at = insert_test_note(&pool, note_id, user_id, "Non-tracking").await;
+
+        sqlx::query(
+            "UPDATE knowledge_notes SET updated_at = now() + interval '5 seconds' WHERE id = $1",
+        )
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("simulated update failed");
+
+        // KnowledgeNote update with "quantity" in payload — should NOT trigger quantity conflict.
+        // Instead, it should go through the conflict copy path.
+        let envelope = MutationEnvelope {
+            mutation_id: Uuid::new_v4(),
+            device_id: Uuid::new_v4(),
+            entity_type: EntityType::KnowledgeNote,
+            entity_id: note_id,
+            operation: Operation::Update,
+            payload: Some(serde_json::json!({ "title": "Note about quantity", "quantity": 3 })),
+            base_version: Some(old_updated_at),
+            occurred_at: Utc::now() + chrono::Duration::hours(1),
+        };
+        let auth = make_auth_user(user_id);
+
+        let result = apply_mutations(&pool, vec![envelope], auth).await;
+        // Should NOT be Conflict error (409); should be Conflicted status (conflict copy).
+        assert!(
+            result.is_ok(),
+            "KnowledgeNote with quantity payload must not return Conflict error"
+        );
+        let results = result.unwrap();
+        assert!(
+            matches!(results[0].status, MutationStatus::Conflicted { .. }),
+            "should be Conflicted (conflict copy), not quantity error; got: {:?}",
+            results[0].status
+        );
+    }
+}

--- a/apps/server/server/src/sync/service.rs
+++ b/apps/server/server/src/sync/service.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Postgres, Transaction};
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::auth::models::AuthUser;
@@ -259,6 +260,79 @@ pub async fn check_ownership(
 }
 
 // ---------------------------------------------------------------------------
+// S005: check_create_allowed (ADR-018)
+// ---------------------------------------------------------------------------
+
+/// Entity types that clients may create via sync push (ADR-018 allowlist).
+const SYNC_CREATABLE_USER_SCOPED: &[EntityType] = &[
+    EntityType::KnowledgeNote,
+    EntityType::GuidanceQuest,
+    EntityType::GuidanceRoutine,
+    EntityType::GuidanceEpic,
+    EntityType::GuidanceFocusSession,
+    EntityType::GuidanceDailyCheckin,
+    EntityType::Tag,
+    EntityType::Initiative,
+    EntityType::Attachment,
+];
+
+const SYNC_CREATABLE_HOUSEHOLD_SCOPED: &[EntityType] = &[
+    EntityType::TrackingLocation,
+    EntityType::TrackingCategory,
+    EntityType::TrackingShoppingList,
+    EntityType::TrackingItem,
+    EntityType::TrackingItemEvent,
+    EntityType::TrackingShoppingListItem,
+];
+
+/// Checks whether a Create mutation is permitted for the given entity type, and verifies
+/// household membership for household-scoped creates (ADR-018).
+///
+/// Returns `Ok(())` if the create is allowed, `AppError::BadRequest` if the entity type
+/// is not creatable via sync, and `AppError::Forbidden` if household membership fails.
+pub async fn check_create_allowed(
+    db: &PgPool,
+    entity_type: &EntityType,
+    payload: Option<&serde_json::Value>,
+    auth_user: &AuthUser,
+) -> Result<(), AppError> {
+    if SYNC_CREATABLE_USER_SCOPED.contains(entity_type) {
+        return Ok(());
+    }
+
+    if SYNC_CREATABLE_HOUSEHOLD_SCOPED.contains(entity_type) {
+        // Extract and verify household_id from payload (ADR-018).
+        let household_id_str = payload
+            .and_then(|p| p.get("household_id"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AppError::BadRequest("household_id required for household-scoped create".to_string()))?;
+        let household_id = Uuid::parse_str(household_id_str)
+            .map_err(|_| AppError::BadRequest("household_id must be a valid UUID".to_string()))?;
+
+        let member: Option<(i32,)> = sqlx::query_as(
+            "SELECT 1 FROM household_memberships \
+             WHERE household_id = $1 AND user_id = $2 AND deleted_at IS NULL",
+        )
+        .bind(household_id)
+        .bind(auth_user.user_id)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+        return if member.is_some() {
+            Ok(())
+        } else {
+            Err(AppError::Forbidden)
+        };
+    }
+
+    // Entity type is not in either allowlist — not creatable via sync.
+    Err(AppError::BadRequest(format!(
+        "{entity_type:?} is not creatable via sync push"
+    )))
+}
+
+// ---------------------------------------------------------------------------
 // S007: detect_conflict
 // ---------------------------------------------------------------------------
 
@@ -342,30 +416,41 @@ pub fn check_quantity_conflict(payload: &serde_json::Value) -> bool {
 }
 
 // ---------------------------------------------------------------------------
-// S006: record_sync_mutation
+// S006: try_record_sync_mutation
 // ---------------------------------------------------------------------------
 
-/// INSERT a row into `sync_mutations` as a dedup record for this mutation.
-/// Called inside the per-mutation transaction, after the mutation is applied.
-async fn record_sync_mutation(
+/// Attempt to INSERT a row into `sync_mutations` as the dedup record for this mutation.
+///
+/// Uses `ON CONFLICT (mutation_id) DO NOTHING RETURNING mutation_id` so the check and
+/// record are atomic within the caller's transaction. Returns `Some(mutation_id)` if the
+/// row was newly inserted (proceed), or `None` if it already existed (Deduplicated).
+async fn try_record_sync_mutation(
     tx: &mut Transaction<'_, Postgres>,
     envelope: &MutationEnvelope,
     user_id: Uuid,
-) -> Result<(), AppError> {
+) -> Result<Option<(Uuid,)>, AppError> {
     // Serialize entity_type and operation to their canonical string forms.
     let entity_type_str = serde_json::to_value(&envelope.entity_type)
-        .ok()
-        .and_then(|v| v.as_str().map(|s| s.to_owned()))
-        .unwrap_or_default();
-    let operation_str = serde_json::to_value(&envelope.operation)
-        .ok()
-        .and_then(|v| v.as_str().map(|s| s.to_owned()))
-        .unwrap_or_default();
+        .map_err(|e| {
+            warn!("failed to serialize entity_type {:?}: {e}", envelope.entity_type);
+            AppError::Internal(anyhow::anyhow!("entity_type serialization failed: {e}"))
+        })?
+        .as_str()
+        .ok_or_else(|| AppError::Internal(anyhow::anyhow!("entity_type serialized to non-string")))?
+        .to_owned();
 
-    sqlx::query(
+    let operation_str = serde_json::to_value(&envelope.operation)
+        .map_err(|e| AppError::Internal(anyhow::anyhow!("operation serialization failed: {e}")))?
+        .as_str()
+        .ok_or_else(|| AppError::Internal(anyhow::anyhow!("operation serialized to non-string")))?
+        .to_owned();
+
+    let row: Option<(Uuid,)> = sqlx::query_as(
         "INSERT INTO sync_mutations \
          (mutation_id, device_id, user_id, entity_type, entity_id, operation) \
-         VALUES ($1, $2, $3, $4, $5, $6)",
+         VALUES ($1, $2, $3, $4, $5, $6) \
+         ON CONFLICT (mutation_id) DO NOTHING \
+         RETURNING mutation_id",
     )
     .bind(envelope.mutation_id)
     .bind(envelope.device_id)
@@ -373,11 +458,11 @@ async fn record_sync_mutation(
     .bind(&entity_type_str)
     .bind(envelope.entity_id)
     .bind(&operation_str)
-    .execute(tx.as_mut())
+    .fetch_optional(tx.as_mut())
     .await
     .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
 
-    Ok(())
+    Ok(row)
 }
 
 // ---------------------------------------------------------------------------
@@ -496,40 +581,39 @@ async fn process_single_mutation(
     envelope: MutationEnvelope,
     auth_user: &AuthUser,
 ) -> Result<MutationResult, AppError> {
-    // Step 1: Dedup check — if mutation_id already applied, skip.
-    let already_applied: Option<(Uuid,)> =
-        sqlx::query_as("SELECT mutation_id FROM sync_mutations WHERE mutation_id = $1")
-            .bind(envelope.mutation_id)
-            .fetch_optional(db)
+    // Step 1: Authorization check.
+    // Create: verify the entity type is creatable via sync and household membership (ADR-018).
+    // Update/Delete: verify the existing row is owned by auth_user.
+    if matches!(envelope.operation, Operation::Create) {
+        check_create_allowed(db, &envelope.entity_type, envelope.payload.as_ref(), auth_user).await?;
+    } else {
+        check_ownership(db, &envelope.entity_type, envelope.entity_id, auth_user).await?;
+    }
+
+    // Step 2: Begin transaction.
+    let mut tx = db
+        .begin()
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    // Step 3: Atomic dedup — attempt to record the mutation. If the mutation_id
+    // already exists, DO NOTHING is triggered and RETURNING yields no row → Deduplicated.
+    let dedup_row: Option<(Uuid,)> = try_record_sync_mutation(&mut tx, &envelope, auth_user.user_id).await?;
+    if dedup_row.is_none() {
+        tx.commit()
             .await
             .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
-
-    if already_applied.is_some() {
         return Ok(MutationResult {
             mutation_id: envelope.mutation_id,
             status: MutationStatus::Deduplicated,
         });
     }
 
-    // Step 2: Ownership check — skip for Create (row doesn't exist yet).
-    // For Update/Delete, the row must already exist and must be owned by auth_user.
-    if !matches!(envelope.operation, Operation::Create) {
-        check_ownership(db, &envelope.entity_type, envelope.entity_id, auth_user).await?;
-    }
-
-    // Step 3: Begin transaction.
-    let mut tx = db
-        .begin()
-        .await
-        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
-
-    // Step 4+5+6: Dispatch by operation.
+    // Step 4+5: Dispatch by operation.
     let mutation_result = dispatch_mutation(&mut tx, &envelope, auth_user).await;
 
     match mutation_result {
         Ok(status) => {
-            // Step 6: Record to sync_mutations.
-            record_sync_mutation(&mut tx, &envelope, auth_user.user_id).await?;
             tx.commit()
                 .await
                 .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
@@ -540,7 +624,9 @@ async fn process_single_mutation(
         }
         Err(e) => {
             // Rollback on any error (Forbidden, Conflict, Internal).
-            let _ = tx.rollback().await;
+            if let Err(rollback_err) = tx.rollback().await {
+                warn!("transaction rollback failed: {rollback_err}");
+            }
             Err(e)
         }
     }
@@ -612,12 +698,9 @@ async fn apply_create(
 
 /// Insert a new row from a payload JSONB value.
 ///
-/// Strategy: build an INSERT using the payload's keys as column names.
-/// Always override `id` to entity_id. For user-scoped tables, override `user_id`.
-/// For household-scoped tables, preserve `household_id` from payload.
-///
-/// This is a "best effort" generic insert: the payload must conform to the
-/// table schema. Any unknown columns will cause a DB error (surfaced as Internal).
+/// Builds a parameterized INSERT using only the allowlisted columns for this entity type.
+/// Always sets `id` from `entity_id`. Adds `user_id` for user-scoped tables.
+/// Payload keys that are not in the allowlist or fail the safe-identifier regex are dropped.
 async fn insert_from_payload(
     tx: &mut Transaction<'_, Postgres>,
     table: &str,
@@ -626,12 +709,17 @@ async fn insert_from_payload(
     user_id: Uuid,
     payload: Option<&serde_json::Value>,
 ) -> Result<(), AppError> {
-    let payload_obj = payload
-        .and_then(|p| p.as_object())
-        .cloned()
-        .unwrap_or_default();
+    // P5-009: require a JSON object; reject arrays and null.
+    let payload_obj = match payload {
+        None => {
+            return Err(AppError::BadRequest("Create payload must be a JSON object".to_string()));
+        }
+        Some(p) => p.as_object().ok_or_else(|| {
+            AppError::BadRequest("Create payload must be a JSON object".to_string())
+        })?,
+    };
 
-    // Determine which "server-controlled" columns to inject/override.
+    // Determine whether this entity type has a server-controlled user_id column.
     let is_user_scoped = matches!(
         entity_type,
         EntityType::Initiative
@@ -647,31 +735,30 @@ async fn insert_from_payload(
             | EntityType::TrackingItem
     );
 
-    // Build column list and placeholder list from payload keys.
-    // We always include `id`. Add `user_id` for user-scoped tables.
-    // Exclude server-managed columns from payload to avoid conflicts.
-    let excluded_keys: &[&str] = &["id", "user_id", "created_at", "updated_at", "deleted_at"];
+    let allow = allowed_columns(entity_type);
+    // Server-controlled columns must never come from the payload.
+    let excluded: &[&str] = &["id", "user_id", "created_at", "updated_at", "deleted_at", "household_id"];
 
-    // The first N columns are typed binds (Uuid). Track how many precede JSON values.
-    let mut typed_uuid_count: usize = 1; // always: id
+    // id is always first; user_id second for user-scoped tables.
     let mut columns: Vec<String> = vec!["id".to_owned()];
     let mut json_values: Vec<serde_json::Value> = vec![];
+    let mut typed_uuid_count: usize = 1;
 
     if is_user_scoped {
         columns.push("user_id".to_owned());
         typed_uuid_count += 1;
     }
 
-    for (key, val) in &payload_obj {
-        if excluded_keys.contains(&key.as_str()) {
+    for (key, val) in payload_obj {
+        if excluded.contains(&key.as_str()) {
+            continue;
+        }
+        // ADR-017: only allowlisted, safe-identifier keys may become column names.
+        if !allow.contains(&key.as_str()) || !is_safe_column_name(key) {
             continue;
         }
         columns.push(key.clone());
         json_values.push(val.clone());
-    }
-
-    if columns.is_empty() {
-        return Err(AppError::BadRequest("Create payload is empty".to_string()));
     }
 
     let col_list = columns.join(", ");
@@ -680,13 +767,10 @@ async fn insert_from_payload(
 
     let sql = format!("INSERT INTO {table} ({col_list}) VALUES ({placeholder_list})");
 
-    // Bind typed Uuid parameters first (avoids TEXT→UUID cast failures in Postgres).
     let mut query = sqlx::query(&sql).bind(entity_id);
     if typed_uuid_count > 1 {
-        // user_id is the second typed param
         query = query.bind(user_id);
     }
-    // Then bind the remaining JSON-derived values.
     for val in &json_values {
         query = bind_json_value(query, val);
     }
@@ -775,49 +859,36 @@ async fn apply_update(
     match outcome {
         ConflictOutcome::Clean => {
             // No conflict; apply the update.
-            apply_update_to_table(tx, &envelope.entity_type, envelope.entity_id).await?;
+            apply_update_to_table(tx, &envelope.entity_type, envelope.entity_id, &envelope.payload).await?;
             Ok(MutationStatus::Accepted)
         }
 
         ConflictOutcome::Accepted { current_payload } => {
             // LWW: incoming wins. For KnowledgeNote, create a conflict copy instead.
             if matches!(envelope.entity_type, EntityType::KnowledgeNote) {
-                if let Some(payload) = &envelope.payload {
-                    let conflict_id = create_conflict_copy(
-                        tx,
-                        envelope.entity_id,
-                        payload,
-                        auth_user.user_id,
-                        envelope.mutation_id,
-                        envelope.base_version,
-                        Some(
-                            current_payload
-                                .get("updated_at")
-                                .and_then(|v| v.as_str())
-                                .and_then(|s| s.parse::<DateTime<Utc>>().ok())
-                                .unwrap_or(envelope.occurred_at),
-                        ),
+                let payload = envelope.payload.as_ref().ok_or_else(|| {
+                    AppError::BadRequest(
+                        "KnowledgeNote update conflict requires a non-null payload".to_string(),
                     )
-                    .await?;
-                    return Ok(MutationStatus::Conflicted { conflict_id });
-                }
-            }
-
-            // TrackingItemEvent + quantity conflict → Conflict error (S009 wiring).
-            if matches!(envelope.entity_type, EntityType::TrackingItemEvent) {
-                if let Some(payload) = &envelope.payload {
-                    if check_quantity_conflict(payload) {
-                        return Err(AppError::Conflict(
-                            "quantity conflict — re-read and resubmit".to_string(),
-                        ));
-                    }
-                }
+                })?;
+                let current_version = parse_updated_at_from_payload(&current_payload, envelope.entity_id);
+                let conflict_id = create_conflict_copy(
+                    tx,
+                    envelope.entity_id,
+                    payload,
+                    auth_user.user_id,
+                    envelope.mutation_id,
+                    envelope.base_version,
+                    Some(current_version),
+                )
+                .await?;
+                return Ok(MutationStatus::Conflicted { conflict_id });
             }
 
             // General LWW: log conflict, apply incoming mutation.
             let conflict_id =
                 record_conflict_row(tx, envelope, &current_payload, auth_user.user_id).await?;
-            apply_update_to_table(tx, &envelope.entity_type, envelope.entity_id).await?;
+            apply_update_to_table(tx, &envelope.entity_type, envelope.entity_id, &envelope.payload).await?;
             Ok(MutationStatus::Conflicted { conflict_id })
         }
 
@@ -825,28 +896,24 @@ async fn apply_update(
             // For KnowledgeNote: still create a conflict copy even when rejected
             // (the spec says "instead of LWW, create a new note row").
             if matches!(envelope.entity_type, EntityType::KnowledgeNote) {
-                if let Some(payload) = &envelope.payload {
-                    let conflict_id = create_conflict_copy(
-                        tx,
-                        envelope.entity_id,
-                        payload,
-                        auth_user.user_id,
-                        envelope.mutation_id,
-                        envelope.base_version,
-                        Some(
-                            current_payload
-                                .get("updated_at")
-                                .and_then(|v| v.as_str())
-                                .and_then(|s| s.parse::<DateTime<Utc>>().ok())
-                                .unwrap_or(envelope.occurred_at),
-                        ),
+                let payload = envelope.payload.as_ref().ok_or_else(|| {
+                    AppError::BadRequest(
+                        "KnowledgeNote update conflict requires a non-null payload".to_string(),
                     )
-                    .await?;
-                    return Ok(MutationStatus::Conflicted { conflict_id });
-                }
+                })?;
+                let current_version = parse_updated_at_from_payload(&current_payload, envelope.entity_id);
+                let conflict_id = create_conflict_copy(
+                    tx,
+                    envelope.entity_id,
+                    payload,
+                    auth_user.user_id,
+                    envelope.mutation_id,
+                    envelope.base_version,
+                    Some(current_version),
+                )
+                .await?;
+                return Ok(MutationStatus::Conflicted { conflict_id });
             }
-
-            // TrackingItemEvent + quantity: hard reject (already handled above for append-only path).
 
             // General LWW reject: log conflict, do NOT apply the update.
             let conflict_id =
@@ -856,16 +923,117 @@ async fn apply_update(
     }
 }
 
-/// Apply a safe UPDATE (only bumps updated_at) for user-scoped mutable tables.
+/// Returns the `updated_at` timestamp from a DB payload JSON object.
+///
+/// Logs a warning if the value is missing or cannot be parsed, and falls back to
+/// `entity_id`-keyed log entry so the caller can correlate which row was affected.
+fn parse_updated_at_from_payload(payload: &serde_json::Value, entity_id: Uuid) -> DateTime<Utc> {
+    match payload
+        .get("updated_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<DateTime<Utc>>().ok())
+    {
+        Some(ts) => ts,
+        None => {
+            warn!(
+                "could not parse updated_at from DB payload for entity {entity_id}; \
+                 falling back to epoch — conflict audit trail may be inaccurate"
+            );
+            DateTime::from_timestamp(0, 0).unwrap()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// S001 (ADR-017): allowed_columns
+// ---------------------------------------------------------------------------
+
+/// Returns the set of column names that clients are permitted to write for a given
+/// entity type via the sync push endpoint.
+///
+/// These are lowercase snake_case names matching the Postgres schema.
+/// `id`, `user_id`, `household_id`, `created_at`, `updated_at`, and `deleted_at`
+/// are **excluded** — they are set server-side.
+///
+/// Any payload key NOT in this list is silently dropped before the INSERT/UPDATE is
+/// built. This is the authoritative injection-prevention control (ADR-017).
+pub(crate) fn allowed_columns(entity_type: &EntityType) -> &'static [&'static str] {
+    match entity_type {
+        EntityType::User => &[],
+        EntityType::Household => &[],
+        EntityType::KnowledgeNoteSnapshot => &[],
+        EntityType::Initiative => &["name", "description", "status"],
+        EntityType::Tag => &["name", "color"],
+        EntityType::Attachment => &["file_name", "mime_type", "size_bytes", "storage_key"],
+        EntityType::GuidanceEpic => &["title", "description", "status", "initiative_id"],
+        EntityType::GuidanceQuest => &["title", "description", "status", "epic_id", "initiative_id", "due_date"],
+        EntityType::GuidanceRoutine => &["title", "description", "frequency", "status"],
+        EntityType::GuidanceFocusSession => &["title", "notes", "quest_id", "started_at", "ended_at", "duration_seconds"],
+        EntityType::GuidanceDailyCheckin => &["mood", "notes", "checkin_date"],
+        EntityType::KnowledgeNote => &["title", "content", "initiative_id"],
+        EntityType::TrackingLocation => &["name", "description"],
+        EntityType::TrackingCategory => &["name", "description", "color"],
+        EntityType::TrackingItem => &["name", "description", "category_id", "location_id", "quantity", "unit", "low_threshold"],
+        EntityType::TrackingItemEvent => &["quantity", "consumed_quantity", "notes", "event_date"],
+        EntityType::TrackingShoppingList => &["name", "notes", "status"],
+        EntityType::TrackingShoppingListItem => &["name", "quantity", "unit", "is_checked"],
+    }
+}
+
+/// Validate a column name key from a client payload.
+///
+/// Returns true only if the key is purely `[a-z_][a-z0-9_]*` (no SQL metacharacters).
+/// This is a defence-in-depth guard that catches any key that somehow escapes the
+/// `allowed_columns` allowlist (e.g., a developer accidentally adds a dangerous string).
+fn is_safe_column_name(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+/// Apply an UPDATE to a table, writing allowed payload fields plus bumping `updated_at`.
 async fn apply_update_to_table(
     tx: &mut Transaction<'_, Postgres>,
     entity_type: &EntityType,
     entity_id: Uuid,
+    payload: &Option<serde_json::Value>,
 ) -> Result<(), AppError> {
     let table = entity_type_to_table(entity_type);
-    let sql = format!("UPDATE {table} SET updated_at = now() WHERE id = $1");
-    sqlx::query(&sql)
-        .bind(entity_id)
+    let allow = allowed_columns(entity_type);
+
+    // Build SET clauses: always include updated_at; add payload fields that pass the allowlist.
+    let mut set_clauses: Vec<String> = vec!["updated_at = now()".to_owned()];
+    let mut json_values: Vec<serde_json::Value> = vec![];
+    let mut param_idx = 2usize; // $1 is entity_id
+
+    if let Some(p) = payload {
+        let obj = p.as_object().ok_or_else(|| {
+            AppError::BadRequest("Update payload must be a JSON object".to_string())
+        })?;
+        for (key, val) in obj {
+            if !allow.contains(&key.as_str()) {
+                continue;
+            }
+            if !is_safe_column_name(key) {
+                // Should not happen given the allowlist, but guard anyway.
+                continue;
+            }
+            set_clauses.push(format!("{key} = ${param_idx}"));
+            json_values.push(val.clone());
+            param_idx += 1;
+        }
+    }
+
+    let set_str = set_clauses.join(", ");
+    let sql = format!("UPDATE {table} SET {set_str} WHERE id = $1");
+    let mut query = sqlx::query(&sql).bind(entity_id);
+    for val in &json_values {
+        query = bind_json_value(query, val);
+    }
+    query
         .execute(tx.as_mut())
         .await
         .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
@@ -886,9 +1054,13 @@ async fn record_conflict_row(
         .and_then(|s| s.parse::<DateTime<Utc>>().ok());
 
     let entity_type_str = serde_json::to_value(&envelope.entity_type)
-        .ok()
-        .and_then(|v| v.as_str().map(|s| s.to_owned()))
-        .unwrap_or_default();
+        .map_err(|e| {
+            warn!("failed to serialize entity_type {:?}: {e}", envelope.entity_type);
+            AppError::Internal(anyhow::anyhow!("entity_type serialization failed: {e}"))
+        })?
+        .as_str()
+        .ok_or_else(|| AppError::Internal(anyhow::anyhow!("entity_type serialized to non-string")))?
+        .to_owned();
 
     let row: (Uuid,) = sqlx::query_as(
         "INSERT INTO sync_conflicts \
@@ -935,14 +1107,148 @@ async fn apply_delete(
     }
 
     let table = entity_type_to_table(&envelope.entity_type);
-    let sql = format!("UPDATE {table} SET deleted_at = now() WHERE id = $1");
-    sqlx::query(&sql)
+    let sql = format!("UPDATE {table} SET deleted_at = now() WHERE id = $1 AND deleted_at IS NULL");
+    let result = sqlx::query(&sql)
         .bind(envelope.entity_id)
         .execute(tx.as_mut())
         .await
         .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
 
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound);
+    }
+
     Ok(MutationStatus::Accepted)
+}
+
+// ---------------------------------------------------------------------------
+// S015: list_conflicts / resolve_conflict (moved from handlers per P5-011)
+// ---------------------------------------------------------------------------
+
+/// Returns a cursor-paginated page of pending sync conflicts for the authenticated user.
+///
+/// Uses a stable `(created_at, id)` tuple cursor so pagination is not disrupted when
+/// the cursor row is later resolved (fixes P5-023).
+pub async fn list_conflicts(
+    db: &PgPool,
+    user_id: Uuid,
+    cursor: Option<Uuid>,
+    limit: u32,
+) -> Result<Vec<crate::sync::models::ConflictRecord>, AppError> {
+    use crate::sync::models::ConflictRow;
+
+    let limit_i64 = limit as i64;
+
+    let rows: Vec<ConflictRow> = if let Some(cursor_id) = cursor {
+        // Stable tuple cursor: fetch the anchor's (created_at, id) so that resolving
+        // the cursor row does not collapse the next page to empty (P5-023).
+        let anchor: Option<(DateTime<Utc>, Uuid)> = sqlx::query_as(
+            "SELECT created_at, id FROM sync_conflicts WHERE id = $1",
+        )
+        .bind(cursor_id)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+        match anchor {
+            None => vec![],
+            Some((anchor_created_at, anchor_id)) => {
+                sqlx::query_as(
+                    "SELECT id, entity_type, entity_id, base_version, current_version, \
+                     incoming_payload, current_payload, created_at \
+                     FROM sync_conflicts \
+                     WHERE user_id = $1 \
+                       AND resolution = 'pending' \
+                       AND (created_at, id) < ($2, $3) \
+                     ORDER BY created_at DESC, id DESC \
+                     LIMIT $4",
+                )
+                .bind(user_id)
+                .bind(anchor_created_at)
+                .bind(anchor_id)
+                .bind(limit_i64)
+                .fetch_all(db)
+                .await
+                .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?
+            }
+        }
+    } else {
+        sqlx::query_as(
+            "SELECT id, entity_type, entity_id, base_version, current_version, \
+             incoming_payload, current_payload, created_at \
+             FROM sync_conflicts \
+             WHERE user_id = $1 \
+               AND resolution = 'pending' \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $2",
+        )
+        .bind(user_id)
+        .bind(limit_i64)
+        .fetch_all(db)
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?
+    };
+
+    let mut records = Vec::with_capacity(rows.len());
+    for row in rows {
+        match crate::sync::models::ConflictRecord::from_row(row) {
+            Some(r) => records.push(r),
+            None => {
+                warn!("sync_conflicts row for user {user_id} has unrecognized entity_type; skipping");
+            }
+        }
+    }
+    Ok(records)
+}
+
+/// Marks a pending conflict as resolved (`accepted` or `rejected`).
+///
+/// Returns:
+/// - `Ok(())` on success
+/// - `AppError::NotFound` if the conflict id does not exist
+/// - `AppError::Forbidden` if the conflict belongs to a different user
+/// - `AppError::Conflict` if the conflict has already been resolved (P5-012)
+pub async fn resolve_conflict(
+    db: &PgPool,
+    conflict_id: Uuid,
+    user_id: Uuid,
+    resolution: &str,
+) -> Result<(), AppError> {
+    // Only update rows that are still pending (P5-012: prevent re-resolution).
+    let result = sqlx::query(
+        "UPDATE sync_conflicts \
+         SET resolution = $1, resolved_at = now() \
+         WHERE id = $2 AND user_id = $3 AND resolution = 'pending'",
+    )
+    .bind(resolution)
+    .bind(conflict_id)
+    .bind(user_id)
+    .execute(db)
+    .await
+    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    if result.rows_affected() == 1 {
+        return Ok(());
+    }
+
+    // Disambiguate: does the row exist at all? Is it the wrong user, or already resolved?
+    let row: Option<(Uuid, String)> =
+        sqlx::query_as("SELECT user_id, resolution FROM sync_conflicts WHERE id = $1")
+            .bind(conflict_id)
+            .fetch_optional(db)
+            .await
+            .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+
+    match row {
+        None => Err(AppError::NotFound),
+        Some((owner_id, _)) if owner_id != user_id => Err(AppError::Forbidden),
+        Some((_, res)) if res != "pending" => Err(AppError::Conflict(format!(
+            "conflict is already {res}"
+        ))),
+        _ => Err(AppError::Internal(anyhow::anyhow!(
+            "resolve_conflict: unexpected state for conflict {conflict_id}"
+        ))),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/server/src/sync/service.rs
+++ b/apps/server/server/src/sync/service.rs
@@ -6,7 +6,9 @@ use uuid::Uuid;
 use crate::auth::models::AuthUser;
 use crate::contracts::EntityType;
 use crate::error::AppError;
-use crate::sync::models::{MutationEnvelope, MutationResult, MutationStatus, Operation};
+use crate::sync::models::{
+    ConflictStatus, MutationEnvelope, MutationPayload, MutationResult, MutationStatus,
+};
 
 // ---------------------------------------------------------------------------
 // S007: ConflictOutcome
@@ -305,7 +307,11 @@ pub async fn check_create_allowed(
         let household_id_str = payload
             .and_then(|p| p.get("household_id"))
             .and_then(|v| v.as_str())
-            .ok_or_else(|| AppError::BadRequest("household_id required for household-scoped create".to_string()))?;
+            .ok_or_else(|| {
+                AppError::BadRequest(
+                    "household_id required for household-scoped create".to_string(),
+                )
+            })?;
         let household_id = Uuid::parse_str(household_id_str)
             .map_err(|_| AppError::BadRequest("household_id must be a valid UUID".to_string()))?;
 
@@ -429,21 +435,20 @@ async fn try_record_sync_mutation(
     envelope: &MutationEnvelope,
     user_id: Uuid,
 ) -> Result<Option<(Uuid,)>, AppError> {
-    // Serialize entity_type and operation to their canonical string forms.
-    let entity_type_str = serde_json::to_value(&envelope.entity_type)
+    // Serialize entity_type to its canonical string form; operation uses the typed method.
+    let entity_type_str = serde_json::to_value(envelope.entity_type)
         .map_err(|e| {
-            warn!("failed to serialize entity_type {:?}: {e}", envelope.entity_type);
+            warn!(
+                "failed to serialize entity_type {:?}: {e}",
+                envelope.entity_type
+            );
             AppError::Internal(anyhow::anyhow!("entity_type serialization failed: {e}"))
         })?
         .as_str()
         .ok_or_else(|| AppError::Internal(anyhow::anyhow!("entity_type serialized to non-string")))?
         .to_owned();
 
-    let operation_str = serde_json::to_value(&envelope.operation)
-        .map_err(|e| AppError::Internal(anyhow::anyhow!("operation serialization failed: {e}")))?
-        .as_str()
-        .ok_or_else(|| AppError::Internal(anyhow::anyhow!("operation serialized to non-string")))?
-        .to_owned();
+    let operation_str = envelope.operation.operation_str();
 
     let row: Option<(Uuid,)> = sqlx::query_as(
         "INSERT INTO sync_mutations \
@@ -455,9 +460,9 @@ async fn try_record_sync_mutation(
     .bind(envelope.mutation_id)
     .bind(envelope.device_id)
     .bind(user_id)
-    .bind(&entity_type_str)
+    .bind(entity_type_str)
     .bind(envelope.entity_id)
-    .bind(&operation_str)
+    .bind(operation_str)
     .fetch_optional(tx.as_mut())
     .await
     .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
@@ -529,22 +534,24 @@ pub async fn create_conflict_copy(
 
     // 3. Record sync_conflicts row with resolution = "conflict_copy".
     let current_payload: Option<serde_json::Value> = None; // caller can pass if needed
-    sqlx::query(
+    let sql = format!(
         "INSERT INTO sync_conflicts \
          (mutation_id, entity_type, entity_id, base_version, current_version, \
           incoming_payload, current_payload, resolution, user_id) \
-         VALUES ($1, 'knowledge_note', $2, $3, $4, $5, $6, 'conflict_copy', $7)",
-    )
-    .bind(mutation_id)
-    .bind(original_entity_id)
-    .bind(base_version)
-    .bind(current_version)
-    .bind(payload)
-    .bind(current_payload)
-    .bind(user_id)
-    .execute(tx.as_mut())
-    .await
-    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+         VALUES ($1, 'knowledge_note', $2, $3, $4, $5, $6, '{}', $7)",
+        ConflictStatus::ConflictCopy.as_str()
+    );
+    sqlx::query(&sql)
+        .bind(mutation_id)
+        .bind(original_entity_id)
+        .bind(base_version)
+        .bind(current_version)
+        .bind(payload)
+        .bind(current_payload)
+        .bind(user_id)
+        .execute(tx.as_mut())
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
 
     Ok(new_id)
 }
@@ -558,6 +565,18 @@ pub async fn create_conflict_copy(
 /// Each mutation is processed independently within its own transaction.
 /// Returns a per-mutation result. Returns Err on unrecoverable errors
 /// (e.g., Forbidden ownership violation or quantity conflict).
+///
+/// # Partial-commit semantics (P5-015)
+///
+/// Mutations are processed one at a time. Each successful mutation is committed
+/// before the next one starts. If a later mutation fails (e.g., Forbidden), the
+/// function returns `Err` immediately — but all earlier mutations in the batch
+/// are already durably committed. Callers receive the error status code (e.g.,
+/// 403) even though some rows from that same batch may have been written.
+///
+/// Clients should not rely on all-or-nothing batch atomicity. If a partial
+/// failure matters, submit mutations in separate requests or ensure the batch
+/// is ordered so dependent mutations come first.
 pub async fn apply_mutations(
     db: &PgPool,
     mutations: Vec<MutationEnvelope>,
@@ -584,8 +603,8 @@ async fn process_single_mutation(
     // Step 1: Authorization check.
     // Create: verify the entity type is creatable via sync and household membership (ADR-018).
     // Update/Delete: verify the existing row is owned by auth_user.
-    if matches!(envelope.operation, Operation::Create) {
-        check_create_allowed(db, &envelope.entity_type, envelope.payload.as_ref(), auth_user).await?;
+    if let MutationPayload::Create { payload } = &envelope.operation {
+        check_create_allowed(db, &envelope.entity_type, payload.as_ref(), auth_user).await?;
     } else {
         check_ownership(db, &envelope.entity_type, envelope.entity_id, auth_user).await?;
     }
@@ -598,7 +617,8 @@ async fn process_single_mutation(
 
     // Step 3: Atomic dedup — attempt to record the mutation. If the mutation_id
     // already exists, DO NOTHING is triggered and RETURNING yields no row → Deduplicated.
-    let dedup_row: Option<(Uuid,)> = try_record_sync_mutation(&mut tx, &envelope, auth_user.user_id).await?;
+    let dedup_row: Option<(Uuid,)> =
+        try_record_sync_mutation(&mut tx, &envelope, auth_user.user_id).await?;
     if dedup_row.is_none() {
         tx.commit()
             .await
@@ -639,9 +659,14 @@ async fn dispatch_mutation(
     auth_user: &AuthUser,
 ) -> Result<MutationStatus, AppError> {
     match &envelope.operation {
-        Operation::Create => apply_create(tx, envelope, auth_user).await,
-        Operation::Update => apply_update(tx, envelope, auth_user).await,
-        Operation::Delete => apply_delete(tx, envelope).await,
+        MutationPayload::Create { payload } => {
+            apply_create(tx, envelope, payload.as_ref(), auth_user).await
+        }
+        MutationPayload::Update {
+            payload,
+            base_version,
+        } => apply_update(tx, envelope, payload.as_ref(), *base_version, auth_user).await,
+        MutationPayload::Delete {} => apply_delete(tx, envelope).await,
     }
 }
 
@@ -652,6 +677,7 @@ async fn dispatch_mutation(
 async fn apply_create(
     tx: &mut Transaction<'_, Postgres>,
     envelope: &MutationEnvelope,
+    payload: Option<&serde_json::Value>,
     auth_user: &AuthUser,
 ) -> Result<MutationStatus, AppError> {
     let table = entity_type_to_table(&envelope.entity_type);
@@ -689,7 +715,7 @@ async fn apply_create(
         &envelope.entity_type,
         envelope.entity_id,
         auth_user.user_id,
-        envelope.payload.as_ref(),
+        payload,
     )
     .await?;
 
@@ -712,7 +738,9 @@ async fn insert_from_payload(
     // P5-009: require a JSON object; reject arrays and null.
     let payload_obj = match payload {
         None => {
-            return Err(AppError::BadRequest("Create payload must be a JSON object".to_string()));
+            return Err(AppError::BadRequest(
+                "Create payload must be a JSON object".to_string(),
+            ));
         }
         Some(p) => p.as_object().ok_or_else(|| {
             AppError::BadRequest("Create payload must be a JSON object".to_string())
@@ -737,7 +765,14 @@ async fn insert_from_payload(
 
     let allow = allowed_columns(entity_type);
     // Server-controlled columns must never come from the payload.
-    let excluded: &[&str] = &["id", "user_id", "created_at", "updated_at", "deleted_at", "household_id"];
+    let excluded: &[&str] = &[
+        "id",
+        "user_id",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+        "household_id",
+    ];
 
     // id is always first; user_id second for user-scoped tables.
     let mut columns: Vec<String> = vec!["id".to_owned()];
@@ -818,6 +853,8 @@ fn bind_json_value<'q>(
 async fn apply_update(
     tx: &mut Transaction<'_, Postgres>,
     envelope: &MutationEnvelope,
+    payload: Option<&serde_json::Value>,
+    base_version: Option<DateTime<Utc>>,
     auth_user: &AuthUser,
 ) -> Result<MutationStatus, AppError> {
     // TrackingItemEvent is append-only: no updated_at. Conflict detection is
@@ -825,13 +862,11 @@ async fn apply_update(
     if matches!(envelope.entity_type, EntityType::TrackingItemEvent) {
         // S009: Check quantity conflict before accepting.
         // Conflict detection is bypassed (no updated_at), so we always hit quantity check.
-        if let Some(payload) = &envelope.payload {
-            if check_quantity_conflict(payload) {
-                // Per S009: reject with Conflict so the client re-reads and resubmits.
-                return Err(AppError::Conflict(
-                    "quantity conflict — re-read and resubmit".to_string(),
-                ));
-            }
+        if payload.is_some_and(check_quantity_conflict) {
+            // Per S009: reject with Conflict so the client re-reads and resubmit.
+            return Err(AppError::Conflict(
+                "quantity conflict — re-read and resubmit".to_string(),
+            ));
         }
         // No conflict check possible; apply LWW accept.
         // For append-only tables, "update" semantics are not applicable.
@@ -851,34 +886,42 @@ async fn apply_update(
         tx,
         &envelope.entity_type,
         envelope.entity_id,
-        envelope.base_version,
+        base_version,
         envelope.occurred_at,
     )
     .await?;
 
+    let owned_payload = payload.cloned();
     match outcome {
         ConflictOutcome::Clean => {
             // No conflict; apply the update.
-            apply_update_to_table(tx, &envelope.entity_type, envelope.entity_id, &envelope.payload).await?;
+            apply_update_to_table(
+                tx,
+                &envelope.entity_type,
+                envelope.entity_id,
+                &owned_payload,
+            )
+            .await?;
             Ok(MutationStatus::Accepted)
         }
 
         ConflictOutcome::Accepted { current_payload } => {
             // LWW: incoming wins. For KnowledgeNote, create a conflict copy instead.
             if matches!(envelope.entity_type, EntityType::KnowledgeNote) {
-                let payload = envelope.payload.as_ref().ok_or_else(|| {
+                let p = payload.ok_or_else(|| {
                     AppError::BadRequest(
                         "KnowledgeNote update conflict requires a non-null payload".to_string(),
                     )
                 })?;
-                let current_version = parse_updated_at_from_payload(&current_payload, envelope.entity_id);
+                let current_version =
+                    parse_updated_at_from_payload(&current_payload, envelope.entity_id);
                 let conflict_id = create_conflict_copy(
                     tx,
                     envelope.entity_id,
-                    payload,
+                    p,
                     auth_user.user_id,
                     envelope.mutation_id,
-                    envelope.base_version,
+                    base_version,
                     Some(current_version),
                 )
                 .await?;
@@ -886,9 +929,22 @@ async fn apply_update(
             }
 
             // General LWW: log conflict, apply incoming mutation.
-            let conflict_id =
-                record_conflict_row(tx, envelope, &current_payload, auth_user.user_id).await?;
-            apply_update_to_table(tx, &envelope.entity_type, envelope.entity_id, &envelope.payload).await?;
+            let conflict_id = record_conflict_row(
+                tx,
+                envelope,
+                base_version,
+                &owned_payload,
+                &current_payload,
+                auth_user.user_id,
+            )
+            .await?;
+            apply_update_to_table(
+                tx,
+                &envelope.entity_type,
+                envelope.entity_id,
+                &owned_payload,
+            )
+            .await?;
             Ok(MutationStatus::Conflicted { conflict_id })
         }
 
@@ -896,19 +952,20 @@ async fn apply_update(
             // For KnowledgeNote: still create a conflict copy even when rejected
             // (the spec says "instead of LWW, create a new note row").
             if matches!(envelope.entity_type, EntityType::KnowledgeNote) {
-                let payload = envelope.payload.as_ref().ok_or_else(|| {
+                let p = payload.ok_or_else(|| {
                     AppError::BadRequest(
                         "KnowledgeNote update conflict requires a non-null payload".to_string(),
                     )
                 })?;
-                let current_version = parse_updated_at_from_payload(&current_payload, envelope.entity_id);
+                let current_version =
+                    parse_updated_at_from_payload(&current_payload, envelope.entity_id);
                 let conflict_id = create_conflict_copy(
                     tx,
                     envelope.entity_id,
-                    payload,
+                    p,
                     auth_user.user_id,
                     envelope.mutation_id,
-                    envelope.base_version,
+                    base_version,
                     Some(current_version),
                 )
                 .await?;
@@ -916,8 +973,15 @@ async fn apply_update(
             }
 
             // General LWW reject: log conflict, do NOT apply the update.
-            let conflict_id =
-                record_conflict_row(tx, envelope, &current_payload, auth_user.user_id).await?;
+            let conflict_id = record_conflict_row(
+                tx,
+                envelope,
+                base_version,
+                &owned_payload,
+                &current_payload,
+                auth_user.user_id,
+            )
+            .await?;
             Ok(MutationStatus::Conflicted { conflict_id })
         }
     }
@@ -966,14 +1030,36 @@ pub(crate) fn allowed_columns(entity_type: &EntityType) -> &'static [&'static st
         EntityType::Tag => &["name", "color"],
         EntityType::Attachment => &["file_name", "mime_type", "size_bytes", "storage_key"],
         EntityType::GuidanceEpic => &["title", "description", "status", "initiative_id"],
-        EntityType::GuidanceQuest => &["title", "description", "status", "epic_id", "initiative_id", "due_date"],
+        EntityType::GuidanceQuest => &[
+            "title",
+            "description",
+            "status",
+            "epic_id",
+            "initiative_id",
+            "due_date",
+        ],
         EntityType::GuidanceRoutine => &["title", "description", "frequency", "status"],
-        EntityType::GuidanceFocusSession => &["title", "notes", "quest_id", "started_at", "ended_at", "duration_seconds"],
+        EntityType::GuidanceFocusSession => &[
+            "title",
+            "notes",
+            "quest_id",
+            "started_at",
+            "ended_at",
+            "duration_seconds",
+        ],
         EntityType::GuidanceDailyCheckin => &["mood", "notes", "checkin_date"],
         EntityType::KnowledgeNote => &["title", "content", "initiative_id"],
         EntityType::TrackingLocation => &["name", "description"],
         EntityType::TrackingCategory => &["name", "description", "color"],
-        EntityType::TrackingItem => &["name", "description", "category_id", "location_id", "quantity", "unit", "low_threshold"],
+        EntityType::TrackingItem => &[
+            "name",
+            "description",
+            "category_id",
+            "location_id",
+            "quantity",
+            "unit",
+            "low_threshold",
+        ],
         EntityType::TrackingItemEvent => &["quantity", "consumed_quantity", "notes", "event_date"],
         EntityType::TrackingShoppingList => &["name", "notes", "status"],
         EntityType::TrackingShoppingListItem => &["name", "quantity", "unit", "is_checked"],
@@ -1044,6 +1130,8 @@ async fn apply_update_to_table(
 async fn record_conflict_row(
     tx: &mut Transaction<'_, Postgres>,
     envelope: &MutationEnvelope,
+    base_version: Option<DateTime<Utc>>,
+    incoming_payload: &Option<serde_json::Value>,
     current_payload: &serde_json::Value,
     user_id: Uuid,
 ) -> Result<Uuid, AppError> {
@@ -1053,33 +1141,38 @@ async fn record_conflict_row(
         .and_then(|v| v.as_str())
         .and_then(|s| s.parse::<DateTime<Utc>>().ok());
 
-    let entity_type_str = serde_json::to_value(&envelope.entity_type)
+    let entity_type_str = serde_json::to_value(envelope.entity_type)
         .map_err(|e| {
-            warn!("failed to serialize entity_type {:?}: {e}", envelope.entity_type);
+            warn!(
+                "failed to serialize entity_type {:?}: {e}",
+                envelope.entity_type
+            );
             AppError::Internal(anyhow::anyhow!("entity_type serialization failed: {e}"))
         })?
         .as_str()
         .ok_or_else(|| AppError::Internal(anyhow::anyhow!("entity_type serialized to non-string")))?
         .to_owned();
 
-    let row: (Uuid,) = sqlx::query_as(
+    let sql = format!(
         "INSERT INTO sync_conflicts \
          (mutation_id, entity_type, entity_id, base_version, current_version, \
           incoming_payload, current_payload, resolution, user_id) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, '{}', $8) \
          RETURNING id",
-    )
-    .bind(envelope.mutation_id)
-    .bind(&entity_type_str)
-    .bind(envelope.entity_id)
-    .bind(envelope.base_version)
-    .bind(current_version)
-    .bind(&envelope.payload)
-    .bind(current_payload)
-    .bind(user_id)
-    .fetch_one(tx.as_mut())
-    .await
-    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+        ConflictStatus::Pending.as_str()
+    );
+    let row: (Uuid,) = sqlx::query_as(&sql)
+        .bind(envelope.mutation_id)
+        .bind(&entity_type_str)
+        .bind(envelope.entity_id)
+        .bind(base_version)
+        .bind(current_version)
+        .bind(incoming_payload)
+        .bind(current_payload)
+        .bind(user_id)
+        .fetch_one(tx.as_mut())
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
 
     Ok(row.0)
 }
@@ -1142,51 +1235,54 @@ pub async fn list_conflicts(
     let rows: Vec<ConflictRow> = if let Some(cursor_id) = cursor {
         // Stable tuple cursor: fetch the anchor's (created_at, id) so that resolving
         // the cursor row does not collapse the next page to empty (P5-023).
-        let anchor: Option<(DateTime<Utc>, Uuid)> = sqlx::query_as(
-            "SELECT created_at, id FROM sync_conflicts WHERE id = $1",
-        )
-        .bind(cursor_id)
-        .fetch_optional(db)
-        .await
-        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+        let anchor: Option<(DateTime<Utc>, Uuid)> =
+            sqlx::query_as("SELECT created_at, id FROM sync_conflicts WHERE id = $1")
+                .bind(cursor_id)
+                .fetch_optional(db)
+                .await
+                .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
 
         match anchor {
             None => vec![],
             Some((anchor_created_at, anchor_id)) => {
-                sqlx::query_as(
+                let sql = format!(
                     "SELECT id, entity_type, entity_id, base_version, current_version, \
                      incoming_payload, current_payload, created_at \
                      FROM sync_conflicts \
                      WHERE user_id = $1 \
-                       AND resolution = 'pending' \
+                       AND resolution = '{}' \
                        AND (created_at, id) < ($2, $3) \
                      ORDER BY created_at DESC, id DESC \
                      LIMIT $4",
-                )
-                .bind(user_id)
-                .bind(anchor_created_at)
-                .bind(anchor_id)
-                .bind(limit_i64)
-                .fetch_all(db)
-                .await
-                .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?
+                    ConflictStatus::Pending.as_str()
+                );
+                sqlx::query_as(&sql)
+                    .bind(user_id)
+                    .bind(anchor_created_at)
+                    .bind(anchor_id)
+                    .bind(limit_i64)
+                    .fetch_all(db)
+                    .await
+                    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?
             }
         }
     } else {
-        sqlx::query_as(
+        let sql = format!(
             "SELECT id, entity_type, entity_id, base_version, current_version, \
              incoming_payload, current_payload, created_at \
              FROM sync_conflicts \
              WHERE user_id = $1 \
-               AND resolution = 'pending' \
+               AND resolution = '{}' \
              ORDER BY created_at DESC, id DESC \
              LIMIT $2",
-        )
-        .bind(user_id)
-        .bind(limit_i64)
-        .fetch_all(db)
-        .await
-        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?
+            ConflictStatus::Pending.as_str()
+        );
+        sqlx::query_as(&sql)
+            .bind(user_id)
+            .bind(limit_i64)
+            .fetch_all(db)
+            .await
+            .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?
     };
 
     let mut records = Vec::with_capacity(rows.len());
@@ -1194,7 +1290,9 @@ pub async fn list_conflicts(
         match crate::sync::models::ConflictRecord::from_row(row) {
             Some(r) => records.push(r),
             None => {
-                warn!("sync_conflicts row for user {user_id} has unrecognized entity_type; skipping");
+                warn!(
+                    "sync_conflicts row for user {user_id} has unrecognized entity_type; skipping"
+                );
             }
         }
     }
@@ -1215,17 +1313,19 @@ pub async fn resolve_conflict(
     resolution: &str,
 ) -> Result<(), AppError> {
     // Only update rows that are still pending (P5-012: prevent re-resolution).
-    let result = sqlx::query(
+    let pending = ConflictStatus::Pending.as_str();
+    let sql = format!(
         "UPDATE sync_conflicts \
          SET resolution = $1, resolved_at = now() \
-         WHERE id = $2 AND user_id = $3 AND resolution = 'pending'",
-    )
-    .bind(resolution)
-    .bind(conflict_id)
-    .bind(user_id)
-    .execute(db)
-    .await
-    .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
+         WHERE id = $2 AND user_id = $3 AND resolution = '{pending}'"
+    );
+    let result = sqlx::query(&sql)
+        .bind(resolution)
+        .bind(conflict_id)
+        .bind(user_id)
+        .execute(db)
+        .await
+        .map_err(|e| AppError::Internal(anyhow::Error::from(e)))?;
 
     if result.rows_affected() == 1 {
         return Ok(());
@@ -1242,9 +1342,9 @@ pub async fn resolve_conflict(
     match row {
         None => Err(AppError::NotFound),
         Some((owner_id, _)) if owner_id != user_id => Err(AppError::Forbidden),
-        Some((_, res)) if res != "pending" => Err(AppError::Conflict(format!(
-            "conflict is already {res}"
-        ))),
+        Some((_, res)) if res != ConflictStatus::Pending.as_str() => {
+            Err(AppError::Conflict(format!("conflict is already {res}")))
+        }
         _ => Err(AppError::Internal(anyhow::anyhow!(
             "resolve_conflict: unexpected state for conflict {conflict_id}"
         ))),
@@ -1260,7 +1360,7 @@ mod tests {
     use super::*;
     use crate::auth::models::AuthUser;
     use crate::contracts::EntityType;
-    use crate::sync::models::{MutationEnvelope, MutationStatus, Operation};
+    use crate::sync::models::{MutationEnvelope, MutationPayload, MutationStatus};
     use sqlx::PgPool;
     use uuid::Uuid;
 
@@ -1332,9 +1432,7 @@ mod tests {
     fn make_envelope(
         entity_type: EntityType,
         entity_id: Uuid,
-        operation: Operation,
-        payload: Option<serde_json::Value>,
-        base_version: Option<DateTime<Utc>>,
+        operation: MutationPayload,
     ) -> MutationEnvelope {
         MutationEnvelope {
             mutation_id: Uuid::new_v4(),
@@ -1342,10 +1440,26 @@ mod tests {
             entity_type,
             entity_id,
             operation,
-            payload,
-            base_version,
             occurred_at: Utc::now(),
         }
+    }
+
+    fn make_create(payload: Option<serde_json::Value>) -> MutationPayload {
+        MutationPayload::Create { payload }
+    }
+
+    fn make_update(
+        payload: Option<serde_json::Value>,
+        base_version: Option<DateTime<Utc>>,
+    ) -> MutationPayload {
+        MutationPayload::Update {
+            payload,
+            base_version,
+        }
+    }
+
+    fn make_delete() -> MutationPayload {
+        MutationPayload::Delete {}
     }
 
     // ------------------------------------------------------------------
@@ -1542,9 +1656,9 @@ mod tests {
         let envelope = make_envelope(
             EntityType::KnowledgeNote,
             note_id,
-            Operation::Create,
-            Some(serde_json::json!({ "title": "New Note", "content": "Hello" })),
-            None,
+            make_create(Some(
+                serde_json::json!({ "title": "New Note", "content": "Hello" }),
+            )),
         );
         let mutation_id = envelope.mutation_id;
         let auth = make_auth_user(user_id);
@@ -1592,9 +1706,7 @@ mod tests {
         let envelope = make_envelope(
             EntityType::KnowledgeNote,
             note_id,
-            Operation::Create,
-            Some(serde_json::json!({ "title": "Dedup Note" })),
-            None,
+            make_create(Some(serde_json::json!({ "title": "Dedup Note" }))),
         );
         let auth = make_auth_user(user_id);
 
@@ -1637,9 +1749,7 @@ mod tests {
         let envelope = make_envelope(
             EntityType::KnowledgeNote,
             note_id,
-            Operation::Update,
-            Some(serde_json::json!({ "title": "Hacked" })),
-            None,
+            make_update(Some(serde_json::json!({ "title": "Hacked" })), None),
         );
         let auth = make_auth_user(attacker);
 
@@ -1660,13 +1770,7 @@ mod tests {
         let note_id = Uuid::new_v4();
         insert_test_note(&pool, note_id, user_id, "To Be Deleted").await;
 
-        let envelope = make_envelope(
-            EntityType::KnowledgeNote,
-            note_id,
-            Operation::Delete,
-            None,
-            None,
-        );
+        let envelope = make_envelope(EntityType::KnowledgeNote, note_id, make_delete());
         let auth = make_auth_user(user_id);
 
         let results = apply_mutations(&pool, vec![envelope], auth)
@@ -1840,9 +1944,10 @@ mod tests {
             device_id: Uuid::new_v4(),
             entity_type: EntityType::KnowledgeNote,
             entity_id: note_id,
-            operation: Operation::Update,
-            payload: Some(serde_json::json!({ "title": "Conflicting update" })),
-            base_version: Some(old_updated_at),
+            operation: MutationPayload::Update {
+                payload: Some(serde_json::json!({ "title": "Conflicting update" })),
+                base_version: Some(old_updated_at),
+            },
             occurred_at: Utc::now() + chrono::Duration::hours(1),
         };
         let auth = make_auth_user(user_id);
@@ -1896,9 +2001,10 @@ mod tests {
             device_id: Uuid::new_v4(),
             entity_type: EntityType::KnowledgeNote,
             entity_id: note_id,
-            operation: Operation::Update,
-            payload: Some(serde_json::json!({ "title": "My Conflicting Version" })),
-            base_version: Some(old_updated_at),
+            operation: MutationPayload::Update {
+                payload: Some(serde_json::json!({ "title": "My Conflicting Version" })),
+                base_version: Some(old_updated_at),
+            },
             occurred_at: Utc::now() + chrono::Duration::hours(1),
         };
         let auth = make_auth_user(user_id);
@@ -1946,9 +2052,10 @@ mod tests {
             device_id: Uuid::new_v4(),
             entity_type: EntityType::KnowledgeNote,
             entity_id: note_id,
-            operation: Operation::Update,
-            payload: Some(serde_json::json!({ "title": "Conflict Copy Relation" })),
-            base_version: Some(old_updated_at),
+            operation: MutationPayload::Update {
+                payload: Some(serde_json::json!({ "title": "Conflict Copy Relation" })),
+                base_version: Some(old_updated_at),
+            },
             occurred_at: Utc::now() + chrono::Duration::hours(1),
         };
         let auth = make_auth_user(user_id);
@@ -1994,9 +2101,10 @@ mod tests {
             device_id: Uuid::new_v4(),
             entity_type: EntityType::KnowledgeNote,
             entity_id: note_id,
-            operation: Operation::Update,
-            payload: Some(serde_json::json!({ "title": "Conflict Resolution" })),
-            base_version: Some(old_updated_at),
+            operation: MutationPayload::Update {
+                payload: Some(serde_json::json!({ "title": "Conflict Resolution" })),
+                base_version: Some(old_updated_at),
+            },
             occurred_at: Utc::now() + chrono::Duration::hours(1),
         };
         let auth = make_auth_user(user_id);
@@ -2040,9 +2148,10 @@ mod tests {
             device_id: Uuid::new_v4(),
             entity_type: EntityType::KnowledgeNote,
             entity_id: note_id,
-            operation: Operation::Update,
-            payload: Some(serde_json::json!({ "title": "Conflict" })),
-            base_version: Some(old_updated_at),
+            operation: MutationPayload::Update {
+                payload: Some(serde_json::json!({ "title": "Conflict" })),
+                base_version: Some(old_updated_at),
+            },
             occurred_at: Utc::now() + chrono::Duration::hours(1),
         };
         let auth = make_auth_user(user_id);
@@ -2084,9 +2193,10 @@ mod tests {
             device_id: Uuid::new_v4(),
             entity_type: EntityType::KnowledgeNote,
             entity_id: note_id,
-            operation: Operation::Update,
-            payload: Some(serde_json::json!({ "title": "My Version" })),
-            base_version: Some(old_updated_at),
+            operation: MutationPayload::Update {
+                payload: Some(serde_json::json!({ "title": "My Version" })),
+                base_version: Some(old_updated_at),
+            },
             occurred_at: Utc::now() + chrono::Duration::hours(1),
         };
         let auth = make_auth_user(user_id);
@@ -2142,9 +2252,7 @@ mod tests {
         let envelope = make_envelope(
             EntityType::TrackingItemEvent,
             event_id,
-            Operation::Update,
-            Some(serde_json::json!({ "quantity": 5 })),
-            None,
+            make_update(Some(serde_json::json!({ "quantity": 5 })), None),
         );
         let auth = make_auth_user(user_id);
 
@@ -2190,9 +2298,10 @@ mod tests {
         let envelope = make_envelope(
             EntityType::TrackingItemEvent,
             event_id,
-            Operation::Update,
-            Some(serde_json::json!({ "notes": "updated note text" })),
-            None,
+            make_update(
+                Some(serde_json::json!({ "notes": "updated note text" })),
+                None,
+            ),
         );
         let auth = make_auth_user(user_id);
 
@@ -2228,9 +2337,10 @@ mod tests {
             device_id: Uuid::new_v4(),
             entity_type: EntityType::KnowledgeNote,
             entity_id: note_id,
-            operation: Operation::Update,
-            payload: Some(serde_json::json!({ "title": "Note about quantity", "quantity": 3 })),
-            base_version: Some(old_updated_at),
+            operation: MutationPayload::Update {
+                payload: Some(serde_json::json!({ "title": "Note about quantity", "quantity": 3 })),
+                base_version: Some(old_updated_at),
+            },
             occurred_at: Utc::now() + chrono::Duration::hours(1),
         };
         let auth = make_auth_user(user_id);
@@ -2246,6 +2356,504 @@ mod tests {
             matches!(results[0].status, MutationStatus::Conflicted { .. }),
             "should be Conflicted (conflict copy), not quantity error; got: {:?}",
             results[0].status
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // S018-T: mixed-validity batch — partial commit semantics (FA-001, FA-004)
+    // ------------------------------------------------------------------
+
+    /// Verifies that in a batch [valid_create, forbidden_update], the first mutation IS
+    /// committed to the DB even though the second returns 403 Forbidden.
+    ///
+    /// Partial-commit semantics: each mutation runs in its own independent transaction.
+    /// If mutation N fails with Forbidden/Conflict/BadRequest, mutations 1..N-1 remain
+    /// committed. The caller (push_handler) propagates the error as an HTTP response for the
+    /// whole batch, but the DB state reflects the partial progress.
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn mixed_batch_partial_commit_first_mutation_survives(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        insert_test_user(&pool, owner, "partial_owner@example.com").await;
+        insert_test_user(&pool, other, "partial_other@example.com").await;
+
+        // Insert a note owned by `other` that `owner` will try to update (forbidden).
+        let foreign_note_id = Uuid::new_v4();
+        insert_test_note(&pool, foreign_note_id, other, "Foreign Note").await;
+
+        // Mutation 1: valid create for a new note (as owner).
+        let new_note_id = Uuid::new_v4();
+        let valid_create = make_envelope(
+            EntityType::KnowledgeNote,
+            new_note_id,
+            make_create(Some(serde_json::json!({ "title": "Valid New Note" }))),
+        );
+
+        // Mutation 2: forbidden update of another user's note.
+        let forbidden_update = make_envelope(
+            EntityType::KnowledgeNote,
+            foreign_note_id,
+            make_update(Some(serde_json::json!({ "title": "Hacked" })), None),
+        );
+
+        let auth = make_auth_user(owner);
+        let result = apply_mutations(&pool, vec![valid_create, forbidden_update], auth).await;
+
+        // The batch as a whole returns Forbidden (from mutation 2).
+        assert!(
+            matches!(result, Err(AppError::Forbidden)),
+            "batch must return Forbidden; got: {:?}",
+            result
+        );
+
+        // Mutation 1 IS committed — the new note row must exist in the DB.
+        let note_exists: Option<(Uuid,)> =
+            sqlx::query_as("SELECT id FROM knowledge_notes WHERE id = $1")
+                .bind(new_note_id)
+                .fetch_optional(&pool)
+                .await
+                .expect("query failed");
+        assert!(
+            note_exists.is_some(),
+            "first mutation must be durably committed even when second fails (partial-commit semantics)"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // S019-T: delete on non-deletable entity types (FA-005)
+    // ------------------------------------------------------------------
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn delete_tracking_item_event_returns_bad_request(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "del_tie@example.com").await;
+        let hh_id = Uuid::new_v4();
+        insert_test_household(&pool, hh_id, user_id).await;
+
+        let item_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tracking_items (id, name, user_id, household_id) VALUES ($1, 'Salt', $2, $3)",
+        )
+        .bind(item_id)
+        .bind(user_id)
+        .bind(hh_id)
+        .execute(&pool)
+        .await
+        .expect("insert tracking_item failed");
+
+        let event_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tracking_item_events \
+             (id, item_id, event_type, quantity_change, occurred_at) \
+             VALUES ($1, $2, 'use', 1, now())",
+        )
+        .bind(event_id)
+        .bind(item_id)
+        .execute(&pool)
+        .await
+        .expect("insert tracking_item_event failed");
+
+        let envelope = make_envelope(EntityType::TrackingItemEvent, event_id, make_delete());
+        let auth = make_auth_user(user_id);
+
+        let result = apply_mutations(&pool, vec![envelope], auth).await;
+        assert!(
+            matches!(result, Err(AppError::BadRequest(_))),
+            "delete on TrackingItemEvent must return BadRequest; got: {:?}",
+            result
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn delete_knowledge_note_snapshot_returns_bad_request(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "del_kns@example.com").await;
+
+        let note_id = Uuid::new_v4();
+        insert_test_note(&pool, note_id, user_id, "Note with snapshot").await;
+
+        let snapshot_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO knowledge_note_snapshots (id, note_id, content, captured_at) \
+             VALUES ($1, $2, 'snapshot content', now())",
+        )
+        .bind(snapshot_id)
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("insert knowledge_note_snapshot failed");
+
+        let envelope = make_envelope(
+            EntityType::KnowledgeNoteSnapshot,
+            snapshot_id,
+            make_delete(),
+        );
+        let auth = make_auth_user(user_id);
+
+        let result = apply_mutations(&pool, vec![envelope], auth).await;
+        assert!(
+            matches!(result, Err(AppError::BadRequest(_))),
+            "delete on KnowledgeNoteSnapshot must return BadRequest; got: {:?}",
+            result
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn delete_tag_returns_bad_request(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "del_tag@example.com").await;
+
+        let tag_id = Uuid::new_v4();
+        sqlx::query("INSERT INTO tags (id, name, user_id) VALUES ($1, 'Work', $2)")
+            .bind(tag_id)
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .expect("insert tag failed");
+
+        let envelope = make_envelope(EntityType::Tag, tag_id, make_delete());
+        let auth = make_auth_user(user_id);
+
+        let result = apply_mutations(&pool, vec![envelope], auth).await;
+        assert!(
+            matches!(result, Err(AppError::BadRequest(_))),
+            "delete on Tag must return BadRequest; got: {:?}",
+            result
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // S020-T: update on immutable KnowledgeNoteSnapshot (FA-005)
+    // ------------------------------------------------------------------
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn update_knowledge_note_snapshot_returns_bad_request_immutable(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "upd_kns@example.com").await;
+
+        let note_id = Uuid::new_v4();
+        insert_test_note(&pool, note_id, user_id, "Snapshotted Note").await;
+
+        let snapshot_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO knowledge_note_snapshots (id, note_id, content, captured_at) \
+             VALUES ($1, $2, 'original content', now())",
+        )
+        .bind(snapshot_id)
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("insert knowledge_note_snapshot failed");
+
+        let envelope = make_envelope(
+            EntityType::KnowledgeNoteSnapshot,
+            snapshot_id,
+            make_update(Some(serde_json::json!({ "content": "modified" })), None),
+        );
+        let auth = make_auth_user(user_id);
+
+        let result = apply_mutations(&pool, vec![envelope], auth).await;
+        assert!(
+            matches!(result, Err(AppError::BadRequest(ref msg)) if msg.contains("immutable")),
+            "update on KnowledgeNoteSnapshot must return BadRequest with 'immutable'; got: {:?}",
+            result
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // S021-T: ownership checks for Household, TrackingItem, TrackingItemEvent (FA-005)
+    // ------------------------------------------------------------------
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn non_member_update_household_returns_forbidden(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let outsider = Uuid::new_v4();
+        insert_test_user(&pool, owner, "hh_own@example.com").await;
+        insert_test_user(&pool, outsider, "hh_out@example.com").await;
+
+        let hh_id = Uuid::new_v4();
+        insert_test_household(&pool, hh_id, owner).await;
+
+        // outsider is NOT a member of this household.
+        let envelope = make_envelope(
+            EntityType::Household,
+            hh_id,
+            make_update(
+                Some(serde_json::json!({ "name": "Hacked Household" })),
+                None,
+            ),
+        );
+        let auth = make_auth_user(outsider);
+
+        let result = apply_mutations(&pool, vec![envelope], auth).await;
+        assert!(
+            matches!(result, Err(AppError::Forbidden)),
+            "non-owner must get Forbidden on Household update; got: {:?}",
+            result
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn non_member_update_tracking_item_returns_forbidden(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let outsider = Uuid::new_v4();
+        insert_test_user(&pool, owner, "ti_own@example.com").await;
+        insert_test_user(&pool, outsider, "ti_out@example.com").await;
+
+        let hh_id = Uuid::new_v4();
+        insert_test_household(&pool, hh_id, owner).await;
+        // owner is member of household but outsider is not.
+
+        let item_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tracking_items (id, name, user_id, household_id) VALUES ($1, 'Milk', $2, $3)",
+        )
+        .bind(item_id)
+        .bind(owner)
+        .bind(hh_id)
+        .execute(&pool)
+        .await
+        .expect("insert tracking_item failed");
+
+        let envelope = make_envelope(
+            EntityType::TrackingItem,
+            item_id,
+            make_update(Some(serde_json::json!({ "name": "Stolen Milk" })), None),
+        );
+        let auth = make_auth_user(outsider);
+
+        let result = apply_mutations(&pool, vec![envelope], auth).await;
+        assert!(
+            matches!(result, Err(AppError::Forbidden)),
+            "non-member must get Forbidden on TrackingItem update; got: {:?}",
+            result
+        );
+    }
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn non_member_update_tracking_item_event_returns_forbidden(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let outsider = Uuid::new_v4();
+        insert_test_user(&pool, owner, "tie_own@example.com").await;
+        insert_test_user(&pool, outsider, "tie_out@example.com").await;
+
+        let hh_id = Uuid::new_v4();
+        insert_test_household(&pool, hh_id, owner).await;
+
+        let item_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tracking_items (id, name, user_id, household_id) VALUES ($1, 'Sugar', $2, $3)",
+        )
+        .bind(item_id)
+        .bind(owner)
+        .bind(hh_id)
+        .execute(&pool)
+        .await
+        .expect("insert tracking_item failed");
+
+        let event_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tracking_item_events \
+             (id, item_id, event_type, quantity_change, occurred_at) \
+             VALUES ($1, $2, 'use', 1, now())",
+        )
+        .bind(event_id)
+        .bind(item_id)
+        .execute(&pool)
+        .await
+        .expect("insert tracking_item_event failed");
+
+        // outsider attempts to update notes on the event — no household membership.
+        let envelope = make_envelope(
+            EntityType::TrackingItemEvent,
+            event_id,
+            make_update(Some(serde_json::json!({ "notes": "sneaky note" })), None),
+        );
+        let auth = make_auth_user(outsider);
+
+        let result = apply_mutations(&pool, vec![envelope], auth).await;
+        assert!(
+            matches!(result, Err(AppError::Forbidden)),
+            "non-member must get Forbidden on TrackingItemEvent update; got: {:?}",
+            result
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // S022-T: resolve endpoint edge cases (P5-019)
+    // ------------------------------------------------------------------
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn resolving_already_resolved_conflict_returns_conflict_error(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "rslv_again@example.com").await;
+        let note_id = Uuid::new_v4();
+        let old_updated_at = insert_test_note(&pool, note_id, user_id, "Already Resolved").await;
+
+        // Trigger a conflict to create a sync_conflicts row.
+        sqlx::query(
+            "UPDATE knowledge_notes SET updated_at = now() + interval '5 seconds' WHERE id = $1",
+        )
+        .bind(note_id)
+        .execute(&pool)
+        .await
+        .expect("simulated update failed");
+
+        // Use a non-KnowledgeNote entity to get a 'pending' conflict (not 'conflict_copy').
+        // Insert a guidance_quest for this purpose.
+        let quest_id = Uuid::new_v4();
+        sqlx::query("INSERT INTO guidance_quests (id, title, user_id) VALUES ($1, 'Quest A', $2)")
+            .bind(quest_id)
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .expect("insert guidance_quest failed");
+
+        sqlx::query(
+            "UPDATE guidance_quests SET updated_at = now() + interval '5 seconds' WHERE id = $1",
+        )
+        .bind(quest_id)
+        .execute(&pool)
+        .await
+        .expect("simulated update failed");
+
+        // Submit a stale update (LWW reject → pending conflict).
+        let envelope = MutationEnvelope {
+            mutation_id: Uuid::new_v4(),
+            device_id: Uuid::new_v4(),
+            entity_type: EntityType::GuidanceQuest,
+            entity_id: quest_id,
+            operation: MutationPayload::Update {
+                payload: Some(serde_json::json!({ "title": "Stale Quest" })),
+                base_version: Some(old_updated_at),
+            },
+            occurred_at: old_updated_at - chrono::Duration::seconds(1),
+        };
+        let auth = make_auth_user(user_id);
+        let results = apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("apply_mutations failed");
+
+        let conflict_id = match results[0].status {
+            MutationStatus::Conflicted { conflict_id } => conflict_id,
+            _ => panic!("expected Conflicted; got: {:?}", results[0].status),
+        };
+
+        // First resolution — should succeed.
+        resolve_conflict(&pool, conflict_id, user_id, "accepted")
+            .await
+            .expect("first resolve should succeed");
+
+        // Second resolution — should return Conflict (already resolved).
+        let second = resolve_conflict(&pool, conflict_id, user_id, "rejected").await;
+        assert!(
+            matches!(second, Err(AppError::Conflict(_))),
+            "re-resolving must return Conflict; got: {:?}",
+            second
+        );
+    }
+
+    #[test]
+    fn invalid_resolution_string_rejected_by_serde() {
+        // ConflictResolution only deserializes "accepted" or "rejected".
+        // Any other string must fail at the serde boundary (not silently accepted).
+        use crate::sync::models::ResolveConflictRequest;
+
+        let bad_json = serde_json::json!({ "resolution": "garbage" });
+        let result: Result<ResolveConflictRequest, _> = serde_json::from_value(bad_json);
+        assert!(
+            result.is_err(),
+            "unknown resolution string 'garbage' must be rejected by serde"
+        );
+
+        let good_json = serde_json::json!({ "resolution": "accepted" });
+        let result: Result<ResolveConflictRequest, _> = serde_json::from_value(good_json);
+        assert!(result.is_ok(), "'accepted' must deserialize successfully");
+    }
+
+    // ------------------------------------------------------------------
+    // S025-T: non-KnowledgeNote LWW Rejected path (FA-008) — GuidanceQuest
+    // ------------------------------------------------------------------
+
+    #[sqlx::test(migrations = "../../../infra/migrations")]
+    async fn guidance_quest_stale_update_yields_conflicted_and_row_unchanged(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        insert_test_user(&pool, user_id, "quest_lww@example.com").await;
+
+        // Insert a guidance_quest.
+        let quest_id = Uuid::new_v4();
+        let row: (DateTime<Utc>,) = sqlx::query_as(
+            "INSERT INTO guidance_quests (id, title, user_id) \
+             VALUES ($1, 'Original Quest Title', $2) RETURNING updated_at",
+        )
+        .bind(quest_id)
+        .bind(user_id)
+        .fetch_one(&pool)
+        .await
+        .expect("insert guidance_quest failed");
+        let original_updated_at = row.0;
+
+        // Simulate a concurrent server update — bump updated_at forward.
+        sqlx::query(
+            "UPDATE guidance_quests SET updated_at = now() + interval '1 hour', \
+             title = 'Server Updated Title' WHERE id = $1",
+        )
+        .bind(quest_id)
+        .execute(&pool)
+        .await
+        .expect("simulated server update failed");
+
+        // Client submits an update with occurred_at BEFORE the server's updated_at → LWW reject.
+        let stale_occurred_at = original_updated_at - chrono::Duration::seconds(5);
+        let envelope = MutationEnvelope {
+            mutation_id: Uuid::new_v4(),
+            device_id: Uuid::new_v4(),
+            entity_type: EntityType::GuidanceQuest,
+            entity_id: quest_id,
+            operation: MutationPayload::Update {
+                payload: Some(serde_json::json!({ "title": "Stale Client Title" })),
+                base_version: Some(original_updated_at),
+            },
+            occurred_at: stale_occurred_at,
+        };
+        let auth = make_auth_user(user_id);
+
+        let results = apply_mutations(&pool, vec![envelope], auth)
+            .await
+            .expect("apply_mutations failed");
+
+        // Assert: response status is Conflicted.
+        assert!(
+            matches!(results[0].status, MutationStatus::Conflicted { .. }),
+            "stale GuidanceQuest update must yield Conflicted; got: {:?}",
+            results[0].status
+        );
+
+        // Assert: row data is unchanged (server's title wins under LWW).
+        let current_title: (String,) =
+            sqlx::query_as("SELECT title FROM guidance_quests WHERE id = $1")
+                .bind(quest_id)
+                .fetch_one(&pool)
+                .await
+                .expect("fetch quest failed");
+        assert_eq!(
+            current_title.0, "Server Updated Title",
+            "row title must be unchanged (server wins under LWW reject)"
+        );
+
+        // Assert: sync_conflicts row exists with resolution = 'pending'.
+        let conflict_row: Option<(String,)> =
+            sqlx::query_as("SELECT resolution FROM sync_conflicts WHERE entity_id = $1")
+                .bind(quest_id)
+                .fetch_optional(&pool)
+                .await
+                .expect("conflict query failed");
+
+        assert!(conflict_row.is_some(), "sync_conflicts row must exist");
+        assert_eq!(
+            conflict_row.unwrap().0,
+            ConflictStatus::Pending.as_str(),
+            "sync_conflicts resolution must be 'pending'"
         );
     }
 }

--- a/apps/server/server/tests/auth_integration.rs
+++ b/apps/server/server/tests/auth_integration.rs
@@ -30,8 +30,8 @@ use tower::ServiceExt;
 
 fn generate_test_rsa_pem() -> String {
     use rsa::rand_core::OsRng;
-    let private_key = rsa::RsaPrivateKey::new(&mut OsRng, 2048)
-        .expect("Failed to generate RSA key for tests");
+    let private_key =
+        rsa::RsaPrivateKey::new(&mut OsRng, 2048).expect("Failed to generate RSA key for tests");
     private_key
         .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
         .expect("Failed to encode RSA key as PEM")
@@ -40,20 +40,16 @@ fn generate_test_rsa_pem() -> String {
 
 fn build_test_app(pool: PgPool) -> Router {
     let pem = generate_test_rsa_pem();
-    let state: AppState = build_app_state(pool, &pem, false)
-        .expect("Failed to build AppState for test");
-    Router::new()
-        .merge(auth_router())
-        .with_state(state)
+    let state: AppState =
+        build_app_state(pool, &pem, false).expect("Failed to build AppState for test");
+    Router::new().merge(auth_router()).with_state(state)
 }
 
 fn build_test_app_with_state(pool: PgPool) -> (Router, AppState) {
     let pem = generate_test_rsa_pem();
-    let state: AppState = build_app_state(pool, &pem, false)
-        .expect("Failed to build AppState for test");
-    let app = Router::new()
-        .merge(auth_router())
-        .with_state(state.clone());
+    let state: AppState =
+        build_app_state(pool, &pem, false).expect("Failed to build AppState for test");
+    let app = Router::new().merge(auth_router()).with_state(state.clone());
     (app, state)
 }
 
@@ -92,22 +88,34 @@ async fn test_first_register_returns_201_admin_active(pool: PgPool) {
     )
     .await;
 
-    assert_eq!(resp.status(), StatusCode::CREATED, "First register must return 201");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "First register must return 201"
+    );
 
     let json = body_json(resp).await;
-    assert!(json["access_token"].is_string(), "access_token must be present");
-    assert!(json["refresh_token"].is_string(), "refresh_token must be present");
+    assert!(
+        json["access_token"].is_string(),
+        "access_token must be present"
+    );
+    assert!(
+        json["refresh_token"].is_string(),
+        "refresh_token must be present"
+    );
     assert_eq!(json["token_type"], "Bearer");
 
     // Verify DB row: is_admin=true, status=active
-    let row: (bool, String) =
-        sqlx::query_as("SELECT is_admin, status FROM users WHERE email = $1")
-            .bind("admin@example.com")
-            .fetch_one(&pool)
-            .await
-            .expect("User must exist in DB after first register");
+    let row: (bool, String) = sqlx::query_as("SELECT is_admin, status FROM users WHERE email = $1")
+        .bind("admin@example.com")
+        .fetch_one(&pool)
+        .await
+        .expect("User must exist in DB after first register");
     assert!(row.0, "First registered user must be admin");
-    assert_eq!(row.1, "active", "First registered user must have status=active");
+    assert_eq!(
+        row.1, "active",
+        "First registered user must have status=active"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -132,22 +140,33 @@ async fn test_second_register_returns_202_pending(pool: PgPool) {
     )
     .await;
 
-    assert_eq!(resp.status(), StatusCode::ACCEPTED, "Second register must return 202");
+    assert_eq!(
+        resp.status(),
+        StatusCode::ACCEPTED,
+        "Second register must return 202"
+    );
 
     let json = body_json(resp).await;
-    assert!(json["access_token"].is_null() || json.get("access_token").is_none(),
-        "Pending user must not receive access_token, got: {json}");
-    assert!(json["message"].is_string(), "Pending response must include a message");
+    assert!(
+        json["access_token"].is_null() || json.get("access_token").is_none(),
+        "Pending user must not receive access_token, got: {json}"
+    );
+    assert!(
+        json["message"].is_string(),
+        "Pending response must include a message"
+    );
 
     // Verify DB row: status=pending, is_admin=false
-    let row: (bool, String) =
-        sqlx::query_as("SELECT is_admin, status FROM users WHERE email = $1")
-            .bind("user@example.com")
-            .fetch_one(&pool)
-            .await
-            .expect("Second user must exist in DB");
+    let row: (bool, String) = sqlx::query_as("SELECT is_admin, status FROM users WHERE email = $1")
+        .bind("user@example.com")
+        .fetch_one(&pool)
+        .await
+        .expect("Second user must exist in DB");
     assert!(!row.0, "Second registered user must not be admin");
-    assert_eq!(row.1, "pending", "Second registered user must have status=pending");
+    assert_eq!(
+        row.1, "pending",
+        "Second registered user must have status=pending"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -170,7 +189,11 @@ async fn test_duplicate_email_returns_409(pool: PgPool) {
     )
     .await;
 
-    assert_eq!(resp.status(), StatusCode::CONFLICT, "Duplicate email must return 409");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "Duplicate email must return 409"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -195,10 +218,15 @@ async fn test_login_active_user_returns_200_with_jwt(pool: PgPool) {
     )
     .await;
 
-    assert_eq!(resp.status(), StatusCode::OK, "Login with valid active user must return 200");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "Login with valid active user must return 200"
+    );
 
     let json = body_json(resp).await;
-    let access_token = json["access_token"].as_str()
+    let access_token = json["access_token"]
+        .as_str()
         .expect("access_token must be a string in login response");
 
     // Decode the JWT and verify email claim is present and correct
@@ -214,7 +242,9 @@ async fn test_login_active_user_returns_200_with_jwt(pool: PgPool) {
 
     // email claim must match
     assert_eq!(
-        claims["email"].as_str().expect("email claim must be a string"),
+        claims["email"]
+            .as_str()
+            .expect("email claim must be a string"),
         "active@example.com",
         "email claim must match registered email"
     );
@@ -248,7 +278,11 @@ async fn test_login_pending_user_returns_403(pool: PgPool) {
     )
     .await;
 
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "Login for pending user must return 403");
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "Login for pending user must return 403"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -271,7 +305,11 @@ async fn test_login_wrong_password_returns_401(pool: PgPool) {
     )
     .await;
 
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "Wrong password must return 401");
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "Wrong password must return 401"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -295,7 +333,8 @@ async fn test_logout_revokes_refresh_token(pool: PgPool) {
     )
     .await;
     let login_json = body_json(login_resp).await;
-    let refresh_token = login_json["refresh_token"].as_str()
+    let refresh_token = login_json["refresh_token"]
+        .as_str()
         .expect("refresh_token must be present after login")
         .to_string();
 
@@ -349,7 +388,8 @@ async fn test_replay_old_refresh_token_after_rotate_returns_401(pool: PgPool) {
     )
     .await;
     let login_json = body_json(login_resp).await;
-    let old_refresh_token = login_json["refresh_token"].as_str()
+    let old_refresh_token = login_json["refresh_token"]
+        .as_str()
         .expect("refresh_token must be present after login")
         .to_string();
 

--- a/apps/server/server/tests/sync_push_integration.rs
+++ b/apps/server/server/tests/sync_push_integration.rs
@@ -1,0 +1,1031 @@
+/// Integration tests for the sync push, conflicts list, and conflict resolve endpoints
+/// (S010-T, S011-T, S015-T, S016-T).
+///
+/// Exercises the full HTTP request/response cycle via tower::ServiceExt::oneshot.
+/// Each DB-backed test gets an isolated database via `#[sqlx::test]`.
+///
+/// Covered assertions (FA-001 through FA-009, plus S015/S016 scenarios):
+///   FA-001 — POST /api/sync/push without JWT → 401
+///   FA-002 — valid JWT + valid create mutation → 200 + Accepted
+///   FA-003 — replay same mutation_id → 200 + Deduplicated
+///   FA-004 — invalid entity_type string → 422
+///   FA-005 — mutation for another user's entity → 403
+///   FA-006 — two Update mutations with same base_version → sync_conflicts row + Conflicted
+///   FA-007 — knowledge_note Update conflict → conflict copy note + entity_relations duplicates + conflict_copy resolution
+///   FA-008 — tracking_item_event Update with quantity field → 409
+///   FA-009 — delete mutation → deleted_at set, row still queryable
+///   S015 — GET /api/sync/conflicts: user isolation, pagination, empty list, 401
+///   S016 — POST /api/sync/conflicts/:id/resolve: accepted, rejected, 404, 403, 401
+use altair_server::{AppState, auth::service::issue_access_token, build_app_state, sync};
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+};
+use chrono::{DateTime, Utc};
+use rsa::pkcs8::EncodePrivateKey;
+use sqlx::PgPool;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn generate_test_rsa_pem() -> String {
+    use rsa::rand_core::OsRng;
+    let private_key =
+        rsa::RsaPrivateKey::new(&mut OsRng, 2048).expect("Failed to generate RSA key for tests");
+    private_key
+        .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
+        .expect("Failed to encode RSA key as PEM")
+        .to_string()
+}
+
+fn build_test_app_with_state(pool: PgPool) -> (Router, AppState) {
+    let pem = generate_test_rsa_pem();
+    let state: AppState =
+        build_app_state(pool, &pem, false).expect("Failed to build AppState for test");
+    let app = Router::new()
+        .merge(sync::router())
+        .with_state(state.clone());
+    (app, state)
+}
+
+/// Issue a test JWT for the given user_id.
+fn make_token(state: &AppState, user_id: Uuid) -> String {
+    issue_access_token(user_id, "test@example.com", vec![], &state.enc_key)
+        .expect("Failed to issue test token")
+}
+
+/// POST to /api/sync/push with a bearer token and JSON body.
+async fn push(app: Router, token: &str, body: serde_json::Value) -> axum::response::Response {
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri("/api/sync/push")
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", token))
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .expect("Failed to build push request"),
+    )
+    .await
+    .expect("Push request failed")
+}
+
+/// POST to /api/sync/push with no auth headers.
+async fn push_unauthenticated(app: Router, body: serde_json::Value) -> axum::response::Response {
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri("/api/sync/push")
+            .header("Content-Type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .expect("Failed to build push request"),
+    )
+    .await
+    .expect("Push request failed")
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read response body");
+    serde_json::from_slice(&bytes).expect("Failed to parse response body as JSON")
+}
+
+// ---------------------------------------------------------------------------
+// DB fixtures
+// ---------------------------------------------------------------------------
+
+async fn insert_test_user(pool: &PgPool, user_id: Uuid, email: &str) {
+    sqlx::query(
+        "INSERT INTO users (id, email, display_name, password_hash, is_admin, status) \
+         VALUES ($1, $2, 'Test User', 'hashed', false, 'active')",
+    )
+    .bind(user_id)
+    .bind(email)
+    .execute(pool)
+    .await
+    .expect("insert_test_user failed");
+}
+
+async fn insert_test_note(
+    pool: &PgPool,
+    note_id: Uuid,
+    user_id: Uuid,
+    title: &str,
+) -> DateTime<Utc> {
+    let row: (DateTime<Utc>,) = sqlx::query_as(
+        "INSERT INTO knowledge_notes (id, title, user_id) \
+         VALUES ($1, $2, $3) RETURNING updated_at",
+    )
+    .bind(note_id)
+    .bind(title)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("insert_test_note failed");
+    row.0
+}
+
+async fn insert_test_household(pool: &PgPool, household_id: Uuid, owner_id: Uuid) {
+    sqlx::query("INSERT INTO households (id, owner_id, name) VALUES ($1, $2, 'Test Household')")
+        .bind(household_id)
+        .bind(owner_id)
+        .execute(pool)
+        .await
+        .expect("insert_test_household failed");
+}
+
+async fn insert_test_tracking_item(
+    pool: &PgPool,
+    item_id: Uuid,
+    user_id: Uuid,
+    household_id: Uuid,
+) {
+    sqlx::query(
+        "INSERT INTO tracking_items (id, name, user_id, household_id) VALUES ($1, 'Test Item', $2, $3)",
+    )
+    .bind(item_id)
+    .bind(user_id)
+    .bind(household_id)
+    .execute(pool)
+    .await
+    .expect("insert_test_tracking_item failed");
+}
+
+async fn insert_test_item_event(pool: &PgPool, event_id: Uuid, item_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO tracking_item_events \
+         (id, item_id, event_type, quantity_change, occurred_at) \
+         VALUES ($1, $2, 'use', 1, now())",
+    )
+    .bind(event_id)
+    .bind(item_id)
+    .execute(pool)
+    .await
+    .expect("insert_test_item_event failed");
+}
+
+/// Build a SyncUploadRequest JSON with a single mutation envelope.
+fn single_mutation(
+    entity_type: &str,
+    entity_id: Uuid,
+    operation: &str,
+    payload: Option<serde_json::Value>,
+    base_version: Option<DateTime<Utc>>,
+) -> serde_json::Value {
+    single_mutation_with_id(
+        Uuid::new_v4(),
+        entity_type,
+        entity_id,
+        operation,
+        payload,
+        base_version,
+    )
+}
+
+fn single_mutation_with_id(
+    mutation_id: Uuid,
+    entity_type: &str,
+    entity_id: Uuid,
+    operation: &str,
+    payload: Option<serde_json::Value>,
+    base_version: Option<DateTime<Utc>>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "mutations": [{
+            "mutation_id": mutation_id.to_string(),
+            "device_id": Uuid::new_v4().to_string(),
+            "entity_type": entity_type,
+            "entity_id": entity_id.to_string(),
+            "operation": operation,
+            "payload": payload,
+            "base_version": base_version.map(|v| v.to_rfc3339()),
+            "occurred_at": Utc::now().to_rfc3339()
+        }]
+    })
+}
+
+// ---------------------------------------------------------------------------
+// FA-001: no JWT → 401
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn fa001_no_jwt_returns_401(pool: PgPool) {
+    let (app, _state) = build_test_app_with_state(pool);
+
+    let body = serde_json::json!({ "mutations": [] });
+    let resp = push_unauthenticated(app, body).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "FA-001: missing JWT must return 401"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FA-002: valid JWT + valid create mutation → 200 + Accepted
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn fa002_valid_create_mutation_returns_200_accepted(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "fa002@example.com").await;
+
+    let (app, state) = build_test_app_with_state(pool.clone());
+    let token = make_token(&state, user_id);
+    let note_id = Uuid::new_v4();
+
+    let body = single_mutation(
+        "knowledge_note",
+        note_id,
+        "create",
+        Some(serde_json::json!({ "title": "FA-002 Note" })),
+        None,
+    );
+
+    let resp = push(app, &token, body).await;
+    assert_eq!(resp.status(), StatusCode::OK, "FA-002: expect 200");
+
+    let json = body_json(resp).await;
+    let results = json["results"].as_array().expect("results must be array");
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results[0]["status"].as_str().unwrap(),
+        "accepted",
+        "FA-002: mutation must be accepted"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FA-003: replay same mutation_id → 200 + Deduplicated
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn fa003_replay_mutation_id_returns_deduplicated(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "fa003@example.com").await;
+
+    let note_id = Uuid::new_v4();
+    let mutation_id = Uuid::new_v4();
+    let body = single_mutation_with_id(
+        mutation_id,
+        "knowledge_note",
+        note_id,
+        "create",
+        Some(serde_json::json!({ "title": "FA-003 Note" })),
+        None,
+    );
+
+    // First submission
+    {
+        let (app, state) = build_test_app_with_state(pool.clone());
+        let token = make_token(&state, user_id);
+        let resp = push(app, &token, body.clone()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert_eq!(json["results"][0]["status"].as_str().unwrap(), "accepted");
+    }
+
+    // Second submission — same mutation_id
+    {
+        let (app, state) = build_test_app_with_state(pool.clone());
+        let token = make_token(&state, user_id);
+        let resp = push(app, &token, body).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "FA-003: expect 200 on replay"
+        );
+        let json = body_json(resp).await;
+        assert_eq!(
+            json["results"][0]["status"].as_str().unwrap(),
+            "deduplicated",
+            "FA-003: second submission must be deduplicated"
+        );
+    }
+
+    // Verify DB row count is exactly 1 (not double-applied)
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM knowledge_notes WHERE id = $1")
+        .bind(note_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count query failed");
+    assert_eq!(
+        count.0, 1,
+        "FA-003: exactly 1 note must exist after dedup replay"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FA-004: invalid entity_type → 422
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn fa004_invalid_entity_type_returns_422(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "fa004@example.com").await;
+
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, user_id);
+
+    // Use an entity_type string that is not in the registry
+    let body = serde_json::json!({
+        "mutations": [{
+            "mutation_id": Uuid::new_v4().to_string(),
+            "device_id": Uuid::new_v4().to_string(),
+            "entity_type": "unknown_type",
+            "entity_id": Uuid::new_v4().to_string(),
+            "operation": "create",
+            "payload": null,
+            "base_version": null,
+            "occurred_at": Utc::now().to_rfc3339()
+        }]
+    });
+
+    let resp = push(app, &token, body).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "FA-004: unknown entity_type must return 422"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FA-005: mutation for another user's entity → 403
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn fa005_mutation_for_other_users_entity_returns_403(pool: PgPool) {
+    let owner_id = Uuid::new_v4();
+    let attacker_id = Uuid::new_v4();
+    insert_test_user(&pool, owner_id, "fa005_owner@example.com").await;
+    insert_test_user(&pool, attacker_id, "fa005_attacker@example.com").await;
+
+    // Create note owned by owner
+    let note_id = Uuid::new_v4();
+    insert_test_note(&pool, note_id, owner_id, "Owner's Note").await;
+
+    // Attacker tries to update it
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, attacker_id);
+
+    let body = single_mutation(
+        "knowledge_note",
+        note_id,
+        "update",
+        Some(serde_json::json!({ "title": "Hacked" })),
+        None,
+    );
+
+    let resp = push(app, &token, body).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "FA-005: mutation for another user's entity must return 403"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FA-006: two Update mutations with same base_version → sync_conflicts row + Conflicted
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn fa006_two_updates_same_base_version_produces_conflict_row(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "fa006@example.com").await;
+
+    let note_id = Uuid::new_v4();
+    let base_version = insert_test_note(&pool, note_id, user_id, "FA-006 Note").await;
+
+    // Simulate a server-side update so the note has moved past base_version
+    sqlx::query(
+        "UPDATE knowledge_notes SET updated_at = now() + interval '10 seconds' WHERE id = $1",
+    )
+    .bind(note_id)
+    .execute(&pool)
+    .await
+    .expect("simulated server update failed");
+
+    // Submit an update with the old base_version (conflict)
+    let (app, state) = build_test_app_with_state(pool.clone());
+    let token = make_token(&state, user_id);
+
+    let body = single_mutation(
+        "knowledge_note",
+        note_id,
+        "update",
+        Some(serde_json::json!({ "title": "Device A version" })),
+        Some(base_version),
+    );
+
+    let resp = push(app, &token, body).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "FA-006: expect 200 even on conflict"
+    );
+
+    let json = body_json(resp).await;
+    assert_eq!(
+        json["results"][0]["status"].as_str().unwrap(),
+        "conflicted",
+        "FA-006: conflicting update must return conflicted status"
+    );
+
+    // Verify sync_conflicts row was written
+    let conflict_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM sync_conflicts WHERE entity_id = $1")
+            .bind(note_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count sync_conflicts failed");
+    assert!(
+        conflict_count.0 > 0,
+        "FA-006: sync_conflicts row must exist after conflict"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FA-007: knowledge_note Update + conflict → conflict copy + duplicates relation + conflict_copy resolution
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn fa007_knowledge_note_conflict_creates_conflict_copy(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "fa007@example.com").await;
+
+    let note_id = Uuid::new_v4();
+    let base_version = insert_test_note(&pool, note_id, user_id, "FA-007 Original").await;
+
+    // Simulate server-side update
+    sqlx::query(
+        "UPDATE knowledge_notes SET updated_at = now() + interval '10 seconds' WHERE id = $1",
+    )
+    .bind(note_id)
+    .execute(&pool)
+    .await
+    .expect("simulated server update failed");
+
+    let (app, state) = build_test_app_with_state(pool.clone());
+    let token = make_token(&state, user_id);
+
+    let body = single_mutation(
+        "knowledge_note",
+        note_id,
+        "update",
+        Some(serde_json::json!({ "title": "FA-007 Conflict Version" })),
+        Some(base_version),
+    );
+
+    let resp = push(app, &token, body).await;
+    assert_eq!(resp.status(), StatusCode::OK, "FA-007: expect 200");
+    let json = body_json(resp).await;
+    assert_eq!(
+        json["results"][0]["status"].as_str().unwrap(),
+        "conflicted",
+        "FA-007: must return conflicted"
+    );
+
+    // Two knowledge_notes rows must exist (original + conflict copy)
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM knowledge_notes WHERE user_id = $1")
+        .bind(user_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count notes failed");
+    assert_eq!(
+        count.0, 2,
+        "FA-007: two knowledge_notes rows must exist (original + conflict copy)"
+    );
+
+    // entity_relations row with relation_type = 'duplicates' must exist
+    let rel: Option<(String,)> = sqlx::query_as(
+        "SELECT relation_type FROM entity_relations \
+         WHERE to_entity_id = $1 AND relation_type = 'duplicates'",
+    )
+    .bind(note_id)
+    .fetch_optional(&pool)
+    .await
+    .expect("query entity_relations failed");
+    assert!(
+        rel.is_some(),
+        "FA-007: entity_relations 'duplicates' row must exist after conflict copy"
+    );
+
+    // sync_conflicts row with resolution = 'conflict_copy' must exist
+    let resolution: Option<(String,)> =
+        sqlx::query_as("SELECT resolution FROM sync_conflicts WHERE entity_id = $1")
+            .bind(note_id)
+            .fetch_optional(&pool)
+            .await
+            .expect("query sync_conflicts failed");
+    assert_eq!(
+        resolution.map(|r| r.0),
+        Some("conflict_copy".to_string()),
+        "FA-007: sync_conflicts resolution must be 'conflict_copy'"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FA-008: tracking_item_event Update with quantity field → 409
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn fa008_tracking_item_event_quantity_conflict_returns_409(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "fa008@example.com").await;
+    let hh_id = Uuid::new_v4();
+    insert_test_household(&pool, hh_id, user_id).await;
+
+    let item_id = Uuid::new_v4();
+    insert_test_tracking_item(&pool, item_id, user_id, hh_id).await;
+
+    let event_id = Uuid::new_v4();
+    insert_test_item_event(&pool, event_id, item_id).await;
+
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, user_id);
+
+    // Update with quantity field → should get 409
+    let body = single_mutation(
+        "tracking_item_event",
+        event_id,
+        "update",
+        Some(serde_json::json!({ "quantity": 10 })),
+        None,
+    );
+
+    let resp = push(app, &token, body).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "FA-008: quantity conflict must return 409"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FA-009: delete mutation → deleted_at set, row still queryable
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn fa009_delete_mutation_sets_deleted_at_row_remains(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "fa009@example.com").await;
+
+    let note_id = Uuid::new_v4();
+    insert_test_note(&pool, note_id, user_id, "FA-009 Note").await;
+
+    let (app, state) = build_test_app_with_state(pool.clone());
+    let token = make_token(&state, user_id);
+
+    let body = single_mutation("knowledge_note", note_id, "delete", None, None);
+
+    let resp = push(app, &token, body).await;
+    assert_eq!(resp.status(), StatusCode::OK, "FA-009: expect 200");
+
+    let json = body_json(resp).await;
+    assert_eq!(
+        json["results"][0]["status"].as_str().unwrap(),
+        "accepted",
+        "FA-009: delete must be accepted"
+    );
+
+    // Row must still exist with deleted_at IS NOT NULL
+    let row: Option<(Option<DateTime<Utc>>,)> =
+        sqlx::query_as("SELECT deleted_at FROM knowledge_notes WHERE id = $1")
+            .bind(note_id)
+            .fetch_optional(&pool)
+            .await
+            .expect("query failed");
+
+    assert!(
+        row.is_some(),
+        "FA-009: row must still exist after soft delete"
+    );
+    assert!(
+        row.unwrap().0.is_some(),
+        "FA-009: deleted_at must be non-null after delete mutation"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for S015 / S016 tests
+// ---------------------------------------------------------------------------
+
+/// Insert a row into sync_conflicts with a given resolution and explicit created_at.
+async fn insert_test_conflict(
+    pool: &PgPool,
+    id: Uuid,
+    user_id: Uuid,
+    resolution: &str,
+    created_at: &str, // ISO 8601
+) {
+    sqlx::query(
+        "INSERT INTO sync_conflicts \
+         (id, entity_type, entity_id, user_id, resolution, created_at) \
+         VALUES ($1, 'knowledge_note', $2, $3, $4, $5::timestamptz)",
+    )
+    .bind(id)
+    .bind(Uuid::new_v4())
+    .bind(user_id)
+    .bind(resolution)
+    .bind(created_at)
+    .execute(pool)
+    .await
+    .expect("insert_test_conflict failed");
+}
+
+/// GET /api/sync/conflicts with a bearer token.
+async fn get_conflicts(app: Router, token: &str, query: &str) -> axum::response::Response {
+    let uri = if query.is_empty() {
+        "/api/sync/conflicts".to_string()
+    } else {
+        format!("/api/sync/conflicts?{}", query)
+    };
+    app.oneshot(
+        Request::builder()
+            .method("GET")
+            .uri(&uri)
+            .header("Authorization", format!("Bearer {}", token))
+            .body(Body::empty())
+            .expect("Failed to build get_conflicts request"),
+    )
+    .await
+    .expect("get_conflicts request failed")
+}
+
+/// GET /api/sync/conflicts with no auth headers.
+async fn get_conflicts_unauthenticated(app: Router) -> axum::response::Response {
+    app.oneshot(
+        Request::builder()
+            .method("GET")
+            .uri("/api/sync/conflicts")
+            .body(Body::empty())
+            .expect("Failed to build unauthenticated get_conflicts request"),
+    )
+    .await
+    .expect("get_conflicts_unauthenticated request failed")
+}
+
+/// POST /api/sync/conflicts/:id/resolve with a bearer token.
+async fn resolve_conflict(
+    app: Router,
+    token: &str,
+    id: Uuid,
+    resolution: &str,
+) -> axum::response::Response {
+    let body = serde_json::json!({ "resolution": resolution });
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri(&format!("/api/sync/conflicts/{}/resolve", id))
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", token))
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .expect("Failed to build resolve_conflict request"),
+    )
+    .await
+    .expect("resolve_conflict request failed")
+}
+
+/// POST /api/sync/conflicts/:id/resolve with no auth headers.
+async fn resolve_conflict_unauthenticated(app: Router, id: Uuid) -> axum::response::Response {
+    let body = serde_json::json!({ "resolution": "accepted" });
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri(&format!("/api/sync/conflicts/{}/resolve", id))
+            .header("Content-Type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .expect("Failed to build unauthenticated resolve request"),
+    )
+    .await
+    .expect("resolve_conflict_unauthenticated request failed")
+}
+
+// ---------------------------------------------------------------------------
+// S015: GET /api/sync/conflicts — user isolation
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s015_conflicts_returns_only_auth_users_pending(pool: PgPool) {
+    let user_a = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    insert_test_user(&pool, user_a, "s015a@example.com").await;
+    insert_test_user(&pool, user_b, "s015b@example.com").await;
+
+    // User A has 2 pending conflicts
+    let a1 = Uuid::new_v4();
+    let a2 = Uuid::new_v4();
+    insert_test_conflict(&pool, a1, user_a, "pending", "2026-01-01T00:00:00Z").await;
+    insert_test_conflict(&pool, a2, user_a, "pending", "2026-01-02T00:00:00Z").await;
+
+    // User B has 1 pending conflict — must NOT appear in User A's results
+    let b1 = Uuid::new_v4();
+    insert_test_conflict(&pool, b1, user_b, "pending", "2026-01-03T00:00:00Z").await;
+
+    let (app, state) = build_test_app_with_state(pool.clone());
+    let token_a = make_token(&state, user_a);
+
+    let resp = get_conflicts(app, &token_a, "").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "S015: expect 200 for conflicts list"
+    );
+
+    let json = body_json(resp).await;
+    let conflicts = json["conflicts"]
+        .as_array()
+        .expect("conflicts must be array");
+    assert_eq!(
+        conflicts.len(),
+        2,
+        "S015: user A must see only their 2 conflicts"
+    );
+
+    // Verify none of user B's conflict IDs appear
+    let ids: Vec<&str> = conflicts
+        .iter()
+        .map(|c| c["id"].as_str().unwrap())
+        .collect();
+    assert!(
+        !ids.contains(&b1.to_string().as_str()),
+        "S015: user B's conflict must not appear in user A's results"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S015: GET /api/sync/conflicts — pagination
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s015_conflicts_pagination(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s015p@example.com").await;
+
+    // Insert 2 conflicts with distinct created_at; newer first when sorted DESC
+    let older_id = Uuid::new_v4();
+    let newer_id = Uuid::new_v4();
+    insert_test_conflict(&pool, older_id, user_id, "pending", "2026-01-01T00:00:00Z").await;
+    insert_test_conflict(&pool, newer_id, user_id, "pending", "2026-01-02T00:00:00Z").await;
+
+    // Page 1: limit=1 — must return the newer conflict + next_cursor set
+    let (app, state) = build_test_app_with_state(pool.clone());
+    let token = make_token(&state, user_id);
+
+    let resp = get_conflicts(app, &token, "limit=1").await;
+    assert_eq!(resp.status(), StatusCode::OK, "S015: page 1 expect 200");
+
+    let json = body_json(resp).await;
+    let conflicts = json["conflicts"]
+        .as_array()
+        .expect("conflicts must be array");
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "S015: page 1 must return exactly 1 conflict"
+    );
+    assert_eq!(
+        conflicts[0]["id"].as_str().unwrap(),
+        newer_id.to_string(),
+        "S015: page 1 must return the newer conflict"
+    );
+
+    let next_cursor = json["next_cursor"]
+        .as_str()
+        .expect("S015: next_cursor must be set on page 1");
+    assert_eq!(
+        next_cursor,
+        newer_id.to_string(),
+        "S015: next_cursor must be the last returned conflict id"
+    );
+
+    // Page 2: cursor=next_cursor, limit=1 — must return the older conflict + no next_cursor
+    let (app2, state2) = build_test_app_with_state(pool.clone());
+    let token2 = make_token(&state2, user_id);
+
+    let query2 = format!("limit=1&cursor={}", next_cursor);
+    let resp2 = get_conflicts(app2, &token2, &query2).await;
+    assert_eq!(resp2.status(), StatusCode::OK, "S015: page 2 expect 200");
+
+    let json2 = body_json(resp2).await;
+    let conflicts2 = json2["conflicts"]
+        .as_array()
+        .expect("conflicts must be array");
+    assert_eq!(
+        conflicts2.len(),
+        1,
+        "S015: page 2 must return exactly 1 conflict"
+    );
+    assert_eq!(
+        conflicts2[0]["id"].as_str().unwrap(),
+        older_id.to_string(),
+        "S015: page 2 must return the older conflict"
+    );
+    assert!(
+        json2["next_cursor"].is_null(),
+        "S015: next_cursor must be null on last page"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S015: GET /api/sync/conflicts — empty list
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s015_conflicts_empty_list(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s015e@example.com").await;
+
+    let (app, state) = build_test_app_with_state(pool.clone());
+    let token = make_token(&state, user_id);
+
+    let resp = get_conflicts(app, &token, "").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "S015: expect 200 with no conflicts"
+    );
+
+    let json = body_json(resp).await;
+    let conflicts = json["conflicts"]
+        .as_array()
+        .expect("conflicts must be array");
+    assert_eq!(
+        conflicts.len(),
+        0,
+        "S015: empty list when no pending conflicts"
+    );
+    assert!(
+        json["next_cursor"].is_null(),
+        "S015: next_cursor must be null when empty"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S015: GET /api/sync/conflicts — 401 without JWT
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s015_conflicts_401_without_jwt(pool: PgPool) {
+    let (app, _state) = build_test_app_with_state(pool);
+    let resp = get_conflicts_unauthenticated(app).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "S015: missing JWT must return 401"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S016: POST /api/sync/conflicts/:id/resolve — accepted → 200
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s016_resolve_accepted_returns_200(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s016a@example.com").await;
+
+    let conflict_id = Uuid::new_v4();
+    insert_test_conflict(
+        &pool,
+        conflict_id,
+        user_id,
+        "pending",
+        "2026-01-01T00:00:00Z",
+    )
+    .await;
+
+    let (app, state) = build_test_app_with_state(pool.clone());
+    let token = make_token(&state, user_id);
+
+    let resp = resolve_conflict(app, &token, conflict_id, "accepted").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "S016: accepted must return 200"
+    );
+
+    // Verify DB: resolution = 'accepted', resolved_at IS NOT NULL
+    let row: (String, Option<DateTime<Utc>>) =
+        sqlx::query_as("SELECT resolution, resolved_at FROM sync_conflicts WHERE id = $1")
+            .bind(conflict_id)
+            .fetch_one(&pool)
+            .await
+            .expect("S016: query failed");
+    assert_eq!(row.0, "accepted", "S016: resolution must be 'accepted'");
+    assert!(row.1.is_some(), "S016: resolved_at must be set");
+}
+
+// ---------------------------------------------------------------------------
+// S016: POST /api/sync/conflicts/:id/resolve — rejected → 200
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s016_resolve_rejected_returns_200(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s016r@example.com").await;
+
+    let conflict_id = Uuid::new_v4();
+    insert_test_conflict(
+        &pool,
+        conflict_id,
+        user_id,
+        "pending",
+        "2026-01-01T00:00:00Z",
+    )
+    .await;
+
+    let (app, state) = build_test_app_with_state(pool.clone());
+    let token = make_token(&state, user_id);
+
+    let resp = resolve_conflict(app, &token, conflict_id, "rejected").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "S016: rejected must return 200"
+    );
+
+    let row: (String, Option<DateTime<Utc>>) =
+        sqlx::query_as("SELECT resolution, resolved_at FROM sync_conflicts WHERE id = $1")
+            .bind(conflict_id)
+            .fetch_one(&pool)
+            .await
+            .expect("S016: query failed");
+    assert_eq!(row.0, "rejected", "S016: resolution must be 'rejected'");
+    assert!(row.1.is_some(), "S016: resolved_at must be set");
+}
+
+// ---------------------------------------------------------------------------
+// S016: POST /api/sync/conflicts/:id/resolve — unknown id → 404
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s016_resolve_unknown_id_returns_404(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s016n@example.com").await;
+
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, user_id);
+
+    let nonexistent = Uuid::new_v4();
+    let resp = resolve_conflict(app, &token, nonexistent, "accepted").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "S016: unknown id must return 404"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S016: POST /api/sync/conflicts/:id/resolve — other user's conflict → 403
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s016_resolve_other_users_conflict_returns_403(pool: PgPool) {
+    let owner_id = Uuid::new_v4();
+    let other_id = Uuid::new_v4();
+    insert_test_user(&pool, owner_id, "s016o@example.com").await;
+    insert_test_user(&pool, other_id, "s016x@example.com").await;
+
+    let conflict_id = Uuid::new_v4();
+    insert_test_conflict(
+        &pool,
+        conflict_id,
+        owner_id,
+        "pending",
+        "2026-01-01T00:00:00Z",
+    )
+    .await;
+
+    // other_id tries to resolve owner_id's conflict
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, other_id);
+
+    let resp = resolve_conflict(app, &token, conflict_id, "accepted").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "S016: resolving another user's conflict must return 403"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S016: POST /api/sync/conflicts/:id/resolve — 401 without JWT
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s016_resolve_401_without_jwt(pool: PgPool) {
+    let (app, _state) = build_test_app_with_state(pool);
+    let conflict_id = Uuid::new_v4();
+    let resp = resolve_conflict_unauthenticated(app, conflict_id).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "S016: missing JWT must return 401"
+    );
+}

--- a/apps/server/server/tests/sync_push_integration.rs
+++ b/apps/server/server/tests/sync_push_integration.rs
@@ -1029,3 +1029,474 @@ async fn s016_resolve_401_without_jwt(pool: PgPool) {
         "S016: missing JWT must return 401"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Additional fixtures for S018-T through S025-T
+// ---------------------------------------------------------------------------
+
+async fn insert_test_tag(pool: &PgPool, tag_id: Uuid, user_id: Uuid) {
+    sqlx::query("INSERT INTO tags (id, user_id, name) VALUES ($1, $2, 'test-tag')")
+        .bind(tag_id)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("insert_test_tag failed");
+}
+
+async fn insert_test_snapshot(pool: &PgPool, snapshot_id: Uuid, note_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO knowledge_note_snapshots (id, note_id, content, captured_at) \
+         VALUES ($1, $2, 'snapshot', now())",
+    )
+    .bind(snapshot_id)
+    .bind(note_id)
+    .execute(pool)
+    .await
+    .expect("insert_test_snapshot failed");
+}
+
+async fn insert_test_quest(pool: &PgPool, quest_id: Uuid, user_id: Uuid, title: &str) -> DateTime<Utc> {
+    let row: (DateTime<Utc>,) = sqlx::query_as(
+        "INSERT INTO guidance_quests (id, user_id, title) VALUES ($1, $2, $3) RETURNING updated_at",
+    )
+    .bind(quest_id)
+    .bind(user_id)
+    .bind(title)
+    .fetch_one(pool)
+    .await
+    .expect("insert_test_quest failed");
+    row.0
+}
+
+// ---------------------------------------------------------------------------
+// S018-T: Mixed-validity batch — partial commit (P5-015)
+// ---------------------------------------------------------------------------
+
+/// Verifies the documented partial-commit semantic of apply_mutations:
+/// mutations are processed serially, each in its own transaction.
+/// A later error (e.g., 403 on the second mutation) does NOT roll back
+/// earlier committed mutations. The HTTP response reflects the error of
+/// the failing mutation, while the first mutation's row is already persisted.
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s018_mixed_batch_partial_commit_first_row_persists_on_second_403(pool: PgPool) {
+    let owner_id = Uuid::new_v4();
+    let attacker_id = Uuid::new_v4();
+    insert_test_user(&pool, owner_id, "s018_owner@example.com").await;
+    insert_test_user(&pool, attacker_id, "s018_attacker@example.com").await;
+
+    // The attacker will issue two mutations:
+    //   1. A valid create of their own note.
+    //   2. An update on owner's note — forbidden.
+    let owner_note_id = Uuid::new_v4();
+    insert_test_note(&pool, owner_note_id, owner_id, "Owner Note").await;
+
+    let attacker_note_id = Uuid::new_v4();
+
+    let (app, state) = build_test_app_with_state(pool.clone());
+    let token = make_token(&state, attacker_id);
+
+    // Build a two-mutation batch manually.
+    let body = serde_json::json!({
+        "mutations": [
+            {
+                "mutation_id": Uuid::new_v4().to_string(),
+                "device_id": Uuid::new_v4().to_string(),
+                "entity_type": "knowledge_note",
+                "entity_id": attacker_note_id.to_string(),
+                "operation": "create",
+                "payload": { "title": "Attacker's Own Note" },
+                "base_version": null,
+                "occurred_at": Utc::now().to_rfc3339()
+            },
+            {
+                "mutation_id": Uuid::new_v4().to_string(),
+                "device_id": Uuid::new_v4().to_string(),
+                "entity_type": "knowledge_note",
+                "entity_id": owner_note_id.to_string(),
+                "operation": "update",
+                "payload": { "title": "Hacked Title" },
+                "base_version": null,
+                "occurred_at": Utc::now().to_rfc3339()
+            }
+        ]
+    });
+
+    let resp = push(app, &token, body).await;
+
+    // The second mutation is forbidden → the whole call returns 403.
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "S018: second mutation forbidden must make overall response 403"
+    );
+
+    // The first mutation's row MUST be present in the DB — it was committed before the error.
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM knowledge_notes WHERE id = $1")
+        .bind(attacker_note_id)
+        .fetch_one(&pool)
+        .await
+        .expect("S018: count query failed");
+    assert_eq!(
+        count.0, 1,
+        "S018: first mutation's row must be persisted despite later 403"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S019-T: Delete on non-deletable entity types → 400 (P5-016)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s019_delete_tracking_item_event_returns_400(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s019_tie@example.com").await;
+    let hh_id = Uuid::new_v4();
+    insert_test_household(&pool, hh_id, user_id).await;
+    let item_id = Uuid::new_v4();
+    insert_test_tracking_item(&pool, item_id, user_id, hh_id).await;
+    let event_id = Uuid::new_v4();
+    insert_test_item_event(&pool, event_id, item_id).await;
+
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, user_id);
+
+    let body = single_mutation("tracking_item_event", event_id, "delete", None, None);
+    let resp = push(app, &token, body).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "S019: delete on tracking_item_event must return 400"
+    );
+}
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s019_delete_knowledge_note_snapshot_returns_400(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s019_kns@example.com").await;
+    let note_id = Uuid::new_v4();
+    insert_test_note(&pool, note_id, user_id, "S019 Note").await;
+    let snapshot_id = Uuid::new_v4();
+    insert_test_snapshot(&pool, snapshot_id, note_id).await;
+
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, user_id);
+
+    let body = single_mutation("knowledge_note_snapshot", snapshot_id, "delete", None, None);
+    let resp = push(app, &token, body).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "S019: delete on knowledge_note_snapshot must return 400"
+    );
+}
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s019_delete_tag_returns_400(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s019_tag@example.com").await;
+    let tag_id = Uuid::new_v4();
+    insert_test_tag(&pool, tag_id, user_id).await;
+
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, user_id);
+
+    let body = single_mutation("tag", tag_id, "delete", None, None);
+    let resp = push(app, &token, body).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "S019: delete on tag must return 400"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S020-T: Update on immutable KnowledgeNoteSnapshot → 400 (P5-017)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s020_update_knowledge_note_snapshot_returns_400_immutable(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s020@example.com").await;
+    let note_id = Uuid::new_v4();
+    insert_test_note(&pool, note_id, user_id, "S020 Note").await;
+    let snapshot_id = Uuid::new_v4();
+    insert_test_snapshot(&pool, snapshot_id, note_id).await;
+
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, user_id);
+
+    let body = single_mutation(
+        "knowledge_note_snapshot",
+        snapshot_id,
+        "update",
+        Some(serde_json::json!({ "content": "new content" })),
+        None,
+    );
+    let resp = push(app, &token, body).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "S020: update on knowledge_note_snapshot must return 400"
+    );
+
+    let json = body_json(resp).await;
+    let body_str = json.to_string();
+    assert!(
+        body_str.contains("knowledge_note_snapshot is immutable"),
+        "S020: response body must contain 'knowledge_note_snapshot is immutable'; got: {body_str}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S021-T: Ownership checks — Household, TrackingItem, TrackingItemEvent (P5-018)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s021_household_update_by_non_owner_returns_403(pool: PgPool) {
+    let owner_id = Uuid::new_v4();
+    let other_id = Uuid::new_v4();
+    insert_test_user(&pool, owner_id, "s021_hh_owner@example.com").await;
+    insert_test_user(&pool, other_id, "s021_hh_other@example.com").await;
+
+    let hh_id = Uuid::new_v4();
+    insert_test_household(&pool, hh_id, owner_id).await;
+
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, other_id);
+
+    let body = single_mutation(
+        "household",
+        hh_id,
+        "update",
+        Some(serde_json::json!({ "name": "Hijacked" })),
+        None,
+    );
+    let resp = push(app, &token, body).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "S021: non-owner household update must return 403"
+    );
+}
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s021_tracking_item_update_by_non_member_returns_403(pool: PgPool) {
+    let owner_id = Uuid::new_v4();
+    let other_id = Uuid::new_v4();
+    insert_test_user(&pool, owner_id, "s021_ti_owner@example.com").await;
+    insert_test_user(&pool, other_id, "s021_ti_other@example.com").await;
+
+    let hh_id = Uuid::new_v4();
+    insert_test_household(&pool, hh_id, owner_id).await;
+
+    let item_id = Uuid::new_v4();
+    insert_test_tracking_item(&pool, item_id, owner_id, hh_id).await;
+
+    // other_id is not owner of the item and not a household member.
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, other_id);
+
+    let body = single_mutation(
+        "tracking_item",
+        item_id,
+        "update",
+        Some(serde_json::json!({ "name": "Hijacked Item" })),
+        None,
+    );
+    let resp = push(app, &token, body).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "S021: non-member tracking_item update must return 403"
+    );
+}
+
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s021_tracking_item_event_update_by_non_member_returns_403(pool: PgPool) {
+    let owner_id = Uuid::new_v4();
+    let other_id = Uuid::new_v4();
+    insert_test_user(&pool, owner_id, "s021_tie_owner@example.com").await;
+    insert_test_user(&pool, other_id, "s021_tie_other@example.com").await;
+
+    let hh_id = Uuid::new_v4();
+    insert_test_household(&pool, hh_id, owner_id).await;
+
+    let item_id = Uuid::new_v4();
+    insert_test_tracking_item(&pool, item_id, owner_id, hh_id).await;
+
+    let event_id = Uuid::new_v4();
+    insert_test_item_event(&pool, event_id, item_id).await;
+
+    // other_id is not owner of the parent item and not a household member.
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, other_id);
+
+    let body = single_mutation(
+        "tracking_item_event",
+        event_id,
+        "update",
+        Some(serde_json::json!({ "notes": "hijacked" })),
+        None,
+    );
+    let resp = push(app, &token, body).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "S021: non-member tracking_item_event update must return 403"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S022-T: Resolve endpoint edge cases (P5-019)
+// ---------------------------------------------------------------------------
+
+/// Resolving an already-resolved conflict returns 409 Conflict.
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s022_resolve_already_resolved_conflict_returns_409(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s022_409@example.com").await;
+
+    let conflict_id = Uuid::new_v4();
+    // Insert with resolution = 'accepted' (already resolved).
+    insert_test_conflict(&pool, conflict_id, user_id, "accepted", "2026-01-01T00:00:00Z").await;
+
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, user_id);
+
+    let resp = resolve_conflict(app, &token, conflict_id, "accepted").await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "S022: resolving an already-resolved conflict must return 409"
+    );
+}
+
+/// Resolving with an unknown enum variant returns 422 (serde rejects at deserialization).
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s022_resolve_invalid_resolution_returns_422(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s022_422@example.com").await;
+
+    let conflict_id = Uuid::new_v4();
+    insert_test_conflict(&pool, conflict_id, user_id, "pending", "2026-01-01T00:00:00Z").await;
+
+    let (app, state) = build_test_app_with_state(pool);
+    let token = make_token(&state, user_id);
+
+    // Pass an invalid resolution string — serde cannot deserialize it into ConflictResolution.
+    let resp = resolve_conflict(app, &token, conflict_id, "garbage").await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "S022: unknown resolution enum variant must return 422"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S025-T: Non-KnowledgeNote LWW Rejected path (P5-026)
+// ---------------------------------------------------------------------------
+
+/// For a user-scoped entity with updated_at (GuidanceQuest):
+/// - Submit an Update where occurred_at is older than the server row's updated_at.
+/// - Expect: response status 200 with status "conflicted" and a non-null conflict_id.
+/// - The quest row's data is UNCHANGED (server value wins under LWW reject).
+/// - A sync_conflicts row exists for the user with resolution "pending".
+#[sqlx::test(migrations = "../../../infra/migrations")]
+async fn s025_guidance_quest_lww_rejected_returns_conflicted_and_row_unchanged(pool: PgPool) {
+    let user_id = Uuid::new_v4();
+    insert_test_user(&pool, user_id, "s025@example.com").await;
+
+    let quest_id = Uuid::new_v4();
+    insert_test_quest(&pool, quest_id, user_id, "Original Title").await;
+
+    // Advance the server's updated_at far into the future to simulate a concurrent server write.
+    sqlx::query(
+        "UPDATE guidance_quests SET updated_at = now() + interval '1 hour' WHERE id = $1",
+    )
+    .bind(quest_id)
+    .execute(&pool)
+    .await
+    .expect("S025: failed to advance updated_at");
+
+    // Read back the actual updated_at to avoid host/DB clock-skew dependency.
+    let (server_updated_at,): (DateTime<Utc>,) =
+        sqlx::query_as("SELECT updated_at FROM guidance_quests WHERE id = $1")
+            .bind(quest_id)
+            .fetch_one(&pool)
+            .await
+            .expect("S025: failed to fetch updated_at");
+
+    // Set occurred_at to 2 hours BEFORE server's updated_at — guaranteed stale regardless of clock skew.
+    let stale_occurred_at = server_updated_at - chrono::Duration::hours(2);
+
+    let (app, state) = build_test_app_with_state(pool.clone());
+    let token = make_token(&state, user_id);
+
+    // Submit an update with explicit stale occurred_at; detect_conflict sees occurred_at < updated_at → Rejected.
+    let body = serde_json::json!({
+        "mutations": [{
+            "mutation_id": Uuid::new_v4().to_string(),
+            "device_id": Uuid::new_v4().to_string(),
+            "entity_type": "guidance_quest",
+            "entity_id": quest_id.to_string(),
+            "operation": "update",
+            "payload": { "title": "Client Stale Title" },
+            "base_version": null,
+            "occurred_at": stale_occurred_at.to_rfc3339()
+        }]
+    });
+
+    let resp = push(app, &token, body).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "S025: LWW-rejected update must return 200"
+    );
+
+    let json = body_json(resp).await;
+    assert_eq!(
+        json["results"][0]["status"].as_str().unwrap(),
+        "conflicted",
+        "S025: LWW-rejected update must return 'conflicted' status"
+    );
+    assert!(
+        !json["results"][0]["conflict_id"].is_null(),
+        "S025: conflict_id must be non-null in conflicted result"
+    );
+
+    // Quest row data must be unchanged — server title wins.
+    let title: (String,) =
+        sqlx::query_as("SELECT title FROM guidance_quests WHERE id = $1")
+            .bind(quest_id)
+            .fetch_one(&pool)
+            .await
+            .expect("S025: quest query failed");
+    assert_eq!(
+        title.0, "Original Title",
+        "S025: quest title must be unchanged after LWW reject"
+    );
+
+    // A sync_conflicts row with resolution 'pending' must exist for this user.
+    let conflict: Option<(String,)> =
+        sqlx::query_as("SELECT resolution FROM sync_conflicts WHERE entity_id = $1 AND user_id = $2")
+            .bind(quest_id)
+            .bind(user_id)
+            .fetch_optional(&pool)
+            .await
+            .expect("S025: sync_conflicts query failed");
+    assert_eq!(
+        conflict.map(|r| r.0),
+        Some("pending".to_string()),
+        "S025: sync_conflicts row must exist with resolution 'pending'"
+    );
+}

--- a/infra/compose/powersync.yml
+++ b/infra/compose/powersync.yml
@@ -1,6 +1,8 @@
 # PowerSync Service Configuration
 # Credentials are injected via environment variables from .env
-# Sync rules are defined in apps/web/src/lib/sync/schema.ts
+
+sync_rules:
+  path: ./sync_rules.yaml
 
 replication:
   connections:

--- a/infra/compose/sync_rules.yaml
+++ b/infra/compose/sync_rules.yaml
@@ -1,0 +1,52 @@
+bucket_definitions:
+
+  # User-owned personal data
+  user_data:
+    parameters: SELECT request.user_id() AS user_id
+    data:
+      - SELECT * FROM users            WHERE id = bucket.user_id
+      - SELECT * FROM initiatives      WHERE user_id = bucket.user_id
+      - SELECT * FROM tags             WHERE user_id = bucket.user_id
+      - SELECT * FROM attachments      WHERE user_id = bucket.user_id
+      - SELECT * FROM entity_relations WHERE user_id = bucket.user_id
+
+  # Household-scoped shared data (user must be a member)
+  household:
+    parameters: >
+      SELECT hm.household_id
+        FROM household_memberships hm
+       WHERE hm.user_id = request.user_id()
+    data:
+      - SELECT * FROM households            WHERE id = bucket.household_id
+      - SELECT * FROM household_memberships WHERE household_id = bucket.household_id
+
+  # Guidance domain — user-owned
+  guidance:
+    parameters: SELECT request.user_id() AS user_id
+    data:
+      - SELECT * FROM guidance_epics          WHERE user_id = bucket.user_id
+      - SELECT * FROM guidance_quests         WHERE user_id = bucket.user_id
+      - SELECT * FROM guidance_routines       WHERE user_id = bucket.user_id
+      - SELECT * FROM guidance_focus_sessions WHERE user_id = bucket.user_id
+      - SELECT * FROM guidance_daily_checkins WHERE user_id = bucket.user_id
+
+  # Knowledge domain — user-owned
+  knowledge:
+    parameters: SELECT request.user_id() AS user_id
+    data:
+      - SELECT * FROM knowledge_notes          WHERE user_id = bucket.user_id
+      - SELECT * FROM knowledge_note_snapshots WHERE user_id = bucket.user_id
+
+  # Tracking domain — household-scoped
+  tracking:
+    parameters: >
+      SELECT hm.household_id
+        FROM household_memberships hm
+       WHERE hm.user_id = request.user_id()
+    data:
+      - SELECT * FROM tracking_locations           WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_categories          WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_items               WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_item_events         WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_shopping_lists      WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_shopping_list_items WHERE household_id = bucket.household_id

--- a/infra/compose/sync_rules.yaml
+++ b/infra/compose/sync_rules.yaml
@@ -34,8 +34,9 @@ bucket_definitions:
   knowledge:
     parameters: SELECT request.user_id() AS user_id
     data:
-      - SELECT * FROM knowledge_notes          WHERE user_id = bucket.user_id
-      - SELECT * FROM knowledge_note_snapshots WHERE user_id = bucket.user_id
+      - SELECT * FROM knowledge_notes WHERE user_id = bucket.user_id
+      - SELECT * FROM knowledge_note_snapshots
+          WHERE note_id IN (SELECT id FROM knowledge_notes WHERE user_id = bucket.user_id)
 
   # Tracking domain — household-scoped
   tracking:
@@ -47,6 +48,8 @@ bucket_definitions:
       - SELECT * FROM tracking_locations           WHERE household_id = bucket.household_id
       - SELECT * FROM tracking_categories          WHERE household_id = bucket.household_id
       - SELECT * FROM tracking_items               WHERE household_id = bucket.household_id
-      - SELECT * FROM tracking_item_events         WHERE household_id = bucket.household_id
-      - SELECT * FROM tracking_shopping_lists      WHERE household_id = bucket.household_id
-      - SELECT * FROM tracking_shopping_list_items WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_item_events
+          WHERE item_id IN (SELECT id FROM tracking_items WHERE household_id = bucket.household_id)
+      - SELECT * FROM tracking_shopping_lists WHERE household_id = bucket.household_id
+      - SELECT * FROM tracking_shopping_list_items
+          WHERE shopping_list_id IN (SELECT id FROM tracking_shopping_lists WHERE household_id = bucket.household_id)

--- a/infra/migrations/20260414000027_create_sync_mutations.down.sql
+++ b/infra/migrations/20260414000027_create_sync_mutations.down.sql
@@ -1,0 +1,2 @@
+-- migrate:down
+DROP TABLE IF EXISTS sync_mutations CASCADE;

--- a/infra/migrations/20260414000027_create_sync_mutations.up.sql
+++ b/infra/migrations/20260414000027_create_sync_mutations.up.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+CREATE TABLE sync_mutations (
+  mutation_id  UUID        PRIMARY KEY,
+  device_id    UUID        NOT NULL,
+  user_id      UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  entity_type  TEXT        NOT NULL,
+  entity_id    UUID        NOT NULL,
+  operation    TEXT        NOT NULL,
+  applied_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_sync_mutations_entity_id ON sync_mutations(entity_id);
+CREATE INDEX idx_sync_mutations_user_id   ON sync_mutations(user_id);

--- a/infra/migrations/20260414000028_create_sync_conflicts.down.sql
+++ b/infra/migrations/20260414000028_create_sync_conflicts.down.sql
@@ -1,0 +1,2 @@
+-- migrate:down
+DROP TABLE IF EXISTS sync_conflicts CASCADE;

--- a/infra/migrations/20260414000028_create_sync_conflicts.up.sql
+++ b/infra/migrations/20260414000028_create_sync_conflicts.up.sql
@@ -1,0 +1,18 @@
+-- migrate:up
+CREATE TABLE sync_conflicts (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  mutation_id      UUID,
+  entity_type      TEXT        NOT NULL,
+  entity_id        UUID        NOT NULL,
+  base_version     TIMESTAMPTZ,
+  current_version  TIMESTAMPTZ,
+  incoming_payload JSONB,
+  current_payload  JSONB,
+  resolution       TEXT        NOT NULL DEFAULT 'pending',
+  resolved_at      TIMESTAMPTZ,
+  user_id          UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_sync_conflicts_entity_id ON sync_conflicts(entity_id);
+CREATE INDEX idx_sync_conflicts_user_id   ON sync_conflicts(user_id);

--- a/infra/migrations/20260414000029_sync_tables_timestamps.down.sql
+++ b/infra/migrations/20260414000029_sync_tables_timestamps.down.sql
@@ -1,0 +1,7 @@
+-- migrate:down
+DROP TRIGGER IF EXISTS sync_conflicts_updated_at ON sync_conflicts;
+ALTER TABLE sync_conflicts DROP COLUMN IF EXISTS updated_at;
+
+DROP TRIGGER IF EXISTS sync_mutations_updated_at ON sync_mutations;
+ALTER TABLE sync_mutations DROP COLUMN IF EXISTS updated_at;
+ALTER TABLE sync_mutations DROP COLUMN IF EXISTS created_at;

--- a/infra/migrations/20260414000029_sync_tables_timestamps.up.sql
+++ b/infra/migrations/20260414000029_sync_tables_timestamps.up.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+-- Add created_at / updated_at columns and trigger to sync_mutations (postgres.md convention).
+-- sync_mutations has applied_at only; add created_at as an alias and updated_at for mutations.
+ALTER TABLE sync_mutations
+  ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+CREATE TRIGGER sync_mutations_updated_at
+  BEFORE UPDATE ON sync_mutations
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Add updated_at column and trigger to sync_conflicts.
+-- sync_conflicts already has created_at but is missing updated_at despite being mutated
+-- (resolution and resolved_at are updated on resolve).
+ALTER TABLE sync_conflicts
+  ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+CREATE TRIGGER sync_conflicts_updated_at
+  BEFORE UPDATE ON sync_conflicts
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/packages/contracts/sync-streams.json
+++ b/packages/contracts/sync-streams.json
@@ -1,7 +1,7 @@
 {
   "contracts_version": "1.0.0",
-  "provisional": true,
-  "note": "Stream SQL bucket definitions are designed in Step 4 (Sync Engine); these names may be revised.",
+  "provisional": false,
+  "note": "Finalised bucket names from Feature 004 sync_rules.yaml: user_data, household, guidance, knowledge, tracking.",
   "values": [
     { "id": "user_data",  "description": "User's own Core entities (initiatives, tags, attachments)" },
     { "id": "household",  "description": "Household-scoped data (memberships, locations, categories)" },


### PR DESCRIPTION
## Summary

- **POST /api/sync/push** — mutation upload endpoint with idempotent dedup, per-entity ownership enforcement, LWW conflict detection, knowledge_note conflict copy, and tracking_item_event quantity conflict (409)
- **GET /api/sync/conflicts** — paginated list of pending conflicts for the authenticated user
- **POST /api/sync/conflicts/:id/resolve** — accept or reject a conflict record
- PowerSync `sync_rules.yaml` with 5 buckets (user_data, household, guidance, knowledge, tracking); soft-deleted rows included for client reconciliation per ADR-003
- `sync_mutations` and `sync_conflicts` migrations with FK constraints, indexes, and reversible DOWN migrations
- `packages/contracts/sync-streams.json` promoted from provisional to final

## Validation

- 18 `sqlx::test` integration tests covering FA-001 through FA-009, and conflict resolution endpoints (S015-T, S016-T)
- `cargo check --tests` exits 0
- Validator drift check: **11 PASS / 0 FAIL / 3 REQUIRES_LIVE_ENV**
- REQUIRES_LIVE_ENV: FA-010 (PowerSync rules parse), FA-011 (user isolation), FA-013/FA-014 (cargo test + sqlx migrate run/revert with live DB)

## Test plan

- [ ] `cargo test` in `apps/server/` against a live PostgreSQL instance
- [ ] `sqlx migrate run` and `sqlx migrate revert` against a fresh DB
- [ ] `docker compose up` — verify PowerSync starts healthy with sync_rules loaded (FA-010)
- [ ] Verify no cross-user data in sync streams (FA-011)