### PR TITLE
Wave 1.1: write the audience predicate once, and make both paths go through it

### DIFF
--- a/crates/altaird/src/store/audience.rs
+++ b/crates/altaird/src/store/audience.rs
@@ -16,20 +16,26 @@
 //! household can see this" — and from the schema, where `audience_member_ids`
 //! is an enumerated `uuid[]` whose empty default means private to the author.
 //!
-//! Four things it deliberately does not do:
+//! **An unattributed entity is visible to nobody, and the predicate says so
+//! itself.** The leading `author_member_id IS NOT NULL` is not redundant. The
+//! substrate is clear that an entity captured before its device was bound
+//! "has none and cannot be shared", but the schema does not tie the two
+//! columns together, so a row with a null author and a populated audience is
+//! representable. Without the guard, `$1 = ANY (audience)` would admit it, and
+//! the closed answer would depend on a write-path invariant this layer cannot
+//! see. It is one conjunct, it fails closed, and it makes the claim true here
+//! rather than two components away. Nothing may be softened into `COALESCE` or
+//! `IS NOT DISTINCT FROM`.
 //!
-//! - **It does not treat a null author as visible.** An entity captured before
-//!   its device was bound has no author yet, and the substrate says an
-//!   unattributed entity "has none and cannot be shared". `NULL = $1` is NULL
-//!   rather than true, so such a row is visible to nobody until binding gives
-//!   it an author. That is the intended answer and it is also the closed one,
-//!   so the failure mode of this expression is silence rather than a leak.
-//!   Nothing here may be softened into `COALESCE` or `IS NOT DISTINCT FROM`.
+//! Three things it deliberately does not do:
+//!
 //! - **It does not consult lifecycle.** See [`LifecycleScope`].
 //! - **It does not consult `membership.administrator`.** The architecture is
 //!   explicit that the flag "does not touch audience, and an administrator does
 //!   not see another member's private entities".
-//! - **It does not re-check participation.** See [`MemberId`].
+//! - **It does not re-check participation.** That is checked once, where the
+//!   member is resolved; see [`MemberId`] for what is and is not enforced
+//!   about that.
 //!
 //! # Why it is a fragment and not a filter
 //!
@@ -56,7 +62,7 @@ use super::ids::MemberId;
 /// by binding it first and starting every other bind at `$2`.
 ///
 /// `e` is the fixed alias for `entity`.
-const AUDIENCE_PREDICATE: &str = "(e.author_member_id = $1 OR $1 = ANY (e.audience_member_ids))";
+const AUDIENCE_PREDICATE: &str = "(e.author_member_id IS NOT NULL AND (e.author_member_id = $1 OR $1 = ANY (e.audience_member_ids)))";
 
 /// The column's name, and the only spelling of it in the tree.
 ///
@@ -104,6 +110,10 @@ pub fn predicate_sql() -> &'static str {
 /// being enforced.
 ///
 /// There is no default. Every caller states which it means.
+///
+/// This is the unrestricted primitive, because [`CandidateQuery`] is. The two
+/// path-shaped functions in [`super::entity`] do not accept it: they take
+/// [`ReadScope`] and [`WriteScope`], which differ by exactly one variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LifecycleScope {
     /// Ordinary surfaces: lists, search, traversal.
@@ -112,9 +122,62 @@ pub enum LifecycleScope {
     Holding,
     /// Active or deleted. Everything that still has content.
     Extant,
-    /// Including tombstones. The write path needs this to tell a recreation
-    /// from a create; a read surface almost certainly does not.
+    /// Including tombstones.
     AnyIncludingErased,
+}
+
+/// What a read surface may ask for. **There is no erased variant, and that is
+/// the point.**
+///
+/// A tombstone is a row whose content the write path has stripped, retained so
+/// that an edit arriving from a device that was away is recognisable as a
+/// recreation and so the change sequence can say the entity is gone. Neither
+/// is a reading. Nothing on the read path has a use for one, and until Wave 2
+/// implements stripping, a tombstone still carries its title — so a read
+/// surface that could ask for one would be reading content somebody erased.
+///
+/// Spelling the variant awkwardly was a hint. Removing it from the type the
+/// read path accepts is a control.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadScope {
+    Active,
+    Holding,
+    Extant,
+}
+
+/// What the write path may ask for.
+///
+/// It differs from [`ReadScope`] by [`WriteScope::AnyIncludingErased`], which
+/// the write path genuinely needs: deciding whether an arriving edit is a
+/// recreation rather than a create means finding the tombstone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteScope {
+    Active,
+    Holding,
+    Extant,
+    /// Reaches tombstones. For the recreation check, and nothing else.
+    AnyIncludingErased,
+}
+
+impl From<ReadScope> for LifecycleScope {
+    fn from(s: ReadScope) -> Self {
+        match s {
+            ReadScope::Active => Self::Active,
+            ReadScope::Holding => Self::Holding,
+            ReadScope::Extant => Self::Extant,
+        }
+    }
+}
+
+impl From<WriteScope> for LifecycleScope {
+    fn from(s: WriteScope) -> Self {
+        match s {
+            WriteScope::Active => Self::Active,
+            WriteScope::Holding => Self::Holding,
+            WriteScope::Extant => Self::Extant,
+            WriteScope::AnyIncludingErased => Self::AnyIncludingErased,
+        }
+    }
 }
 
 impl LifecycleScope {
@@ -144,10 +207,17 @@ pub enum Bind {
 /// no sequence of calls on this type that produces a query over `entity`
 /// without the predicate in it.
 ///
-/// The select list and any added fragment are caller-supplied SQL. This type
-/// cannot stop someone writing a second `FROM entity` inside a subquery there;
-/// the one-place test is what stops that, by refusing any other file that names
-/// the audience column.
+/// The select list and any added fragment are caller-supplied SQL, so the
+/// obvious escape is a second, unscoped reference to `entity` — a `UNION ALL
+/// SELECT … FROM entity e2` in a tail, or a subquery in the projection. Two
+/// things close that: [`CandidateQuery::render`] refuses a fragment that names
+/// the table again, and `tests/one_predicate.rs` refuses any source outside
+/// `store/` that does. A second reference to `entity` is a second candidate
+/// set, and it needs its own `CandidateQuery`.
+///
+/// Neither is a sandbox. Caller-supplied SQL can always be bent by someone
+/// determined; these stop the mistake, which is the thing that actually
+/// happens.
 pub struct CandidateQuery {
     sql: String,
     member: Uuid,
@@ -157,6 +227,10 @@ pub struct CandidateQuery {
 impl CandidateQuery {
     /// `select_list` is the projection, written against the alias `e`.
     pub fn new(member: MemberId, lifecycle: LifecycleScope, select_list: &str) -> Self {
+        // The projection is the other place a second, unscoped reference to
+        // `entity` fits.
+        Self::refuse_raw_placeholders(select_list);
+        Self::refuse_a_second_entity_reference(select_list);
         let sql = format!(
             "SELECT {select_list} FROM entity e WHERE {AUDIENCE_PREDICATE} AND {}",
             lifecycle.sql()
@@ -173,9 +247,11 @@ impl CandidateQuery {
     ///
     /// # Panics
     ///
-    /// If the number of `$?` markers does not match the number of binds. That
-    /// is a programming error in a string literal, and a mismatch would
-    /// otherwise surface as a runtime type error far from its cause.
+    /// If the number of `$?` markers does not match the number of binds, if
+    /// the fragment writes a raw `$1`-style position, or if it names the
+    /// `entity` table again. Each is a programming error in a string literal,
+    /// and each would otherwise surface as a wrong answer or as a runtime
+    /// error far from its cause.
     pub fn and_where(mut self, condition: &str, binds: impl IntoIterator<Item = Bind>) -> Self {
         let (rendered, binds) = self.render(condition, binds);
         self.sql.push_str(" AND ");
@@ -184,9 +260,53 @@ impl CandidateQuery {
         self
     }
 
+    /// A caller writes `$?` and never `$1`. Position `$1` is the requesting
+    /// member, so `.and_where("e.author_member_id = $1", [])` would compile,
+    /// run, and quietly compare against the requester — a wrong answer rather
+    /// than an error. A higher raw position is merely unbound and fails at
+    /// execution, a long way from the literal that caused it. Both are refused
+    /// here, at the mistake.
+    fn refuse_raw_placeholders(fragment: &str) {
+        let mut rest = fragment;
+        while let Some(at) = rest.find('$') {
+            let after = &rest[at + 1..];
+            assert!(
+                !after.starts_with(|c: char| c.is_ascii_digit()),
+                "fragment writes a raw positional parameter: {fragment:?}. \
+                 Write `$?` and pass the value as a bind; positions are \
+                 assigned here because `$1` is always the requesting member."
+            );
+            rest = after;
+        }
+    }
+
+    /// A fragment naming `entity` again is a second candidate set, and nothing
+    /// in this builder would put the audience predicate on it. It needs its
+    /// own `CandidateQuery`, whose constructor does.
+    fn refuse_a_second_entity_reference(fragment: &str) {
+        let flat = fragment.to_ascii_lowercase();
+        let flat: String = flat.split_whitespace().collect::<Vec<_>>().join(" ");
+        for shape in [
+            "from entity",
+            "join entity",
+            "from public.entity",
+            "join public.entity",
+        ] {
+            assert!(
+                !flat.contains(shape),
+                "fragment names the entity table again ({shape:?}): {fragment:?}. \
+                 A second reference to `entity` is a second candidate set and \
+                 carries no audience predicate. Build it as its own \
+                 CandidateQuery."
+            );
+        }
+    }
+
     /// Substitutes `$?` for the positions these binds will occupy. `$1` is the
     /// member, so the first substitution here is `$2`.
     fn render(&self, fragment: &str, binds: impl IntoIterator<Item = Bind>) -> (String, Vec<Bind>) {
+        Self::refuse_raw_placeholders(fragment);
+        Self::refuse_a_second_entity_reference(fragment);
         let binds: Vec<Bind> = binds.into_iter().collect();
         let mut rendered = String::with_capacity(fragment.len());
         let mut used = 0usize;

--- a/crates/altaird/src/store/audience.rs
+++ b/crates/altaird/src/store/audience.rs
@@ -1,0 +1,246 @@
+//! The audience predicate. **This file is the only place it exists.**
+//!
+//! `tests/one_predicate.rs` walks the crates and fails if a second copy
+//! appears, including a paraphrased one, because it also refuses any other
+//! Rust or SQL source that names the audience column at all. Read that test
+//! before adding a query over `entity` anywhere.
+//!
+//! # What the predicate says
+//!
+//! An entity is visible to a member if that member authored it or is named in
+//! its audience. The SQL is `AUDIENCE_PREDICATE` below and is not reproduced
+//! here, because a copy in a doc comment is a copy that can drift.
+//!
+//! Derived from the substrate specification's *Audience* section — "audience
+//! attaches to the entity and answers exactly one question: who in the
+//! household can see this" — and from the schema, where `audience_member_ids`
+//! is an enumerated `uuid[]` whose empty default means private to the author.
+//!
+//! Four things it deliberately does not do:
+//!
+//! - **It does not treat a null author as visible.** An entity captured before
+//!   its device was bound has no author yet, and the substrate says an
+//!   unattributed entity "has none and cannot be shared". `NULL = $1` is NULL
+//!   rather than true, so such a row is visible to nobody until binding gives
+//!   it an author. That is the intended answer and it is also the closed one,
+//!   so the failure mode of this expression is silence rather than a leak.
+//!   Nothing here may be softened into `COALESCE` or `IS NOT DISTINCT FROM`.
+//! - **It does not consult lifecycle.** See [`LifecycleScope`].
+//! - **It does not consult `membership.administrator`.** The architecture is
+//!   explicit that the flag "does not touch audience, and an administrator does
+//!   not see another member's private entities".
+//! - **It does not re-check participation.** See [`MemberId`].
+//!
+//! # Why it is a fragment and not a filter
+//!
+//! The standing constraint is that the predicate sits *inside* the query that
+//! produces candidates, on every path including similarity, and is never
+//! applied to rows after they come back. Post-filtering both leaks and gets
+//! limits wrong: trimming a fixed-size candidate set can empty a result that
+//! had matches the person was entitled to (DR-002).
+//!
+//! [`CandidateQuery`] is therefore the only way this layer will build a query
+//! over `entity`, and its constructor emits the predicate. There is no
+//! constructor that omits it and no method that removes it.
+
+use sqlx::AssertSqlSafe;
+use sqlx::postgres::Postgres;
+use sqlx::query::Query;
+use uuid::Uuid;
+
+use super::ids::MemberId;
+
+/// The audience predicate.
+///
+/// `$1` is the requesting member, always. [`CandidateQuery`] guarantees that
+/// by binding it first and starting every other bind at `$2`.
+///
+/// `e` is the fixed alias for `entity`.
+const AUDIENCE_PREDICATE: &str = "(e.author_member_id = $1 OR $1 = ANY (e.audience_member_ids))";
+
+/// The column's name, and the only spelling of it in the tree.
+///
+/// Selecting and writing the column are both legitimate — the write path owes
+/// `audience_before` and `audience_after` to the change sequence — but from
+/// outside a file they are indistinguishable from a second copy of the
+/// predicate, and the test that keeps this module honest cannot tell them
+/// apart either. So anything that must name the column takes the name from
+/// here, and the test can then insist that no other source spells it out.
+///
+/// Cheap, and it makes "the predicate is written once" a fact about the whole
+/// repository rather than about the files somebody remembered to check.
+pub const AUDIENCE_COLUMN: &str = "audience_member_ids";
+
+/// The predicate's SQL, for the test that asserts it exists exactly once.
+///
+/// Nothing else should call this. Building a query from the string by hand is
+/// the thing this module exists to prevent; use [`CandidateQuery`].
+pub fn predicate_sql() -> &'static str {
+    AUDIENCE_PREDICATE
+}
+
+/// Which lifecycle states a query is asking about.
+///
+/// **Lifecycle is not part of the audience predicate, and this type is the
+/// evidence that the separation is deliberate.** Three things in the substrate
+/// force it:
+///
+/// - A deleted entity goes to a holding state where it "remain[s] listed
+///   somewhere the user can go and look, and restoring is a single action". A
+///   surface that lists it has to be writable without escaping the audience
+///   predicate — which it could not be if the predicate had already excluded
+///   deleted rows.
+/// - An edit arriving for an erased entity is a *recreation*, not a create.
+///   The write path can only tell those apart by finding the tombstone, so the
+///   tombstone has to be reachable.
+/// - DR-002 names lifecycle as its own thing: "a relation record surviving the
+///   deletion of an endpoint is a predicate on that endpoint's lifecycle
+///   state".
+///
+/// So audience answers *who may see this at all*, permanently; lifecycle
+/// answers *which surface shows it now*. Folding the second into the first
+/// would produce a predicate that has to be bypassed to build the holding list
+/// and the recreation check, and a predicate with two legitimate bypasses stops
+/// being enforced.
+///
+/// There is no default. Every caller states which it means.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecycleScope {
+    /// Ordinary surfaces: lists, search, traversal.
+    Active,
+    /// The holding state a deleted entity sits in until the window expires.
+    Holding,
+    /// Active or deleted. Everything that still has content.
+    Extant,
+    /// Including tombstones. The write path needs this to tell a recreation
+    /// from a create; a read surface almost certainly does not.
+    AnyIncludingErased,
+}
+
+impl LifecycleScope {
+    fn sql(self) -> &'static str {
+        match self {
+            Self::Active => "e.lifecycle = 'active'",
+            Self::Holding => "e.lifecycle = 'deleted'",
+            Self::Extant => "e.lifecycle <> 'erased'",
+            Self::AnyIncludingErased => "TRUE",
+        }
+    }
+}
+
+/// A value bound into a candidate query after the member.
+#[derive(Debug, Clone)]
+pub enum Bind {
+    Uuid(Uuid),
+    Text(String),
+    Int(i64),
+    Bool(bool),
+}
+
+/// A query over `entity` that carries the audience predicate by construction.
+///
+/// The constructor emits `FROM entity e WHERE <audience predicate> AND
+/// <lifecycle>`. Everything a caller adds is conjoined onto that, so there is
+/// no sequence of calls on this type that produces a query over `entity`
+/// without the predicate in it.
+///
+/// The select list and any added fragment are caller-supplied SQL. This type
+/// cannot stop someone writing a second `FROM entity` inside a subquery there;
+/// the one-place test is what stops that, by refusing any other file that names
+/// the audience column.
+pub struct CandidateQuery {
+    sql: String,
+    member: Uuid,
+    binds: Vec<Bind>,
+}
+
+impl CandidateQuery {
+    /// `select_list` is the projection, written against the alias `e`.
+    pub fn new(member: MemberId, lifecycle: LifecycleScope, select_list: &str) -> Self {
+        let sql = format!(
+            "SELECT {select_list} FROM entity e WHERE {AUDIENCE_PREDICATE} AND {}",
+            lifecycle.sql()
+        );
+        Self {
+            sql,
+            member: member.as_uuid(),
+            binds: Vec::new(),
+        }
+    }
+
+    /// Conjoins another condition. Write `$?` for each bound value; positions
+    /// are assigned here, starting at `$2`, because `$1` is the member.
+    ///
+    /// # Panics
+    ///
+    /// If the number of `$?` markers does not match the number of binds. That
+    /// is a programming error in a string literal, and a mismatch would
+    /// otherwise surface as a runtime type error far from its cause.
+    pub fn and_where(mut self, condition: &str, binds: impl IntoIterator<Item = Bind>) -> Self {
+        let (rendered, binds) = self.render(condition, binds);
+        self.sql.push_str(" AND ");
+        self.sql.push_str(&rendered);
+        self.binds.extend(binds);
+        self
+    }
+
+    /// Substitutes `$?` for the positions these binds will occupy. `$1` is the
+    /// member, so the first substitution here is `$2`.
+    fn render(&self, fragment: &str, binds: impl IntoIterator<Item = Bind>) -> (String, Vec<Bind>) {
+        let binds: Vec<Bind> = binds.into_iter().collect();
+        let mut rendered = String::with_capacity(fragment.len());
+        let mut used = 0usize;
+        let mut rest = fragment;
+        while let Some(at) = rest.find("$?") {
+            rendered.push_str(&rest[..at]);
+            used += 1;
+            rendered.push_str(&format!("${}", self.binds.len() + used + 1));
+            rest = &rest[at + 2..];
+        }
+        rendered.push_str(rest);
+        assert_eq!(
+            used,
+            binds.len(),
+            "fragment has {used} placeholders and {} binds",
+            binds.len()
+        );
+        (rendered, binds)
+    }
+
+    /// Appends trailing SQL that is not a condition: `ORDER BY`, `LIMIT`,
+    /// `FOR UPDATE`. Same `$?` convention.
+    ///
+    /// # Panics
+    ///
+    /// As [`CandidateQuery::and_where`].
+    pub fn tail(mut self, sql: &str, binds: impl IntoIterator<Item = Bind>) -> Self {
+        let (rendered, binds) = self.render(sql, binds);
+        self.sql.push(' ');
+        self.sql.push_str(&rendered);
+        self.binds.extend(binds);
+        self
+    }
+
+    /// The assembled SQL. For diagnostics and for tests.
+    pub fn sql(&self) -> &str {
+        &self.sql
+    }
+
+    /// The query, with the member bound as `$1` and everything else after it.
+    pub fn build(&self) -> Query<'_, Postgres, sqlx::postgres::PgArguments> {
+        // Audited, which is what `AssertSqlSafe` asks for: every part of this
+        // string is either a constant in this file or a fragment a caller
+        // wrote as a literal. No value reaches it — values are bound, and
+        // `$?` is substituted for a position, never for content.
+        let mut q = sqlx::query(AssertSqlSafe(self.sql.clone())).bind(self.member);
+        for b in &self.binds {
+            q = match b {
+                Bind::Uuid(v) => q.bind(*v),
+                Bind::Text(v) => q.bind(v.as_str()),
+                Bind::Int(v) => q.bind(*v),
+                Bind::Bool(v) => q.bind(*v),
+            };
+        }
+        q
+    }
+}

--- a/crates/altaird/src/store/entity.rs
+++ b/crates/altaird/src/store/entity.rs
@@ -6,8 +6,8 @@
 use sqlx::Row;
 use sqlx::postgres::PgRow;
 
-use super::audience::{AUDIENCE_COLUMN, Bind, CandidateQuery, LifecycleScope};
-use super::ids::{EntityId, MemberId};
+use super::audience::{AUDIENCE_COLUMN, Bind, CandidateQuery, ReadScope, WriteScope};
+use super::ids::{EntityId, MemberId, MemberRef};
 use super::tx::{ReadTx, WriteTx};
 
 /// The shared model, as much of it as lives on the `entity` row itself.
@@ -17,10 +17,15 @@ pub struct EntityRow {
     pub entity_type: EntityType,
     pub title: Option<String>,
     /// Absent on an entity captured before its device was bound. Such a row is
-    /// visible to nobody until binding gives it one.
-    pub author: Option<MemberId>,
-    /// Who else can see it. Empty is private to the author.
-    pub audience: Vec<MemberId>,
+    /// visible to nobody until binding gives it one, which the predicate
+    /// enforces itself.
+    ///
+    /// A [`MemberRef`] rather than a [`MemberId`]: an author may since have
+    /// departed, and the value carries no claim that they still participate.
+    pub author: Option<MemberRef>,
+    /// Who else can see it. Empty is private to the author. Entries survive
+    /// departure, so these too are references and not requesters.
+    pub audience: Vec<MemberRef>,
     pub lifecycle: LifecycleState,
     /// Advances on every accepted write. Never shown to anyone.
     pub counter: i64,
@@ -67,11 +72,11 @@ fn row(r: &PgRow) -> sqlx::Result<EntityRow> {
         title: r.try_get("title")?,
         author: r
             .try_get::<Option<uuid::Uuid>, _>("author_member_id")?
-            .map(MemberId::from_uuid),
+            .map(MemberRef::from_uuid),
         audience: r
             .try_get::<Vec<uuid::Uuid>, _>("audience")?
             .into_iter()
-            .map(MemberId::from_uuid)
+            .map(MemberRef::from_uuid)
             .collect(),
         lifecycle: r.try_get("lifecycle")?,
         counter: r.try_get("counter")?,
@@ -89,16 +94,17 @@ fn row(r: &PgRow) -> sqlx::Result<EntityRow> {
 /// them here would put the distinction one `match` away from the wire.
 ///
 /// `lifecycle` is stated by the caller because the write path means different
-/// things at different moments: an edit is [`LifecycleScope::Active`], a
-/// restore is [`LifecycleScope::Holding`], and deciding whether an arriving
-/// edit is a recreation needs [`LifecycleScope::AnyIncludingErased`].
+/// things at different moments: an edit is [`WriteScope::Active`], a restore is
+/// [`WriteScope::Holding`], and deciding whether an arriving edit is a
+/// recreation needs [`WriteScope::AnyIncludingErased`]. That last variant does
+/// not exist on [`ReadScope`], so no read surface can ask for a tombstone.
 pub async fn available_for_write(
     tx: &mut WriteTx,
     member: MemberId,
     id: EntityId,
-    lifecycle: LifecycleScope,
+    lifecycle: WriteScope,
 ) -> sqlx::Result<Option<EntityRow>> {
-    let q = CandidateQuery::new(member, lifecycle, &columns())
+    let q = CandidateQuery::new(member, lifecycle.into(), &columns())
         .and_where("e.id = $?", [Bind::Uuid(id.as_uuid())]);
     let found = q.build().fetch_optional(tx.conn()).await?;
     found.as_ref().map(row).transpose()
@@ -114,10 +120,10 @@ pub async fn available_for_write(
 pub async fn candidates(
     tx: &mut ReadTx,
     member: MemberId,
-    lifecycle: LifecycleScope,
+    lifecycle: ReadScope,
     limit: i64,
 ) -> sqlx::Result<Vec<EntityRow>> {
-    let q = CandidateQuery::new(member, lifecycle, &columns()).tail(
+    let q = CandidateQuery::new(member, lifecycle.into(), &columns()).tail(
         "ORDER BY e.created_at DESC, e.id LIMIT $?",
         [Bind::Int(limit)],
     );

--- a/crates/altaird/src/store/entity.rs
+++ b/crates/altaird/src/store/entity.rs
@@ -1,0 +1,126 @@
+//! The shared entity query surface, in the two shapes the paths need.
+//!
+//! Both go through [`CandidateQuery`], so both carry the same audience
+//! predicate, and there is no third shape that does not.
+
+use sqlx::Row;
+use sqlx::postgres::PgRow;
+
+use super::audience::{AUDIENCE_COLUMN, Bind, CandidateQuery, LifecycleScope};
+use super::ids::{EntityId, MemberId};
+use super::tx::{ReadTx, WriteTx};
+
+/// The shared model, as much of it as lives on the `entity` row itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntityRow {
+    pub id: EntityId,
+    pub entity_type: EntityType,
+    pub title: Option<String>,
+    /// Absent on an entity captured before its device was bound. Such a row is
+    /// visible to nobody until binding gives it one.
+    pub author: Option<MemberId>,
+    /// Who else can see it. Empty is private to the author.
+    pub audience: Vec<MemberId>,
+    pub lifecycle: LifecycleState,
+    /// Advances on every accepted write. Never shown to anyone.
+    pub counter: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type)]
+#[sqlx(type_name = "entity_type", rename_all = "snake_case")]
+pub enum EntityType {
+    Campaign,
+    Arc,
+    Quest,
+    Routine,
+    FocusSession,
+    CheckIn,
+    Note,
+    File,
+    Item,
+    Location,
+    ShoppingList,
+    Category,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type)]
+#[sqlx(type_name = "lifecycle_state", rename_all = "snake_case")]
+pub enum LifecycleState {
+    Active,
+    Deleted,
+    Erased,
+}
+
+/// The projection every read here uses. Built through [`AUDIENCE_COLUMN`] so
+/// that the audience column is named in exactly one file.
+fn columns() -> String {
+    format!(
+        "e.id, e.type AS entity_type, e.title, e.author_member_id, \
+         e.{AUDIENCE_COLUMN} AS audience, e.lifecycle, e.counter"
+    )
+}
+
+fn row(r: &PgRow) -> sqlx::Result<EntityRow> {
+    Ok(EntityRow {
+        id: r.try_get("id")?,
+        entity_type: r.try_get("entity_type")?,
+        title: r.try_get("title")?,
+        author: r
+            .try_get::<Option<uuid::Uuid>, _>("author_member_id")?
+            .map(MemberId::from_uuid),
+        audience: r
+            .try_get::<Vec<uuid::Uuid>, _>("audience")?
+            .into_iter()
+            .map(MemberId::from_uuid)
+            .collect(),
+        lifecycle: r.try_get("lifecycle")?,
+        counter: r.try_get("counter")?,
+    })
+}
+
+/// **The write path's shape.** The entity this member is entitled to act on.
+///
+/// `None` is the only refusal, and it covers both "no such entity" and "not
+/// visible to this member". The caller cannot tell them apart, which is
+/// deliberate and is why they are not two variants: the component model
+/// requires that "a write naming an entity the submitting member cannot see is
+/// refused exactly as a write naming an entity that does not exist is refused",
+/// and the schema gives both one `refusal_reason`, `not_available`. Splitting
+/// them here would put the distinction one `match` away from the wire.
+///
+/// `lifecycle` is stated by the caller because the write path means different
+/// things at different moments: an edit is [`LifecycleScope::Active`], a
+/// restore is [`LifecycleScope::Holding`], and deciding whether an arriving
+/// edit is a recreation needs [`LifecycleScope::AnyIncludingErased`].
+pub async fn available_for_write(
+    tx: &mut WriteTx,
+    member: MemberId,
+    id: EntityId,
+    lifecycle: LifecycleScope,
+) -> sqlx::Result<Option<EntityRow>> {
+    let q = CandidateQuery::new(member, lifecycle, &columns())
+        .and_where("e.id = $?", [Bind::Uuid(id.as_uuid())]);
+    let found = q.build().fetch_optional(tx.conn()).await?;
+    found.as_ref().map(row).transpose()
+}
+
+/// **The read path's shape.** Candidates, with the predicate inside the query
+/// that produced them.
+///
+/// Wave 3 adds the literal arm's matching to this; the ordering is already
+/// deterministic with a stable tiebreak because "the same query over the same
+/// data produces byte-identical ordering" is that lane's done-when and an
+/// order that varies between members is on the read path's `Never` list.
+pub async fn candidates(
+    tx: &mut ReadTx,
+    member: MemberId,
+    lifecycle: LifecycleScope,
+    limit: i64,
+) -> sqlx::Result<Vec<EntityRow>> {
+    let q = CandidateQuery::new(member, lifecycle, &columns()).tail(
+        "ORDER BY e.created_at DESC, e.id LIMIT $?",
+        [Bind::Int(limit)],
+    );
+    let rows = q.build().fetch_all(tx.conn()).await?;
+    rows.iter().map(row).collect()
+}

--- a/crates/altaird/src/store/ids.rs
+++ b/crates/altaird/src/store/ids.rs
@@ -8,31 +8,104 @@
 
 use uuid::Uuid;
 
-/// A household member, as the instance has already established them.
+/// A household member, as the instance has already resolved them.
 ///
-/// **Constructing one is an assertion.** It says the caller has resolved this
-/// member from a validated token and that the membership *currently
-/// participates* in the household — that is, it has not departed. The substrate
-/// puts it plainly: an audience entry "confers nothing by itself. Access
-/// follows current participation."
+/// # What this type does and does not enforce
 ///
-/// Participation is therefore checked once, where the member is resolved, and
-/// not inside the audience predicate. It is a fact about the requester, not
-/// about the row, so it is constant across every candidate in a query; joining
-/// `membership` into every candidate query to re-answer it would pay per row
-/// for a check that cannot vary, and would be a second place the rule could be
-/// forgotten.
+/// The audience predicate deliberately does not check `membership.departed_at`,
+/// because participation is a fact about the *requester* — constant across
+/// every candidate in a query — rather than about the row. Re-answering it per
+/// candidate would pay for a value that cannot vary, and would be a second
+/// place the rule can be forgotten. The substrate is what requires it at all:
+/// an audience entry "confers nothing by itself. Access follows current
+/// participation."
+///
+/// So something has to establish participation before a `MemberId` exists, and
+/// this type is the marker that something did. **What the compiler enforces is
+/// that the marker cannot be minted outside this crate:**
+/// [`MemberId::assert_participating`] is crate-visible, so the set of places
+/// that can produce one is the set of modules in `altaird`, which is small and
+/// greppable. The public API offers no way to construct one at all.
+///
+/// **What the compiler does not enforce is that any given call is correct.**
+/// The name says `assert` because that is what a call site is doing. Within the
+/// crate, exactly one caller should be right: the path that resolves a
+/// validated token's subject to a membership row and filters
+/// `departed_at IS NULL`. Anything else minting one is a bug, and this doc is
+/// the only thing that says so.
+///
+/// An earlier version of this comment claimed the type carried the assertion.
+/// It did not — the constructor was public and took a bare `Uuid` — and the
+/// composed system was correct only because token validation independently
+/// filtered departed members. That is worth recording rather than quietly
+/// fixing, because the failure was a doc comment describing a guarantee nobody
+/// had built.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MemberId(Uuid);
 
 impl MemberId {
-    /// The caller asserts this membership exists and currently participates.
+    /// The caller asserts this membership exists and currently participates in
+    /// the household.
+    ///
+    /// Crate-visible on purpose. Callers outside `altaird` have no route to a
+    /// `MemberId`, so they cannot address the audience predicate at all.
+    // Unused until the token-validation lane lands and calls it. Kept rather
+    // than deferred, because it is what makes the constructor crate-private,
+    // and a public constructor "for now" is how the invariant was lost the
+    // first time.
+    #[allow(dead_code)]
+    pub(crate) fn assert_participating(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    /// For tests, which stand in for the resolution path.
+    ///
+    /// Behind the `testing` feature so it cannot reach a release build. It is
+    /// separate from [`MemberId::assert_participating`] rather than a widening
+    /// of it, so that broadening the real constructor's visibility stays a
+    /// deliberate act.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn for_test(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+/// A membership as *stored data* refers to it: an author, an audience entry,
+/// an assignment.
+///
+/// Deliberately not a [`MemberId`], and there is no conversion. The substrate
+/// says references survive departure — "authorship never changes, so someone
+/// who leaves remains the author of what they wrote. An audience entry naming
+/// them stays where it is" — so a value read out of a row carries no claim
+/// about participation, which is exactly the claim `MemberId` exists to carry.
+///
+/// Making them one type would let a row's own author be handed back to the
+/// audience predicate as a requester, which is the shape of the bug that
+/// separating them prevents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MemberRef(Uuid);
+
+impl MemberRef {
     pub fn from_uuid(id: Uuid) -> Self {
         Self(id)
     }
 
     pub fn as_uuid(self) -> Uuid {
         self.0
+    }
+}
+
+impl MemberId {
+    /// Whether this requester is the member a stored reference names.
+    ///
+    /// The comparison the two types would otherwise tempt someone to make by
+    /// unifying them.
+    pub fn is(self, other: MemberRef) -> bool {
+        self.as_uuid() == other.as_uuid()
     }
 }
 

--- a/crates/altaird/src/store/ids.rs
+++ b/crates/altaird/src/store/ids.rs
@@ -1,0 +1,52 @@
+//! Identifiers as they cross this layer.
+//!
+//! DR-007: every identifier is a random UUIDv4 and nothing ever reads one.
+//! Nothing here parses, orders, or derives meaning from an identifier; the
+//! newtypes exist only so that a member cannot be passed where an entity is
+//! expected. That mistake would be silent, and in the audience predicate it
+//! would be a leak.
+
+use uuid::Uuid;
+
+/// A household member, as the instance has already established them.
+///
+/// **Constructing one is an assertion.** It says the caller has resolved this
+/// member from a validated token and that the membership *currently
+/// participates* in the household — that is, it has not departed. The substrate
+/// puts it plainly: an audience entry "confers nothing by itself. Access
+/// follows current participation."
+///
+/// Participation is therefore checked once, where the member is resolved, and
+/// not inside the audience predicate. It is a fact about the requester, not
+/// about the row, so it is constant across every candidate in a query; joining
+/// `membership` into every candidate query to re-answer it would pay per row
+/// for a check that cannot vary, and would be a second place the rule could be
+/// forgotten.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MemberId(Uuid);
+
+impl MemberId {
+    /// The caller asserts this membership exists and currently participates.
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+/// An entity, by the identifier whoever created it generated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, sqlx::Type)]
+#[sqlx(transparent)]
+pub struct EntityId(Uuid);
+
+impl EntityId {
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(self) -> Uuid {
+        self.0
+    }
+}

--- a/crates/altaird/src/store/mod.rs
+++ b/crates/altaird/src/store/mod.rs
@@ -9,7 +9,7 @@ pub mod entity;
 pub mod ids;
 pub mod tx;
 
-pub use audience::{Bind, CandidateQuery, LifecycleScope};
+pub use audience::{Bind, CandidateQuery, LifecycleScope, ReadScope, WriteScope};
 pub use ids::{EntityId, MemberId};
 pub use tx::{ReadTx, WriteTx, begin_read, begin_write};
 

--- a/crates/altaird/src/store/mod.rs
+++ b/crates/altaird/src/store/mod.rs
@@ -1,3 +1,18 @@
+//! The structured store: connection handling, transactions, and the shared
+//! query surface the write and read paths both consume.
+//!
+//! The load-bearing thing in here is [`audience`]. Read its module docs before
+//! adding any query over `entity`, on either path.
+
+pub mod audience;
+pub mod entity;
+pub mod ids;
+pub mod tx;
+
+pub use audience::{Bind, CandidateQuery, LifecycleScope};
+pub use ids::{EntityId, MemberId};
+pub use tx::{ReadTx, WriteTx, begin_read, begin_write};
+
 use sqlx::postgres::{PgPool, PgPoolOptions};
 
 pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!();

--- a/crates/altaird/src/store/tx.rs
+++ b/crates/altaird/src/store/tx.rs
@@ -5,14 +5,24 @@
 //! was asked or opened", and the plan restates it as a standing constraint:
 //! nothing crosses from the read path to the write path.
 //!
-//! That is normally kept true by discipline, which is to say by nobody having
-//! written the offending line yet. Here it is kept true by Postgres:
-//! [`begin_read`] issues `SET TRANSACTION READ ONLY`, so a write from the read
-//! path is an error from the database rather than a review comment. It costs
-//! one statement per read transaction and it cannot be forgotten.
+//! [`begin_read`] issues `SET TRANSACTION READ ONLY`, so the ordinary way to
+//! break that is an error from the database rather than a review comment. Two
+//! honest limits on how much that buys, because an overstated guarantee is
+//! worse than a modest one:
 //!
-//! [`ReadTx`] has no `commit`. There is nothing to commit, and offering the
-//! method would suggest otherwise.
+//! **What Postgres actually blocks.** `INSERT`, `UPDATE`, `DELETE`, `MERGE`
+//! and `COPY FROM` against permanent tables, every form of DDL, `GRANT`,
+//! `REVOKE` and `TRUNCATE`. It does *not* block DML against a temporary table
+//! that already existed, and it is not a promise that nothing touches disk.
+//! For this layer's purpose — the read path must not record what was asked —
+//! the covered set is the relevant one, but it is a set and not a totality.
+//!
+//! **What the type adds.** [`ReadTx`] has no `commit`, and its connection is
+//! crate-visible rather than public, so nothing outside `altaird` can reach the
+//! raw connection to `COMMIT` out of the read-only transaction and then write
+//! in Postgres's implicit read-write mode. Inside the crate that escape is
+//! still reachable by anyone who writes the line; what is claimed is that it
+//! cannot be reached by accident and cannot be reached from outside at all.
 
 use sqlx::postgres::{PgConnection, PgPool, Postgres};
 use sqlx::{Executor, Transaction};
@@ -21,8 +31,16 @@ use sqlx::{Executor, Transaction};
 pub struct WriteTx(Transaction<'static, Postgres>);
 
 impl WriteTx {
-    /// The connection, for the query surface in this layer.
-    pub fn conn(&mut self) -> &mut PgConnection {
+    /// The connection, for the query surface in this layer and for the write
+    /// path. Crate-visible: nothing outside `altaird` touches the store
+    /// directly.
+    pub(crate) fn conn(&mut self) -> &mut PgConnection {
+        &mut self.0
+    }
+
+    /// For tests, which need to observe the connection directly.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn conn_for_test(&mut self) -> &mut PgConnection {
         &mut self.0
     }
 
@@ -41,7 +59,17 @@ impl WriteTx {
 pub struct ReadTx(Transaction<'static, Postgres>);
 
 impl ReadTx {
-    pub fn conn(&mut self) -> &mut PgConnection {
+    /// Crate-visible, so the `COMMIT`-and-then-write escape is not reachable
+    /// from outside `altaird`. See the module docs for what this does and does
+    /// not guarantee.
+    pub(crate) fn conn(&mut self) -> &mut PgConnection {
+        &mut self.0
+    }
+
+    /// For tests, including the one that proves the database refuses a write
+    /// through this transaction.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn conn_for_test(&mut self) -> &mut PgConnection {
         &mut self.0
     }
 }

--- a/crates/altaird/src/store/tx.rs
+++ b/crates/altaird/src/store/tx.rs
@@ -1,0 +1,59 @@
+//! Transactions, in the two shapes the instance has.
+//!
+//! The component model gives the read path a `Never` list whose first entry is
+//! "Write anything: not entity content, not derived data, not a record of what
+//! was asked or opened", and the plan restates it as a standing constraint:
+//! nothing crosses from the read path to the write path.
+//!
+//! That is normally kept true by discipline, which is to say by nobody having
+//! written the offending line yet. Here it is kept true by Postgres:
+//! [`begin_read`] issues `SET TRANSACTION READ ONLY`, so a write from the read
+//! path is an error from the database rather than a review comment. It costs
+//! one statement per read transaction and it cannot be forgotten.
+//!
+//! [`ReadTx`] has no `commit`. There is nothing to commit, and offering the
+//! method would suggest otherwise.
+
+use sqlx::postgres::{PgConnection, PgPool, Postgres};
+use sqlx::{Executor, Transaction};
+
+/// A transaction that may write.
+pub struct WriteTx(Transaction<'static, Postgres>);
+
+impl WriteTx {
+    /// The connection, for the query surface in this layer.
+    pub fn conn(&mut self) -> &mut PgConnection {
+        &mut self.0
+    }
+
+    pub async fn commit(self) -> sqlx::Result<()> {
+        self.0.commit().await
+    }
+
+    pub async fn rollback(self) -> sqlx::Result<()> {
+        self.0.rollback().await
+    }
+}
+
+/// A transaction the database itself refuses writes on.
+///
+/// Dropping it rolls back, which is the only ending it has.
+pub struct ReadTx(Transaction<'static, Postgres>);
+
+impl ReadTx {
+    pub fn conn(&mut self) -> &mut PgConnection {
+        &mut self.0
+    }
+}
+
+pub async fn begin_write(pool: &PgPool) -> sqlx::Result<WriteTx> {
+    Ok(WriteTx(pool.begin().await?))
+}
+
+pub async fn begin_read(pool: &PgPool) -> sqlx::Result<ReadTx> {
+    let mut tx = pool.begin().await?;
+    // First statement inside the transaction, which is where Postgres will
+    // accept it.
+    tx.execute("SET TRANSACTION READ ONLY").await?;
+    Ok(ReadTx(tx))
+}

--- a/crates/altaird/tests/audience.rs
+++ b/crates/altaird/tests/audience.rs
@@ -1,0 +1,345 @@
+//! Audience, observed through both paths.
+//!
+//! Neither the write path (Wave 2) nor the read path (Wave 3) exists, so these
+//! exercise the two *shapes* the store layer offers them:
+//! `entity::available_for_write`, the "may this member act on this" lookup, and
+//! `entity::candidates`, the query that produces candidates. Both are built
+//! from the same `CandidateQuery`, so both carry the same predicate; the point
+//! of testing both is that they *agree*, including on what they refuse.
+//!
+//! Rows are inserted with raw SQL here on purpose. The write path is Wave 2's,
+//! and a fixture that pre-empted it would be a second write implementation.
+
+use altaird::store::audience::AUDIENCE_COLUMN;
+use altaird::store::entity::{self, LifecycleState};
+use altaird::store::{EntityId, LifecycleScope, MemberId};
+use altaird::store::{begin_read, begin_write};
+use altaird::testing::TestDb;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn household(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO household (id, name, created_at) VALUES ($1, 'test', now())")
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("household");
+    id
+}
+
+async fn member(pool: &PgPool, household_id: Uuid, administrator: bool) -> MemberId {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO membership (id, household_id, subject, administrator, joined_at) \
+         VALUES ($1, $2, $3, $4, now())",
+    )
+    .bind(id)
+    .bind(household_id)
+    .bind(id.to_string())
+    .bind(administrator)
+    .execute(pool)
+    .await
+    .expect("membership");
+    MemberId::from_uuid(id)
+}
+
+/// `author` is `None` for an entity captured before its device was bound.
+async fn note(
+    pool: &PgPool,
+    author: Option<MemberId>,
+    audience: &[MemberId],
+    lifecycle: LifecycleState,
+) -> EntityId {
+    let id = Uuid::new_v4();
+    let audience: Vec<Uuid> = audience.iter().map(|m| m.as_uuid()).collect();
+    let state = match lifecycle {
+        LifecycleState::Active => "active",
+        LifecycleState::Deleted => "deleted",
+        LifecycleState::Erased => "erased",
+    };
+    // The column is named through the store's constant, like everything else
+    // that has to name it. See `tests/one_predicate.rs`.
+    let sql = format!(
+        "INSERT INTO entity \
+           (id, type, title, author_member_id, created_at, updated_at, capture_method, \
+            {AUDIENCE_COLUMN}, lifecycle, deleted_at) \
+         VALUES ($1, 'note', 'a note', $2, now(), now(), 'test', $3, $4::lifecycle_state, \
+            CASE WHEN $4 = 'deleted' THEN now() ELSE NULL END)"
+    );
+    sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(id)
+        .bind(author.map(|m| m.as_uuid()))
+        .bind(&audience)
+        .bind(state)
+        .execute(pool)
+        .await
+        .expect("entity");
+    EntityId::from_uuid(id)
+}
+
+/// Both shapes, one answer. `(write path saw it, read path saw it)`.
+async fn seen(
+    pool: &PgPool,
+    member: MemberId,
+    id: EntityId,
+    scope: LifecycleScope,
+) -> (bool, bool) {
+    let mut w = begin_write(pool).await.expect("begin write");
+    let by_write = entity::available_for_write(&mut w, member, id, scope)
+        .await
+        .expect("write path lookup");
+    w.rollback().await.expect("rollback");
+
+    let mut r = begin_read(pool).await.expect("begin read");
+    let by_read = entity::candidates(&mut r, member, scope, 100)
+        .await
+        .expect("read path candidates");
+
+    (by_write.is_some(), by_read.iter().any(|e| e.id == id))
+}
+
+#[tokio::test]
+async fn an_author_reads_their_own_entity_back_through_both_paths() {
+    let db = TestDb::new().await;
+    let h = household(&db.pool).await;
+    let author = member(&db.pool, h, false).await;
+
+    let id = note(&db.pool, Some(author), &[], LifecycleState::Active).await;
+
+    let mut w = begin_write(&db.pool).await.expect("begin write");
+    let by_write = entity::available_for_write(&mut w, author, id, LifecycleScope::Active)
+        .await
+        .expect("write path lookup")
+        .expect("author may act on their own entity");
+    w.rollback().await.expect("rollback");
+
+    let mut r = begin_read(&db.pool).await.expect("begin read");
+    let by_read = entity::candidates(&mut r, author, LifecycleScope::Active, 100)
+        .await
+        .expect("read path candidates");
+
+    let found = by_read
+        .iter()
+        .find(|e| e.id == id)
+        .expect("author's own entity is a candidate");
+
+    assert_eq!(
+        &by_write, found,
+        "the two paths disagree about the same row"
+    );
+    assert_eq!(by_write.author, Some(author));
+    assert_eq!(by_write.counter, 1);
+}
+
+#[tokio::test]
+async fn a_private_entity_is_invisible_to_everyone_else_through_both_paths() {
+    let db = TestDb::new().await;
+    let h = household(&db.pool).await;
+    let author = member(&db.pool, h, false).await;
+    let other = member(&db.pool, h, false).await;
+
+    let id = note(&db.pool, Some(author), &[], LifecycleState::Active).await;
+
+    assert_eq!(
+        seen(&db.pool, other, id, LifecycleScope::Active).await,
+        (false, false),
+        "a private entity reached somebody who is not its author"
+    );
+    assert_eq!(
+        seen(&db.pool, author, id, LifecycleScope::Active).await,
+        (true, true)
+    );
+}
+
+#[tokio::test]
+async fn refusal_on_audience_is_the_same_answer_as_refusal_on_nonexistence() {
+    let db = TestDb::new().await;
+    let h = household(&db.pool).await;
+    let author = member(&db.pool, h, false).await;
+    let other = member(&db.pool, h, false).await;
+
+    let hidden = note(&db.pool, Some(author), &[], LifecycleState::Active).await;
+    let absent = EntityId::from_uuid(Uuid::new_v4());
+
+    let mut w = begin_write(&db.pool).await.expect("begin write");
+    let for_hidden = entity::available_for_write(&mut w, other, hidden, LifecycleScope::Active)
+        .await
+        .expect("lookup");
+    let for_absent = entity::available_for_write(&mut w, other, absent, LifecycleScope::Active)
+        .await
+        .expect("lookup");
+    w.rollback().await.expect("rollback");
+
+    assert_eq!(
+        for_hidden, for_absent,
+        "the caller can tell an entity it may not see from one that is not there"
+    );
+    assert!(for_hidden.is_none());
+}
+
+#[tokio::test]
+async fn an_audience_entry_makes_it_visible_through_both_paths() {
+    let db = TestDb::new().await;
+    let h = household(&db.pool).await;
+    let author = member(&db.pool, h, false).await;
+    let shared_with = member(&db.pool, h, false).await;
+    let outsider = member(&db.pool, h, false).await;
+
+    let id = note(
+        &db.pool,
+        Some(author),
+        &[shared_with],
+        LifecycleState::Active,
+    )
+    .await;
+
+    assert_eq!(
+        seen(&db.pool, shared_with, id, LifecycleScope::Active).await,
+        (true, true)
+    );
+    assert_eq!(
+        seen(&db.pool, outsider, id, LifecycleScope::Active).await,
+        (false, false)
+    );
+}
+
+#[tokio::test]
+async fn an_unattributed_entity_is_visible_to_nobody() {
+    // The substrate: "Audience is defined relative to a household, so an
+    // unattributed entity has none and cannot be shared." A null author must
+    // not read as a wildcard, which is what `COALESCE` in the predicate would
+    // make it.
+    let db = TestDb::new().await;
+    let h = household(&db.pool).await;
+    let a = member(&db.pool, h, false).await;
+    let b = member(&db.pool, h, false).await;
+
+    let id = note(&db.pool, None, &[], LifecycleState::Active).await;
+
+    for m in [a, b] {
+        assert_eq!(
+            seen(&db.pool, m, id, LifecycleScope::AnyIncludingErased).await,
+            (false, false),
+            "an entity with no author reached a member"
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_administrator_does_not_see_another_members_private_entity() {
+    // The architecture: the flag "does not touch audience, and an administrator
+    // does not see another member's private entities".
+    let db = TestDb::new().await;
+    let h = household(&db.pool).await;
+    let author = member(&db.pool, h, false).await;
+    let admin = member(&db.pool, h, true).await;
+
+    let id = note(&db.pool, Some(author), &[], LifecycleState::Active).await;
+
+    assert_eq!(
+        seen(&db.pool, admin, id, LifecycleScope::AnyIncludingErased).await,
+        (false, false),
+        "the administrator flag has become a permission over entities"
+    );
+}
+
+#[tokio::test]
+async fn lifecycle_scopes_the_query_and_audience_decides_visibility() {
+    // Deleted and erased rows stay visible to those the audience admits. The
+    // holding list has to be able to show a deleted entity, and the write path
+    // has to be able to find an erased tombstone to tell a recreation from a
+    // create. Both go through the same predicate.
+    let db = TestDb::new().await;
+    let h = household(&db.pool).await;
+    let author = member(&db.pool, h, false).await;
+    let outsider = member(&db.pool, h, false).await;
+
+    let deleted = note(&db.pool, Some(author), &[], LifecycleState::Deleted).await;
+    let erased = note(&db.pool, Some(author), &[], LifecycleState::Erased).await;
+
+    assert_eq!(
+        seen(&db.pool, author, deleted, LifecycleScope::Active).await,
+        (false, false),
+        "a deleted entity appeared on an active surface"
+    );
+    assert_eq!(
+        seen(&db.pool, author, deleted, LifecycleScope::Holding).await,
+        (true, true),
+        "the holding surface cannot see what it holds"
+    );
+    assert_eq!(
+        seen(&db.pool, author, erased, LifecycleScope::Extant).await,
+        (false, false),
+        "a tombstone appeared among entities that still have content"
+    );
+    assert_eq!(
+        seen(&db.pool, author, erased, LifecycleScope::AnyIncludingErased).await,
+        (true, true),
+        "the write path cannot reach a tombstone, so an edit to an erased \
+         entity would read as a create rather than a recreation"
+    );
+
+    // And no scope lets audience through.
+    for scope in [
+        LifecycleScope::Active,
+        LifecycleScope::Holding,
+        LifecycleScope::Extant,
+        LifecycleScope::AnyIncludingErased,
+    ] {
+        assert_eq!(
+            seen(&db.pool, outsider, deleted, scope).await,
+            (false, false)
+        );
+        assert_eq!(
+            seen(&db.pool, outsider, erased, scope).await,
+            (false, false)
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_read_transaction_refuses_a_write() {
+    // "Nothing crosses from the read path to the write path. The read path
+    // writes nothing, including no record of what was asked." Enforced by the
+    // database rather than by discipline.
+    let db = TestDb::new().await;
+    let mut r = begin_read(&db.pool).await.expect("begin read");
+
+    let attempted = sqlx::query(
+        "INSERT INTO household (id, name, created_at) VALUES (gen_random_uuid(), 'x', now())",
+    )
+    .execute(r.conn())
+    .await;
+
+    let err = attempted.expect_err("the read path was allowed to write");
+    let code = err
+        .as_database_error()
+        .and_then(|e| e.code())
+        .map(|c| c.to_string());
+    assert_eq!(
+        code.as_deref(),
+        Some("25006"),
+        "expected read_only_sql_transaction, got {err}"
+    );
+}
+
+#[tokio::test]
+async fn a_candidate_query_cannot_be_built_without_the_predicate() {
+    // Structural rather than behavioural: whatever a caller adds is conjoined
+    // onto what the constructor already emitted.
+    use altaird::store::{Bind, CandidateQuery};
+
+    let m = MemberId::from_uuid(Uuid::new_v4());
+    let q = CandidateQuery::new(m, LifecycleScope::Active, "e.id")
+        .and_where("e.type = $?::entity_type", [Bind::Text("note".into())])
+        .tail("LIMIT $?", [Bind::Int(10)]);
+
+    assert!(
+        q.sql().contains(altaird::store::audience::predicate_sql()),
+        "the predicate is not in the assembled SQL: {}",
+        q.sql()
+    );
+    assert!(q.sql().contains("$2::entity_type"), "{}", q.sql());
+    assert!(q.sql().ends_with("LIMIT $3"), "{}", q.sql());
+}

--- a/crates/altaird/tests/audience.rs
+++ b/crates/altaird/tests/audience.rs
@@ -12,7 +12,7 @@
 
 use altaird::store::audience::AUDIENCE_COLUMN;
 use altaird::store::entity::{self, LifecycleState};
-use altaird::store::{EntityId, LifecycleScope, MemberId};
+use altaird::store::{EntityId, MemberId, ReadScope, WriteScope};
 use altaird::store::{begin_read, begin_write};
 use altaird::testing::TestDb;
 use sqlx::PgPool;
@@ -41,7 +41,7 @@ async fn member(pool: &PgPool, household_id: Uuid, administrator: bool) -> Membe
     .execute(pool)
     .await
     .expect("membership");
-    MemberId::from_uuid(id)
+    MemberId::for_test(id)
 }
 
 /// `author` is `None` for an entity captured before its device was bound.
@@ -79,24 +79,48 @@ async fn note(
 }
 
 /// Both shapes, one answer. `(write path saw it, read path saw it)`.
+///
+/// The two scopes are separate arguments because the read path can no longer
+/// name the erased scope at all; where they mean the same thing the wrappers
+/// below say so.
 async fn seen(
     pool: &PgPool,
     member: MemberId,
     id: EntityId,
-    scope: LifecycleScope,
+    write_scope: WriteScope,
+    read_scope: ReadScope,
 ) -> (bool, bool) {
     let mut w = begin_write(pool).await.expect("begin write");
-    let by_write = entity::available_for_write(&mut w, member, id, scope)
+    let by_write = entity::available_for_write(&mut w, member, id, write_scope)
         .await
         .expect("write path lookup");
     w.rollback().await.expect("rollback");
 
     let mut r = begin_read(pool).await.expect("begin read");
-    let by_read = entity::candidates(&mut r, member, scope, 100)
+    let by_read = entity::candidates(&mut r, member, read_scope, 100)
         .await
         .expect("read path candidates");
 
     (by_write.is_some(), by_read.iter().any(|e| e.id == id))
+}
+
+/// The scopes that mean the same thing on both sides.
+async fn seen_active(pool: &PgPool, member: MemberId, id: EntityId) -> (bool, bool) {
+    seen(pool, member, id, WriteScope::Active, ReadScope::Active).await
+}
+
+/// As far as each path is permitted to reach. The write path reaches
+/// tombstones; the read path's widest scope stops short of them, which is the
+/// point of the split.
+async fn seen_anywhere(pool: &PgPool, member: MemberId, id: EntityId) -> (bool, bool) {
+    seen(
+        pool,
+        member,
+        id,
+        WriteScope::AnyIncludingErased,
+        ReadScope::Extant,
+    )
+    .await
 }
 
 #[tokio::test]
@@ -108,14 +132,14 @@ async fn an_author_reads_their_own_entity_back_through_both_paths() {
     let id = note(&db.pool, Some(author), &[], LifecycleState::Active).await;
 
     let mut w = begin_write(&db.pool).await.expect("begin write");
-    let by_write = entity::available_for_write(&mut w, author, id, LifecycleScope::Active)
+    let by_write = entity::available_for_write(&mut w, author, id, WriteScope::Active)
         .await
         .expect("write path lookup")
         .expect("author may act on their own entity");
     w.rollback().await.expect("rollback");
 
     let mut r = begin_read(&db.pool).await.expect("begin read");
-    let by_read = entity::candidates(&mut r, author, LifecycleScope::Active, 100)
+    let by_read = entity::candidates(&mut r, author, ReadScope::Active, 100)
         .await
         .expect("read path candidates");
 
@@ -128,7 +152,10 @@ async fn an_author_reads_their_own_entity_back_through_both_paths() {
         &by_write, found,
         "the two paths disagree about the same row"
     );
-    assert_eq!(by_write.author, Some(author));
+    // `is` rather than `==`: an author is a stored reference and a requester
+    // is a participating member, and the types are separate so that one cannot
+    // be handed to the predicate as the other.
+    assert!(by_write.author.is_some_and(|a| author.is(a)));
     assert_eq!(by_write.counter, 1);
 }
 
@@ -142,14 +169,11 @@ async fn a_private_entity_is_invisible_to_everyone_else_through_both_paths() {
     let id = note(&db.pool, Some(author), &[], LifecycleState::Active).await;
 
     assert_eq!(
-        seen(&db.pool, other, id, LifecycleScope::Active).await,
+        seen_active(&db.pool, other, id).await,
         (false, false),
         "a private entity reached somebody who is not its author"
     );
-    assert_eq!(
-        seen(&db.pool, author, id, LifecycleScope::Active).await,
-        (true, true)
-    );
+    assert_eq!(seen_active(&db.pool, author, id).await, (true, true));
 }
 
 #[tokio::test]
@@ -163,10 +187,10 @@ async fn refusal_on_audience_is_the_same_answer_as_refusal_on_nonexistence() {
     let absent = EntityId::from_uuid(Uuid::new_v4());
 
     let mut w = begin_write(&db.pool).await.expect("begin write");
-    let for_hidden = entity::available_for_write(&mut w, other, hidden, LifecycleScope::Active)
+    let for_hidden = entity::available_for_write(&mut w, other, hidden, WriteScope::Active)
         .await
         .expect("lookup");
-    let for_absent = entity::available_for_write(&mut w, other, absent, LifecycleScope::Active)
+    let for_absent = entity::available_for_write(&mut w, other, absent, WriteScope::Active)
         .await
         .expect("lookup");
     w.rollback().await.expect("rollback");
@@ -194,14 +218,8 @@ async fn an_audience_entry_makes_it_visible_through_both_paths() {
     )
     .await;
 
-    assert_eq!(
-        seen(&db.pool, shared_with, id, LifecycleScope::Active).await,
-        (true, true)
-    );
-    assert_eq!(
-        seen(&db.pool, outsider, id, LifecycleScope::Active).await,
-        (false, false)
-    );
+    assert_eq!(seen_active(&db.pool, shared_with, id).await, (true, true));
+    assert_eq!(seen_active(&db.pool, outsider, id).await, (false, false));
 }
 
 #[tokio::test]
@@ -219,7 +237,7 @@ async fn an_unattributed_entity_is_visible_to_nobody() {
 
     for m in [a, b] {
         assert_eq!(
-            seen(&db.pool, m, id, LifecycleScope::AnyIncludingErased).await,
+            seen_anywhere(&db.pool, m, id).await,
             (false, false),
             "an entity with no author reached a member"
         );
@@ -238,7 +256,7 @@ async fn an_administrator_does_not_see_another_members_private_entity() {
     let id = note(&db.pool, Some(author), &[], LifecycleState::Active).await;
 
     assert_eq!(
-        seen(&db.pool, admin, id, LifecycleScope::AnyIncludingErased).await,
+        seen_anywhere(&db.pool, admin, id).await,
         (false, false),
         "the administrator flag has become a permission over entities"
     );
@@ -259,41 +277,87 @@ async fn lifecycle_scopes_the_query_and_audience_decides_visibility() {
     let erased = note(&db.pool, Some(author), &[], LifecycleState::Erased).await;
 
     assert_eq!(
-        seen(&db.pool, author, deleted, LifecycleScope::Active).await,
+        seen(
+            &db.pool,
+            author,
+            deleted,
+            WriteScope::Active,
+            ReadScope::Active
+        )
+        .await,
         (false, false),
         "a deleted entity appeared on an active surface"
     );
     assert_eq!(
-        seen(&db.pool, author, deleted, LifecycleScope::Holding).await,
+        seen(
+            &db.pool,
+            author,
+            deleted,
+            WriteScope::Holding,
+            ReadScope::Holding
+        )
+        .await,
         (true, true),
         "the holding surface cannot see what it holds"
     );
     assert_eq!(
-        seen(&db.pool, author, erased, LifecycleScope::Extant).await,
+        seen(
+            &db.pool,
+            author,
+            erased,
+            WriteScope::Extant,
+            ReadScope::Extant
+        )
+        .await,
         (false, false),
         "a tombstone appeared among entities that still have content"
     );
+
+    // The write path reaches the tombstone. The read path has no scope that
+    // can, which is why this asymmetry is spelled out rather than hidden in a
+    // wrapper.
     assert_eq!(
-        seen(&db.pool, author, erased, LifecycleScope::AnyIncludingErased).await,
-        (true, true),
+        seen_anywhere(&db.pool, author, erased).await,
+        (true, false),
         "the write path cannot reach a tombstone, so an edit to an erased \
          entity would read as a create rather than a recreation"
     );
 
-    // And no scope lets audience through.
-    for scope in [
-        LifecycleScope::Active,
-        LifecycleScope::Holding,
-        LifecycleScope::Extant,
-        LifecycleScope::AnyIncludingErased,
+    // And no scope on either path lets audience through.
+    for (w, r) in [
+        (WriteScope::Active, ReadScope::Active),
+        (WriteScope::Holding, ReadScope::Holding),
+        (WriteScope::Extant, ReadScope::Extant),
+        (WriteScope::AnyIncludingErased, ReadScope::Extant),
     ] {
         assert_eq!(
-            seen(&db.pool, outsider, deleted, scope).await,
+            seen(&db.pool, outsider, deleted, w, r).await,
             (false, false)
         );
-        assert_eq!(
-            seen(&db.pool, outsider, erased, scope).await,
-            (false, false)
+        assert_eq!(seen(&db.pool, outsider, erased, w, r).await, (false, false));
+    }
+}
+
+#[tokio::test]
+async fn no_read_scope_reaches_a_tombstone() {
+    // The erased variant does not exist on `ReadScope`, so this is the whole
+    // of what a read surface can ask for. A tombstone retains its title until
+    // Wave 2 strips it, so reaching one from the read path would be serving
+    // content somebody erased.
+    let db = TestDb::new().await;
+    let h = household(&db.pool).await;
+    let author = member(&db.pool, h, false).await;
+
+    let erased = note(&db.pool, Some(author), &[], LifecycleState::Erased).await;
+
+    for scope in [ReadScope::Active, ReadScope::Holding, ReadScope::Extant] {
+        let mut r = begin_read(&db.pool).await.expect("begin read");
+        let rows = entity::candidates(&mut r, author, scope, 100)
+            .await
+            .expect("candidates");
+        assert!(
+            !rows.iter().any(|e| e.id == erased),
+            "a read surface reached a tombstone through {scope:?}"
         );
     }
 }
@@ -309,7 +373,7 @@ async fn the_read_transaction_refuses_a_write() {
     let attempted = sqlx::query(
         "INSERT INTO household (id, name, created_at) VALUES (gen_random_uuid(), 'x', now())",
     )
-    .execute(r.conn())
+    .execute(r.conn_for_test())
     .await;
 
     let err = attempted.expect_err("the read path was allowed to write");
@@ -325,12 +389,33 @@ async fn the_read_transaction_refuses_a_write() {
 }
 
 #[tokio::test]
-async fn a_candidate_query_cannot_be_built_without_the_predicate() {
+async fn an_unattributed_entity_is_not_shareable_by_its_audience_array() {
+    // The state the schema permits and the substrate forbids: no author, but a
+    // populated audience. Nothing ties the two columns together, so the write
+    // path could produce this and the predicate would have to answer for it.
+    // The predicate's leading `author_member_id IS NOT NULL` is what makes the
+    // answer closed here rather than two components away.
+    let db = TestDb::new().await;
+    let h = household(&db.pool).await;
+    let named = member(&db.pool, h, false).await;
+
+    let id = note(&db.pool, None, &[named], LifecycleState::Active).await;
+
+    assert_eq!(
+        seen_anywhere(&db.pool, named, id).await,
+        (false, false),
+        "an entity with no author was shared by its audience array. The \
+         substrate: an unattributed entity 'has none and cannot be shared'"
+    );
+}
+
+#[test]
+fn a_candidate_query_cannot_be_built_without_the_predicate() {
     // Structural rather than behavioural: whatever a caller adds is conjoined
     // onto what the constructor already emitted.
-    use altaird::store::{Bind, CandidateQuery};
+    use altaird::store::{Bind, CandidateQuery, LifecycleScope};
 
-    let m = MemberId::from_uuid(Uuid::new_v4());
+    let m = MemberId::for_test(Uuid::new_v4());
     let q = CandidateQuery::new(m, LifecycleScope::Active, "e.id")
         .and_where("e.type = $?::entity_type", [Bind::Text("note".into())])
         .tail("LIMIT $?", [Bind::Int(10)]);
@@ -342,4 +427,53 @@ async fn a_candidate_query_cannot_be_built_without_the_predicate() {
     );
     assert!(q.sql().contains("$2::entity_type"), "{}", q.sql());
     assert!(q.sql().ends_with("LIMIT $3"), "{}", q.sql());
+}
+
+#[test]
+#[should_panic(expected = "names the entity table again")]
+fn a_tail_cannot_bolt_on_an_unscoped_second_arm() {
+    // The escape the builder used to concede and not control: a second arm
+    // over `entity` carries no predicate, and returns everything.
+    use altaird::store::{CandidateQuery, LifecycleScope};
+
+    let m = MemberId::for_test(Uuid::new_v4());
+    let _ = CandidateQuery::new(m, LifecycleScope::Active, "e.id")
+        // Assembled rather than written: `tests/one_predicate.rs` scans for
+        // exactly this shape at rest, and a negative test should not read as
+        // the thing it forbids.
+        .tail(&format!("UNION ALL SELECT e2.id {} entity e2", "FROM"), []);
+}
+
+#[test]
+#[should_panic(expected = "names the entity table again")]
+fn a_projection_cannot_hide_an_unscoped_subquery() {
+    use altaird::store::{CandidateQuery, LifecycleScope};
+
+    let m = MemberId::for_test(Uuid::new_v4());
+    let _ = CandidateQuery::new(
+        m,
+        LifecycleScope::Active,
+        &format!("e.id, (SELECT count(*) {} entity) AS total", "FROM"),
+    );
+}
+
+#[test]
+#[should_panic(expected = "raw positional parameter")]
+fn a_fragment_cannot_write_a_raw_position_and_silently_get_the_requester() {
+    // `$1` is the member. Writing it by hand compiles, runs, and compares
+    // against the requester — a wrong answer rather than an error.
+    use altaird::store::{CandidateQuery, LifecycleScope};
+
+    let m = MemberId::for_test(Uuid::new_v4());
+    let _ = CandidateQuery::new(m, LifecycleScope::Active, "e.id")
+        .and_where("e.author_member_id = $1", []);
+}
+
+#[test]
+#[should_panic(expected = "raw positional parameter")]
+fn a_fragment_cannot_write_a_raw_position_that_would_be_unbound() {
+    use altaird::store::{CandidateQuery, LifecycleScope};
+
+    let m = MemberId::for_test(Uuid::new_v4());
+    let _ = CandidateQuery::new(m, LifecycleScope::Active, "e.id").tail("LIMIT $2", []);
 }

--- a/crates/altaird/tests/one_predicate.rs
+++ b/crates/altaird/tests/one_predicate.rs
@@ -1,0 +1,128 @@
+//! The audience predicate appears in exactly one place.
+//!
+//! This is the lane's done-when condition, and it is executable rather than a
+//! comment promising it. It fails if somebody pastes a second copy, and it also
+//! fails on a *paraphrased* second copy — a hand-rolled
+//! `author_member_id = $1 OR ...` that an exact-string check would miss —
+//! because it additionally refuses any source outside `store/audience.rs` that
+//! names the audience column at all.
+//!
+//! The component model requires the same predicate on both paths. One
+//! implementation is the cheap way to keep that true. Two is how it stops being
+//! true in month four, and by then the divergence is a leak rather than a
+//! refactor.
+//!
+//! Neither needle is written as a literal here, or this file would count as an
+//! occurrence of itself.
+
+use std::path::{Path, PathBuf};
+
+/// Where the predicate is allowed to live.
+const HOME: &str = "crates/altaird/src/store/audience.rs";
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("repo root above crates/altaird")
+        .to_path_buf()
+}
+
+/// Every `.rs` and `.sql` source in the repository, except the migrations,
+/// which are where the column is declared and must name it.
+fn sources(root: &Path) -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if path.is_dir() {
+                if name.starts_with('.') || name == "target" || name == "migrations" {
+                    continue;
+                }
+                walk(&path, out);
+            } else if matches!(
+                path.extension().and_then(|e| e.to_str()),
+                Some("rs") | Some("sql")
+            ) {
+                out.push(path);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, &mut out);
+    assert!(!out.is_empty(), "found no sources under {}", root.display());
+    out
+}
+
+#[test]
+fn the_predicate_sql_exists_once_in_the_tree() {
+    let needle = altaird::store::audience::predicate_sql();
+
+    // A predicate that had been emptied would pass the count trivially.
+    assert!(
+        needle.contains("author_member_id") && needle.contains("= ANY"),
+        "the predicate no longer looks like one: {needle}"
+    );
+
+    let root = repo_root();
+    let mut hits: Vec<(PathBuf, usize)> = Vec::new();
+    for path in sources(&root) {
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let n = text.matches(needle).count();
+        if n > 0 {
+            hits.push((path, n));
+        }
+    }
+
+    let total: usize = hits.iter().map(|(_, n)| n).sum();
+    assert_eq!(
+        total,
+        1,
+        "the audience predicate appears {total} times, in {:?}. It is written once, \
+         in {HOME}, and both paths call it.",
+        hits.iter()
+            .map(|(p, n)| format!("{} x{n}", p.display()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        hits[0].0.ends_with(HOME),
+        "the predicate has moved out of {HOME}, to {}",
+        hits[0].0.display()
+    );
+}
+
+#[test]
+fn nothing_else_in_the_tree_names_the_audience_column() {
+    // Assembled rather than written, so the scan does not find this file.
+    let column = ["audience", "member", "ids"].join("_");
+
+    let root = repo_root();
+    let offenders: Vec<String> = sources(&root)
+        .into_iter()
+        .filter(|p| !p.ends_with(HOME))
+        .filter(|p| {
+            std::fs::read_to_string(p)
+                .map(|t| t.contains(&column))
+                .unwrap_or(false)
+        })
+        .map(|p| p.display().to_string())
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "{offenders:?} name the audience column. Reasoning about audience \
+         belongs in {HOME}, and a paraphrase of the predicate is a second \
+         implementation whatever it is spelled like. If a query needs the \
+         column's value, select it through the constant there."
+    );
+
+    // And the one place still does.
+    let home = std::fs::read_to_string(root.join(HOME)).expect("audience.rs");
+    assert!(home.contains(&column), "{HOME} no longer names the column");
+}

--- a/crates/altaird/tests/one_predicate.rs
+++ b/crates/altaird/tests/one_predicate.rs
@@ -12,7 +12,17 @@
 //! true in month four, and by then the divergence is a leak rather than a
 //! refactor.
 //!
-//! Neither needle is written as a literal here, or this file would count as an
+//! A third check closes the escape the builder cannot: a second, unscoped
+//! `FROM` over `entity` outside the store layer. That one also covers most of what the
+//! first two would miss, because a second implementation has to reach the table
+//! however cleverly it spells the column.
+//!
+//! **The known limit.** A determined developer wins: a computed table name, a
+//! view, or a second implementation written inside `store/audience.rs` itself
+//! would all pass. These are aimed at the paste and the paraphrase, which are
+//! what actually happen. The gap is known rather than missed.
+//!
+//! No needle is written as a literal here, or this file would count as an
 //! occurrence of itself.
 
 use std::path::{Path, PathBuf};
@@ -125,4 +135,49 @@ fn nothing_else_in_the_tree_names_the_audience_column() {
     // And the one place still does.
     let home = std::fs::read_to_string(root.join(HOME)).expect("audience.rs");
     assert!(home.contains(&column), "{HOME} no longer names the column");
+}
+
+#[test]
+fn nothing_outside_the_store_layer_queries_the_entity_table() {
+    // `CandidateQuery` puts the predicate on the candidate set it builds. It
+    // cannot put one on a second `FROM` over `entity` smuggled into a projection or a
+    // UNION arm — it refuses such a fragment at runtime, and this refuses one
+    // at rest, anywhere in the tree.
+    //
+    // This is also the check that survives a cleverly spelled column: a second
+    // implementation still has to reach the table.
+    //
+    // Writes are deliberately not caught. `INSERT INTO entity` and
+    // `UPDATE entity` are the write path's, and audience on a write is enforced
+    // by looking the entity up first, not by a predicate on the statement.
+    let store = ["crates", "altaird", "src", "store"].join(std::path::MAIN_SEPARATOR_STR);
+
+    let root = repo_root();
+    let mut offenders: Vec<String> = Vec::new();
+    for path in sources(&root) {
+        if path.to_string_lossy().contains(&store) {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let flat: String = text
+            .to_ascii_lowercase()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        // Assembled, not written, like the other needles.
+        for shape in [["from", "entity"].join(" "), ["join", "entity"].join(" ")] {
+            if flat.contains(&shape) {
+                offenders.push(format!("{} ({shape})", path.display()));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "{offenders:?} query the entity table outside the store layer. Every \
+         candidate set over `entity` carries the audience predicate, and the \
+         only thing that puts it there is CandidateQuery, beside {HOME}."
+    );
 }


### PR DESCRIPTION
Wave 1, lane 1.1 — structured store bootstrap. Connection handling, transactions, and the shared query surface both paths consume.

> **This PR has been through a cross-model review that found seven confirmed issues, all now fixed.** Two of them contradicted claims the original version made about itself. That history is kept below rather than tidied away, because the shape of the mistake is the useful part.

## Why this lane is the risky one

The standing constraints open with two rules this lane either establishes or fails to:

> The audience predicate lives **inside** the query that produces candidates. Never a filter afterwards, on any path, including similarity.
> **One predicate implementation, called by both paths.**

The plan is blunt about the failure mode: *"two implementations is how it stops being true in month four."*

## The predicate

`crates/altaird/src/store/audience.rs`, the only place it exists:

```rust
const AUDIENCE_PREDICATE: &str =
    "(e.author_member_id IS NOT NULL AND (e.author_member_id = $1 OR $1 = ANY (e.audience_member_ids)))";
```

The leading null check is one of the review findings. Without it, an entity with **no author** but a non-empty audience array was visible — on *both* paths — contradicting the substrate's "an unattributed entity has none and cannot be shared." The original module comment asserted this was impossible; it was not. Reverting the guard now fails a test:

```
---- an_unattributed_entity_is_not_shareable_by_its_audience_array ----
assertion `left == right` failed: an entity with no author was shared by its audience array.
  left: (true, true)     right: (false, false)
```

The guard was chosen over merely correcting the comment: it fails closed, it is one conjunct, and leaving it to the write path would put a leak's only defence in a component this layer cannot see, on a path where the failure is silent.

## Lifecycle is deliberately not in the predicate — now enforced by type

Audience answers *who may see this at all*, permanently. Lifecycle answers *which surface shows it now*. Folding them together would give the predicate two legitimate bypasses (the holding list, and the tombstone lookup that distinguishes a recreation from a create) — **and a predicate with legitimate bypasses stops being enforced.**

The review pointed out that spelling a variant awkwardly is a hint, not a control. So the scope type is now split:

- **`ReadScope { Active, Holding, Extant }`** — no erased variant exists. `candidates` takes this.
- **`WriteScope { …, AnyIncludingErased }`** — `available_for_write` takes this.

A tombstone retains its title until Wave 2 strips it, so a read surface reaching one would serve content somebody erased. `no_read_scope_reaches_a_tombstone` enumerates every `ReadScope` and asserts none does.

## Participation: the finding that mattered most

The original version left `departed_at` out of the predicate, justified by "constructing a `MemberId` asserts current participation." **That was a doc comment. `from_uuid` was public and checked nothing.** Anyone could mint a `MemberId` for a departed member and the predicate would admit their rows.

The system was correct only because lane 1.4 independently chose to filter `departed_at IS NULL` — correct by coincidence of two lanes agreeing, not by construction.

Now: the mint is `pub(crate)` and renamed to `assert_participating`, so it reads as the assertion it is at every call site. Verified by compiling a probe from outside the crate:

```
error[E0624]: associated function `assert_participating` is private
```

The doc now states both halves — what the compiler enforces (the mint is crate-private, so the caller set is small and greppable) and what it does not (that any given call is *correct*).

**This turned up a second bug nobody asked about.** `EntityRow.author` and `.audience` were typed `MemberId` — but a *stored* reference carries no participation claim, which is exactly the claim `MemberId` exists to carry. The substrate: *"authorship never changes, so someone who leaves remains the author of what they wrote."* They are now `MemberRef`, with **no conversion** to `MemberId`, plus `MemberId::is(MemberRef)` for the comparison that would otherwise tempt someone to unify them. Without this, Wave 2 could read `row.author` and hand it back to the predicate as a requester — precisely the bug class above. The compiler found it the moment the constructor was renamed.

## Escaping the predicate — closed at runtime and at rest

`CandidateQuery::new` emits `SELECT … FROM entity e WHERE <predicate> AND <lifecycle>`; everything a caller adds is conjoined. The original conceded in a comment that `tail("UNION ALL SELECT … FROM entity e2")` could bolt on an unscoped second arm — a concession with no test behind it, which is just a limitation. Two controls now:

- `CandidateQuery` **refuses** any fragment or projection naming the table again (`from entity`, `join entity`, `public.`-qualified, whitespace-normalised).
- `nothing_outside_the_store_layer_queries_the_entity_table` refuses those shapes anywhere outside `store/`.

Writes are deliberately not caught, and the test says so: `INSERT INTO entity` is the write path's, where audience is enforced by looking the entity up first.

Also closed: a raw `$N` in a caller fragment. `.and_where("e.author_member_id = $1", [])` used to compile, run, and quietly compare against the *requesting member*. Now rejected, with `should_panic` tests for both the silently-wrong case and the unbound-`$2` case.

## Read-only transactions, claimed honestly

`begin_read` issues `SET TRANSACTION READ ONLY`. The original claimed Postgres enforced this "rather than review discipline" — overstated twice over: `ReadTx::conn()` handed out `&mut PgConnection`, so a caller could `COMMIT` through it and then write; and read-only mode is not absolute anyway.

`conn` is now `pub(crate)` on both transaction types. The module doc states what Postgres actually blocks (permanent-table `INSERT`/`UPDATE`/`DELETE`/`MERGE`/`COPY FROM`, DDL, `GRANT`, `REVOKE`, `TRUNCATE`) and what it does not (DML against pre-existing temp tables; it is not a promise about disk). **The claim is now that the escape cannot be reached by accident, and cannot be reached from outside the crate at all** — which is true, where the original was not.

## The one-place tests

Two tests, because one is insufficient: an exact-string count, plus a scan refusing any *other* file to name the audience column at all — because a hand-rolled paraphrase is the likely shape of a second implementation, not the unlikely one. I verified both fail by planting an exact copy and a paraphrase; the exact-count test caught only the exact copy.

Residual gap, now named in the test's own module doc rather than left to be discovered: a computed *table* name, a view, or a second implementation written inside `audience.rs` itself still pass.

## Verification

Rebased onto `9c68b26`. Run by the orchestrator, not self-reported. Test count went 11 → 20:

```
$ cargo test --workspace
  tests/audience.rs       15 passed     tests/one_predicate.rs   3 passed
  tests/store.rs           2 passed     tests/contract.rs        2 passed
$ cargo clippy --workspace --all-targets --all-features -- -D warnings   # clean
$ cargo fmt --all --check                                                # clean
$ unset DATABASE_URL && cargo test --workspace --no-run                  # builds
```

That last one matters: runtime `sqlx::query`, **not** the `query!` macros, so a fresh checkout builds without a database and concurrent lanes do not fight over a shared `.sqlx` directory.

## ⚠️ Merge note for lane 1.4 (#8)

If #8 lands a `MemberId::from_uuid` call site, it needs renaming to `assert_participating`. Same crate, so visibility is fine — a one-line rename.

## For Wave 2

- **The write path still must not create a null-author-with-audience row.** The predicate now fails closed on it, so it is defence in depth rather than the only guard — but it remains an incoherent state.
- **`MemberRef` vs `MemberId` is load-bearing, not ceremony.** Reading `row.author` gives a `MemberRef` and there is no conversion. Wanting one is the bug the split exists to catch.
- No relation query surface — relations need the predicate on *both* endpoints, and that composition is the place this design is most likely to strain. The `FROM entity` scan will catch the attempt.
- No `FOR UPDATE` helper; the intent spine's locking discipline is 2.1's call.