### PR TITLE
Scope the Claude review to review moments, and guard the loop

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,26 +2,40 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # Deliberately NOT `synchronize`. That fires on every push, so a branch
+    # rebased or fixed up five times is reviewed five times, and it is also the
+    # edge a review-to-push loop would run around. Review happens when a pull
+    # request is put forward for review, and afterwards on request by commenting
+    # `@claude` on it.
+    types: [opened, ready_for_review, reopened]
+
+# One review per pull request at a time. A rapid open-then-ready sequence
+# supersedes rather than stacks.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Drafts are opened early on purpose here (see CLAUDE.md on GitHub Flow),
+    # so reviewing them on arrival would spend a review on work that is
+    # knowingly unfinished. `ready_for_review` above is the moment that counts.
+    #
+    # The actor check is the loop guard. It is redundant while this workflow can
+    # only comment and `claude.yml` cannot push, and it is what stops a loop
+    # forming if either of those ever changes.
+    if: |
+      github.event.pull_request.draft == false
+      && github.actor != 'claude[bot]'
+      && github.actor != 'github-actions[bot]'
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      # write, not read: the prompt below posts inline review comments, and
+      # read lets the review run to completion and then silently fail to
+      # deliver it.
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -42,4 +56,3 @@ jobs:
           claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,23 @@ on:
 
 jobs:
   claude:
+    # Every branch requires a human author. Without that, a review comment or
+    # issue body that happens to contain the mention re-triggers this workflow,
+    # which is the first half of a loop; the second half arrives the day this
+    # job is granted `contents: write` so it can push fixes.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment'
+        && github.event.comment.user.type != 'Bot'
+        && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment'
+        && github.event.comment.user.type != 'Bot'
+        && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review'
+        && github.event.review.user.type != 'Bot'
+        && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues'
+        && github.event.issue.user.type != 'Bot'
+        && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,4 +59,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-


### PR DESCRIPTION
Follow-up to #4. Two problems, one active and one latent.

## The review cannot post what it produces

The prompt is `/code-review:code-review --comment ...` and `create_inline_comment` is the one allowed tool — but the job grants `pull-requests: read`. It runs to completion, does the whole review, and then fails at delivery.

Raised to `pull-requests: write`.

## It ran on every push

`types: [opened, synchronize, ready_for_review, reopened]` — `synchronize` fires on **every push to the branch**. A PR that gets rebased or fixed up five times is reviewed five times, at full cost each.

That is immediate, not hypothetical: Wave 1 is five lanes, each of which will be rebased onto `main` at least once and revised after review findings.

Now: `opened`, `ready_for_review`, `reopened`. Re-review on demand by commenting `@claude` on the PR. Drafts are skipped — CLAUDE.md's GitHub Flow section says to open PRs early and knowingly unfinished, so reviewing on arrival spends a review on work that is not ready. `ready_for_review` is the moment that counts.

Added a `concurrency` group keyed on the PR number with `cancel-in-progress`, so open-then-ready supersedes rather than stacks.

## The loop, which is latent rather than active

Worth stating precisely, because the fix looks like superstition otherwise.

**Nothing loops today.** The review workflow can only comment; `claude.yml` has `contents: read` and cannot push; no push means no `synchronize` event.

**It arms the day `claude.yml` gets `contents: write`** so `@claude` can push fixes:

```
push → synchronize → review runs → posts inline comment
     → comment contains "@claude" → claude.yml → pushes → synchronize → …
```

GitHub's built-in re-trigger suppression does **not** protect against this. That suppression only applies to pushes authenticated with `GITHUB_TOKEN`, and `claude-code-action` authenticates as a GitHub App.

Both ends are guarded now rather than after someone gets a surprise bill:

- **This workflow** skips when `github.actor` is `claude[bot]` or `github-actions[bot]`.
- **`claude.yml`** requires `user.type != 'Bot'` on all four trigger branches, so a bot-authored comment containing the mention no longer re-enters it.

Removing `synchronize` already breaks the cycle on its own. The actor checks are the belt to that braces — they are what keeps it broken if someone later restores `synchronize` or grants write access without re-deriving this analysis.

## Verification

All three workflow files parse:

```
$ python3 -c "import yaml; [yaml.safe_load(open(f)) for f in [...]]"
all three parse
```

Trigger behaviour is not verifiable before merge — by construction, it takes a subsequent PR to observe. This PR is itself the first test: it should draw exactly one review on open, and none on any later push to it.