### PR TITLE
Close Wave 0: CI workflow and a one-command local test task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      # Matches compose.yaml. Set directly rather than via .env so the
+      # workflow has no dependency on the gitignored local override file.
+      DATABASE_URL: postgres://postgres:altair@localhost:5432/altair
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+      - uses: Swatinem/rust-cache@v2
+      - run: docker compose up -d --wait
+      - run: cargo test --workspace
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+      - uses: Swatinem/rust-cache@v2
+      # Runs the same hooks configured in .pre-commit-config.yaml, so CI and
+      # the local pre-commit path can never drift apart.
+      - run: prek run --all-files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,9 @@ Rules that follow from this and are easy to violate:
 
 ## Documents that are already accepted as artefacts
 
-- `docs/altair-schema.sql` — the structured store, adopted as **migration one**. Applied and exercised on PostgreSQL 18.6 with pgvector 0.8.6. Do not re-derive it.
-- `docs/altair.proto` — the public interface (`package altair.v1`). **Field numbers are permanent; removed fields are reserved, never reused.** Closing one of its recorded gaps means adding a field, not editing one.
-- `docs/altair-outbox-conformance.md` — the outbox specification made executable, written once and run against every implementation (Rust and Kotlin). Scenarios observe behaviour at two boundaries only: what the person sees, and what reaches the instance.
+- `crates/altaird/migrations/0001_initial.sql` — the structured store, adopted as **migration one**. Applied and exercised on PostgreSQL 18.6 with pgvector 0.8.6. Do not re-derive it.
+- `proto/altair/v1/altair.proto` — the public interface (`package altair.v1`). **Field numbers are permanent; removed fields are reserved, never reused.** Closing one of its recorded gaps means adding a field, not editing one.
+- `conformance/scenarios.md` — the outbox specification made executable, written once and run against every implementation (Rust and Kotlin). Scenarios observe behaviour at two boundaries only: what the person sees, and what reaches the instance.
 
 ## Architecture in one pass
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 "github:akiomik/mado" = "latest"
 prek = "latest"
-rust = "latest"
+rust = { version = "latest", profile = "default" }
 rust-analyzer = "latest"
 
 [tasks.test]

--- a/mise.toml
+++ b/mise.toml
@@ -3,3 +3,7 @@
 prek = "latest"
 rust = "latest"
 rust-analyzer = "latest"
+
+[tasks.test]
+description = "Bring up Postgres and run the workspace test suite"
+run = "docker compose up -d --wait && cargo test --workspace"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml`: a `test` job that reuses `compose.yaml` for Postgres (rather than duplicating the pgvector image/config into workflow YAML) and runs `cargo test --workspace`, plus a `lint` job that runs `prek run --all-files` so CI enforces exactly the hooks already configured in `.pre-commit-config.yaml`.
- Adds `mise run test` (`docker compose up -d --wait && cargo test --workspace`) so a fresh checkout has the single command Wave 0's "done when" criterion calls for.
- Fixes three stale `docs/` paths in CLAUDE.md's "already accepted as artefacts" list — `altair-schema.sql`, `altair.proto`, and the outbox conformance scenarios all moved out of `docs/` into their implementation locations while building Wave 0, but the doc still pointed at the old paths.

This closes the last open item in Wave 0 · Plumbing (workspace/codegen, migration runner, integration harness, and now CI were the four listed outcomes).

## Test plan

- [x] `mise run test` passes locally (Postgres up via compose, `cargo test --workspace` green: 3 tests across `altair-proto` and `altaird`)
- [x] `prek run --all-files` passes locally (all hooks green, including `cargo fmt`, `cargo clippy -D warnings`, `mado`)
- [ ] CI run on this PR green

🤖 Generated with [Claude Code](https://claude.com/claude-code)