### PR TITLE
Wave 1.3: file bodies behind four operations, and a test that keeps them there

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,8 +36,12 @@ version = "0.0.0"
 dependencies = [
  "altaird",
  "anyhow",
+ "async-trait",
  "dotenvy",
+ "futures",
  "sqlx",
+ "tempfile",
+ "thiserror",
  "tokio",
  "uuid",
 ]
@@ -455,6 +459,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +518,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,8 +546,10 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,8 @@ dependencies = [
  "async-trait",
  "dotenvy",
  "futures",
+ "proptest",
+ "pulldown-cmark",
  "sqlx",
  "tempfile",
  "thiserror",
@@ -149,6 +151,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,7 +234,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -580,14 +597,26 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1232,6 +1261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1286,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -1363,6 +1420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,9 +1436,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -1385,7 +1464,26 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1393,6 +1491,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1507,6 +1614,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1778,7 +1897,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2132,6 +2251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,6 +2343,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,6 +2365,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2434,6 +2577,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,6 +2609,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/crates/altaird/Cargo.toml
+++ b/crates/altaird/Cargo.toml
@@ -10,11 +10,15 @@ testing = ["dep:dotenvy"]
 
 [dependencies]
 anyhow = "1.0.104"
+async-trait = "0.1.89"
 dotenvy = { version = "0.15.7", optional = true }
+futures = "0.3.31"
 sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "uuid", "chrono", "macros", "migrate"] }
-tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros"] }
+thiserror = "2.0.19"
+tokio = { version = "1.53.1", features = ["fs", "io-util", "rt-multi-thread", "macros"] }
 uuid = { version = "1.24.1", features = ["v4"] }
 
 
 [dev-dependencies]
 altaird = { path = ".", features = ["testing"] }
+tempfile = "3.24.0"

--- a/crates/altaird/src/lib.rs
+++ b/crates/altaird/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod objects;
 pub mod store;
 
 #[cfg(feature = "testing")]

--- a/crates/altaird/src/objects/filesystem.rs
+++ b/crates/altaird/src/objects/filesystem.rs
@@ -1,0 +1,299 @@
+//! The filesystem, behind the four operations (DR-003).
+//!
+//! Everything in this file is *beneath* the interface and therefore not a
+//! decision at this level: the directory fan-out, the staging area, the chunk
+//! size, and the use of rename to publish a body are all replaceable without
+//! any caller noticing. What callers may rely on is only what
+//! [`super::ObjectStore`] promises.
+//!
+//! The one path that crosses this boundary is the root directory, named once
+//! when the store is opened. Nothing hands a path back out.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use futures::StreamExt;
+use futures::stream;
+use tokio::fs;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use uuid::Uuid;
+
+use super::{Body, BodyId, BodyListing, BodyStream, ByteSource, Error, ObjectStore, StoredBody};
+
+/// Read and written in 64 KiB pieces. Large enough that syscall overhead
+/// disappears against the copy, small enough that a body of any size costs
+/// bounded memory at the boundary and fits inside a gRPC message with room to
+/// spare.
+const CHUNK: usize = 64 * 1024;
+
+/// Bodies are published under two levels of 256, taken from the first four hex
+/// digits of the identity. Not meaning — the identity stays opaque — only a
+/// way to keep any one directory small enough that the enumerate walk stays
+/// cheap on a household's worth of files.
+const FAN_OUT: &str = "bodies";
+
+/// Incomplete uploads live here and are renamed into place when whole, so a
+/// reader never sees a partial body and a crash never leaves one visible.
+const STAGING: &str = "staging";
+
+pub struct FilesystemObjectStore {
+    root: PathBuf,
+}
+
+impl FilesystemObjectStore {
+    /// Open, creating the layout if it is not there.
+    ///
+    /// This is the only place a filesystem path enters, and it does not leave
+    /// again.
+    pub async fn open(root: impl AsRef<Path> + Send) -> Result<Self, Error> {
+        let root = root.as_ref().to_path_buf();
+        fs::create_dir_all(root.join(FAN_OUT))
+            .await
+            .map_err(Error::Unavailable)?;
+        fs::create_dir_all(root.join(STAGING))
+            .await
+            .map_err(Error::Unavailable)?;
+        Ok(Self { root })
+    }
+
+    fn bodies(&self) -> PathBuf {
+        self.root.join(FAN_OUT)
+    }
+
+    fn body_path(&self, id: BodyId) -> PathBuf {
+        let name = id.as_uuid().simple().to_string();
+        self.bodies()
+            .join(&name[0..2])
+            .join(&name[2..4])
+            .join(&name)
+    }
+
+    /// Whether the store itself is reachable, asked only when an operation has
+    /// already come back empty-handed. A missing body under a present store is
+    /// [`Error::NoSuchBody`]; a missing store is [`Error::Unavailable`], and
+    /// conflating the two would let reclamation read "the disk is not mounted"
+    /// as "those bytes are already gone".
+    async fn absent_or_unavailable(&self, cause: io::Error) -> Error {
+        match fs::metadata(self.bodies()).await {
+            Ok(meta) if meta.is_dir() => Error::NoSuchBody,
+            _ => Error::Unavailable(cause),
+        }
+    }
+}
+
+/// Removes its file unless it was published. Covers every way out of `put` —
+/// a source that stopped, a write that failed, a future that was dropped —
+/// so a failed upload leaves nothing behind.
+struct Staged {
+    path: PathBuf,
+    published: bool,
+}
+
+impl Drop for Staged {
+    fn drop(&mut self) {
+        if !self.published {
+            // Blocking, but it is one unlink on a failure path.
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+/// `fsync` on the directory, so a rename survives a crash rather than only the
+/// bytes it published. Without this, "the bytes are durable before the record
+/// is committed" is true of the content and not of the name that finds it.
+#[cfg(unix)]
+async fn sync_dir(dir: &Path) -> io::Result<()> {
+    fs::File::open(dir).await?.sync_all().await
+}
+
+#[cfg(not(unix))]
+async fn sync_dir(_dir: &Path) -> io::Result<()> {
+    // Opening a directory as a file is not portable. Platforms without it get
+    // the file's own durability and not the rename's.
+    Ok(())
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for FilesystemObjectStore {
+    async fn put(&self, id: BodyId, mut source: ByteSource) -> Result<u64, Error> {
+        let mut staged = Staged {
+            path: self
+                .root
+                .join(STAGING)
+                .join(format!("{}.part", Uuid::new_v4().simple())),
+            published: false,
+        };
+
+        let mut file = fs::File::create(&staged.path)
+            .await
+            .map_err(Error::Unavailable)?;
+
+        let mut written: u64 = 0;
+        while let Some(chunk) = source.next().await {
+            let chunk = chunk.map_err(Error::Source)?;
+            file.write_all(&chunk).await.map_err(Error::Unavailable)?;
+            written += chunk.len() as u64;
+        }
+
+        // Durable before it is visible, and visible only whole. Callers order
+        // the record after this returns; that ordering is worth nothing if the
+        // bytes are still in a page cache when the record commits.
+        file.sync_all().await.map_err(Error::Unavailable)?;
+        drop(file);
+
+        let destination = self.body_path(id);
+        let parent = destination.parent().expect("a body path has a parent");
+        fs::create_dir_all(parent)
+            .await
+            .map_err(Error::Unavailable)?;
+
+        // Rename is atomic and replaces silently, which is exactly what
+        // idempotent re-upload wants: a second attempt at the same identity
+        // repairs whatever the first one left, and no reader observes the
+        // moment in between.
+        fs::rename(&staged.path, &destination)
+            .await
+            .map_err(Error::Unavailable)?;
+        staged.published = true;
+
+        sync_dir(parent).await.map_err(Error::Unavailable)?;
+        Ok(written)
+    }
+
+    async fn get(&self, id: BodyId) -> Result<Body, Error> {
+        let path = self.body_path(id);
+
+        let meta = match fs::metadata(&path).await {
+            Ok(meta) => meta,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                return Err(self.absent_or_unavailable(e).await);
+            }
+            Err(e) => return Err(Error::Unavailable(e)),
+        };
+
+        let file = match fs::File::open(&path).await {
+            Ok(file) => file,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                return Err(self.absent_or_unavailable(e).await);
+            }
+            Err(e) => return Err(Error::Unavailable(e)),
+        };
+
+        // Read lazily. A caller relaying a body to a client never holds more
+        // than one chunk of it.
+        let chunks: BodyStream = Box::pin(stream::unfold(Some(file), |state| async move {
+            let mut file = state?;
+            let mut buf = vec![0u8; CHUNK];
+            match file.read(&mut buf).await {
+                Ok(0) => None,
+                Ok(n) => {
+                    buf.truncate(n);
+                    Some((Ok(buf), Some(file)))
+                }
+                Err(e) => Some((Err(Error::Unavailable(e)), None)),
+            }
+        }));
+
+        Ok(Body::new(meta.len(), chunks))
+    }
+
+    async fn delete(&self, id: BodyId) -> Result<(), Error> {
+        match fs::remove_file(self.body_path(id)).await {
+            Ok(()) => Ok(()),
+            // Already gone is the ordinary case: erasure and the sweep both
+            // remove the same bytes, and they race by design.
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                match self.absent_or_unavailable(e).await {
+                    Error::NoSuchBody => Ok(()),
+                    other => Err(other),
+                }
+            }
+            Err(e) => Err(Error::Unavailable(e)),
+        }
+    }
+
+    fn enumerate(&self) -> BodyListing<'_> {
+        Box::pin(stream::unfold(
+            Walk::Start(self.bodies()),
+            |state| async move {
+                let mut stack = match state {
+                    Walk::Start(root) => match fs::read_dir(&root).await {
+                        Ok(dir) => vec![dir],
+                        // The store is unreachable. Say so once, then end: a sweep
+                        // that saw this must not conclude anything about what is
+                        // held.
+                        Err(e) => {
+                            return Some((Err(Error::Unavailable(e)), Walk::Walking(Vec::new())));
+                        }
+                    },
+                    Walk::Walking(stack) => stack,
+                };
+
+                loop {
+                    let dir = stack.last_mut()?;
+                    let entry = match dir.next_entry().await {
+                        Ok(Some(entry)) => entry,
+                        Ok(None) => {
+                            stack.pop();
+                            continue;
+                        }
+                        Err(e) => {
+                            stack.pop();
+                            return Some((Err(Error::Unavailable(e)), Walk::Walking(stack)));
+                        }
+                    };
+
+                    let file_type = match entry.file_type().await {
+                        Ok(file_type) => file_type,
+                        Err(e) => return Some((Err(Error::Unavailable(e)), Walk::Walking(stack))),
+                    };
+
+                    if file_type.is_dir() {
+                        match fs::read_dir(entry.path()).await {
+                            Ok(dir) => stack.push(dir),
+                            Err(e) => {
+                                return Some((Err(Error::Unavailable(e)), Walk::Walking(stack)));
+                            }
+                        }
+                        continue;
+                    }
+
+                    // Nothing but published bodies should be here; anything else
+                    // is not the store's to report on.
+                    let Some(id) = entry
+                        .file_name()
+                        .to_str()
+                        .and_then(|name| Uuid::try_parse(name).ok())
+                        .map(BodyId::from_uuid)
+                    else {
+                        continue;
+                    };
+
+                    let meta = match entry.metadata().await {
+                        Ok(meta) => meta,
+                        // It was published a moment ago and erased before the stat.
+                        // Nothing is owed about a body that is no longer there.
+                        Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+                        Err(e) => return Some((Err(Error::Unavailable(e)), Walk::Walking(stack))),
+                    };
+
+                    let body = StoredBody {
+                        id,
+                        len: meta.len(),
+                        written_at: meta.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+                    };
+                    return Some((Ok(body), Walk::Walking(stack)));
+                }
+            },
+        ))
+    }
+}
+
+/// The walk holds only the open directories on its current path, so
+/// enumerating costs memory in the depth of the layout rather than in the
+/// number of bodies.
+enum Walk {
+    Start(PathBuf),
+    Walking(Vec<fs::ReadDir>),
+}

--- a/crates/altaird/src/objects/interface.rs
+++ b/crates/altaird/src/objects/interface.rs
@@ -1,0 +1,227 @@
+//! The four operations, and nothing else.
+//!
+//! This file is the boundary DR-003 calls "the decision". It names no
+//! filesystem type on purpose: if a path could cross it, the four operations
+//! would stop being the whole boundary and replacing what sits behind them
+//! would stop being contained. A test in `tests/object_store_boundary.rs`
+//! fails if the word for a filesystem path appears here at all.
+
+use std::time::SystemTime;
+use std::{fmt, pin::Pin};
+
+use futures::Stream;
+use uuid::Uuid;
+
+/// Whatever went wrong upstream of the store while it was producing bytes —
+/// a client that hung up mid-upload, most often. The store does not interpret
+/// it; it only has to be able to say a `put` failed for a reason that was not
+/// the store's.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Bytes on their way in. A stream rather than a slice because `PutBody` is a
+/// streaming RPC and a body has no size limit: taking `&[u8]` would put every
+/// uploaded file in memory at the boundary, whatever sat behind it.
+pub type ByteSource = Pin<Box<dyn Stream<Item = Result<Vec<u8>, BoxError>> + Send + 'static>>;
+
+/// Bytes on their way out, in the same chunked shape `GetBody` returns them.
+pub type BodyStream = Pin<Box<dyn Stream<Item = Result<Vec<u8>, Error>> + Send + 'static>>;
+
+/// What the store holds, one item at a time. Borrowed from the store so an
+/// implementation may hold a connection open across the walk.
+pub type BodyListing<'a> = Pin<Box<dyn Stream<Item = Result<StoredBody, Error>> + Send + 'a>>;
+
+/// The identity of one body.
+///
+/// A random UUIDv4 assigned by whatever brought the body into existence, and
+/// read by nothing (DR-007). It is deliberately not derived from the content:
+/// content addressing would make the identity mean something, and something
+/// would eventually parse it back out.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BodyId(Uuid);
+
+impl BodyId {
+    /// A fresh identity. Callers that already hold one — the client assigns it
+    /// before the upload starts — use [`BodyId::from_uuid`] or [`TryFrom`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    #[must_use]
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    /// The sixteen bytes the wire carries in `BodyChunk.body_id`.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        self.0.as_bytes()
+    }
+
+    pub(crate) fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl Default for BodyId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Sixteen bytes off the wire. The only failure is a wrong length, which is a
+/// malformed request rather than anything the store has an opinion about.
+impl TryFrom<&[u8]> for BodyId {
+    type Error = uuid::Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, uuid::Error> {
+        Uuid::from_slice(bytes).map(Self)
+    }
+}
+
+impl fmt::Debug for BodyId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BodyId({})", self.0.simple())
+    }
+}
+
+/// One body, as [`ObjectStore::enumerate`] sees it: identity, size, and when
+/// the bytes landed.
+///
+/// The timestamp is here because reclamation needs it. Bytes are written
+/// before the record that points at them, so at any moment some unreferenced
+/// bytes belong to a record that is about to be committed. Without an age, a
+/// sweep cannot tell those from genuine orphans and would delete a body out
+/// from under a capture in flight. What the grace period should be is Wave
+/// 2.4's to decide; being able to have one is this interface's obligation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StoredBody {
+    pub id: BodyId,
+    pub len: u64,
+    pub written_at: SystemTime,
+}
+
+/// One body, on its way to a reader.
+///
+/// The length is separated from the bytes so a caller can say how big the
+/// answer is before it has read any of it, and never has to buffer the body to
+/// find out.
+pub struct Body {
+    pub len: u64,
+    chunks: BodyStream,
+}
+
+impl Body {
+    #[must_use]
+    pub fn new(len: u64, chunks: BodyStream) -> Self {
+        Self { len, chunks }
+    }
+
+    #[must_use]
+    pub fn into_chunks(self) -> BodyStream {
+        self.chunks
+    }
+}
+
+impl fmt::Debug for Body {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Body").field("len", &self.len).finish()
+    }
+}
+
+/// What can go wrong.
+///
+/// The two absent cases are separate on purpose, because the component model
+/// makes them different statements to a person: a body that is not there is
+/// missing, and a store that cannot be reached means the entity, its title,
+/// its relations and its derived text are all still available and only the
+/// body is *currently unavailable*.
+///
+/// It also matters to reclamation, which must never read "the store is gone"
+/// as "the bytes are already deleted".
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// No body has that identity. The store answered.
+    #[error("no body with that identity")]
+    NoSuchBody,
+
+    /// The store could not answer. Says nothing about whether the body exists.
+    #[error("the object store is currently unavailable")]
+    Unavailable(#[source] std::io::Error),
+
+    /// The bytes being uploaded stopped arriving. Nothing was stored.
+    #[error("the byte source failed before the body was complete")]
+    Source(#[source] BoxError),
+}
+
+impl Error {
+    /// True when the store answered and the answer was "not here".
+    #[must_use]
+    pub fn is_no_such_body(&self) -> bool {
+        matches!(self, Self::NoSuchBody)
+    }
+
+    /// True when the store could not answer, which is never evidence about
+    /// what it holds.
+    #[must_use]
+    pub fn is_currently_unavailable(&self) -> bool {
+        matches!(self, Self::Unavailable(_))
+    }
+}
+
+/// Write bytes, read a body, remove bytes, and enumerate what is held.
+///
+/// Deliberately absent, because nothing in the requirements asks for it:
+/// content addressing, multipart upload, lifecycle policy, replication,
+/// listing by prefix, and any notion of a container or bucket.
+///
+/// **This cannot participate in a transaction with the structured store**, and
+/// the interface offers nothing that pretends otherwise. That is why the
+/// ordering rules exist and why they are the caller's to keep: bytes before
+/// the record on creation, the record before the bytes on erasure. Every
+/// operation here is one step, so a caller can order the two sides itself.
+#[async_trait::async_trait]
+pub trait ObjectStore: Send + Sync + 'static {
+    /// Store `source` under `id`, and answer with how many bytes were stored.
+    ///
+    /// **Idempotent**, as the wire contract promises: re-uploading the same
+    /// identity after a broken connection is ordinary, and repeats the write
+    /// rather than refusing it, so an attempt that was cut short is repaired
+    /// rather than left half-written. Content is the caller's promise; nothing
+    /// here compares bytes.
+    ///
+    /// **A body becomes visible whole or not at all.** No reader ever observes
+    /// a partial one, and a `put` that fails part-way stores nothing.
+    ///
+    /// Returning means the bytes are durable, which is what makes "bytes
+    /// before the record" worth anything.
+    async fn put(&self, id: BodyId, source: ByteSource) -> Result<u64, Error>;
+
+    /// Read a body back whole.
+    ///
+    /// [`Error::NoSuchBody`] when the store answered and holds no such body;
+    /// [`Error::Unavailable`] when it could not answer.
+    async fn get(&self, id: BodyId) -> Result<Body, Error>;
+
+    /// Remove the bytes.
+    ///
+    /// **Idempotent, and removing something absent is success**, because
+    /// reclamation sweeps repeatedly and erasure may have already removed the
+    /// same bytes. It is not success when the store could not be reached —
+    /// that is [`Error::Unavailable`], so a sweep never records bytes as gone
+    /// on the strength of a store it could not talk to.
+    async fn delete(&self, id: BodyId) -> Result<(), Error>;
+
+    /// Every body held, one at a time.
+    ///
+    /// **Load-bearing rather than housekeeping.** Erasure removes the record
+    /// before the bytes, so this sweep is what closes the erasure window;
+    /// reclamation joins what this yields against what the structured store
+    /// references.
+    ///
+    /// It streams, and never reads a body, so the cost is one directory walk
+    /// and one stat per body no matter how large the bodies are — which is
+    /// what "cheap enough to run on a schedule" requires. Order is not
+    /// specified, and a caller that depends on one is wrong.
+    fn enumerate(&self) -> BodyListing<'_>;
+}

--- a/crates/altaird/src/objects/mod.rs
+++ b/crates/altaird/src/objects/mod.rs
@@ -1,0 +1,18 @@
+//! File bodies, and nothing else.
+//!
+//! Four operations — put, get, delete, enumerate — with the filesystem behind
+//! them (DR-003). The interface is the decision: it is small enough that
+//! putting something else behind it later is a contained piece of work, and
+//! that stays true only while nothing outside it touches the bytes.
+//!
+//! [`interface`] holds the boundary and names no filesystem type;
+//! [`filesystem`] holds the one implementation and everything beneath the
+//! boundary, none of which is a decision at this level.
+
+mod filesystem;
+mod interface;
+
+pub use filesystem::FilesystemObjectStore;
+pub use interface::{
+    Body, BodyId, BodyListing, BodyStream, BoxError, ByteSource, Error, ObjectStore, StoredBody,
+};

--- a/crates/altaird/tests/object_store.rs
+++ b/crates/altaird/tests/object_store.rs
@@ -1,0 +1,380 @@
+//! The four operations, exercised against the filesystem implementation.
+//!
+//! These tests are written against [`ObjectStore`] and never against the
+//! filesystem behind it, except where they deliberately break the store to
+//! check what it says when it cannot answer, and where they assert that a
+//! failed upload left nothing behind. Both need to see the root directory the
+//! test itself created, and both are named in the allow list in
+//! `object_store_boundary.rs`.
+
+use std::time::{Duration, SystemTime};
+
+use altaird::objects::{
+    Body, BodyId, ByteSource, Error, FilesystemObjectStore, ObjectStore, StoredBody,
+};
+use futures::{StreamExt, stream};
+use tempfile::TempDir;
+
+async fn store() -> (TempDir, FilesystemObjectStore) {
+    let root = TempDir::new().expect("temp root");
+    let store = FilesystemObjectStore::open(root.path())
+        .await
+        .expect("open the store");
+    (root, store)
+}
+
+fn source(chunks: Vec<Vec<u8>>) -> ByteSource {
+    Box::pin(stream::iter(chunks.into_iter().map(Ok)))
+}
+
+/// A source that produces some bytes and then stops, the way a client that
+/// hangs up mid-upload does.
+fn failing_source(prefix: Vec<u8>) -> ByteSource {
+    Box::pin(stream::iter(vec![
+        Ok(prefix),
+        Err("the client hung up".into()),
+    ]))
+}
+
+async fn drain(body: Body) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let mut chunks = body.into_chunks();
+    while let Some(chunk) = chunks.next().await {
+        bytes.extend_from_slice(&chunk.expect("read a chunk"));
+    }
+    bytes
+}
+
+async fn listing(store: &FilesystemObjectStore) -> Vec<StoredBody> {
+    store
+        .enumerate()
+        .map(|entry| entry.expect("enumerate"))
+        .collect()
+        .await
+}
+
+/// Two hundred kilobytes, so both the write and the read cross the chunk size
+/// several times and the test is not silently about a single buffer.
+fn large_body() -> Vec<u8> {
+    (0..200 * 1024).map(|i| (i % 251) as u8).collect()
+}
+
+#[tokio::test]
+async fn put_then_get_returns_the_same_bytes() {
+    let (_root, store) = store().await;
+    let id = BodyId::new();
+    let bytes = large_body();
+
+    let written = store
+        .put(id, source(vec![bytes.clone()]))
+        .await
+        .expect("put");
+    assert_eq!(written, bytes.len() as u64);
+
+    let body = store.get(id).await.expect("get");
+    assert_eq!(body.len, bytes.len() as u64);
+    assert_eq!(drain(body).await, bytes);
+}
+
+#[tokio::test]
+async fn a_body_arriving_in_pieces_is_stored_whole() {
+    let (_root, store) = store().await;
+    let id = BodyId::new();
+    let pieces: Vec<Vec<u8>> = (0..8u8).map(|n| vec![n; 40 * 1024]).collect();
+    let whole: Vec<u8> = pieces.concat();
+
+    let written = store.put(id, source(pieces)).await.expect("put");
+    assert_eq!(written, whole.len() as u64);
+    assert_eq!(drain(store.get(id).await.expect("get")).await, whole);
+}
+
+#[tokio::test]
+async fn an_empty_body_round_trips() {
+    let (_root, store) = store().await;
+    let id = BodyId::new();
+
+    assert_eq!(store.put(id, source(vec![])).await.expect("put"), 0);
+    let body = store.get(id).await.expect("get");
+    assert_eq!(body.len, 0);
+    assert!(drain(body).await.is_empty());
+}
+
+#[tokio::test]
+async fn re_uploading_the_same_identity_is_ordinary_and_repairs_the_first_attempt() {
+    let (_root, store) = store().await;
+    let id = BodyId::new();
+
+    // A first attempt that was cut short leaves nothing.
+    let failed = store.put(id, failing_source(vec![9; 4096])).await;
+    assert!(matches!(failed, Err(Error::Source(_))), "{failed:?}");
+    assert!(store.get(id).await.is_err());
+
+    // The retry is not refused, and the body is whole afterwards.
+    let bytes = vec![7u8; 100 * 1024];
+    store
+        .put(id, source(vec![bytes.clone()]))
+        .await
+        .expect("retry");
+    assert_eq!(drain(store.get(id).await.expect("get")).await, bytes);
+
+    // And a second complete upload of the same identity is accepted too.
+    store
+        .put(id, source(vec![bytes.clone()]))
+        .await
+        .expect("re-upload");
+    assert_eq!(drain(store.get(id).await.expect("get")).await, bytes);
+    assert_eq!(listing(&store).await.len(), 1, "one identity, one body");
+}
+
+#[tokio::test]
+async fn an_upload_that_fails_part_way_stores_nothing_and_leaves_nothing() {
+    let (root, store) = store().await;
+    let id = BodyId::new();
+
+    let failed = store.put(id, failing_source(vec![1; 64 * 1024])).await;
+    assert!(matches!(failed, Err(Error::Source(_))), "{failed:?}");
+
+    assert!(
+        store.get(id).await.unwrap_err().is_no_such_body(),
+        "a partial body must never become visible"
+    );
+    assert!(listing(&store).await.is_empty());
+
+    let staged: Vec<_> = std::fs::read_dir(root.path().join("staging"))
+        .expect("staging")
+        .map(|entry| entry.expect("entry").file_name())
+        .collect();
+    assert!(staged.is_empty(), "incomplete upload left {staged:?}");
+}
+
+#[tokio::test]
+async fn getting_a_body_that_was_never_put_says_no_such_body() {
+    let (_root, store) = store().await;
+    let error = store.get(BodyId::new()).await.unwrap_err();
+    assert!(error.is_no_such_body(), "{error:?}");
+    assert!(!error.is_currently_unavailable());
+}
+
+#[tokio::test]
+async fn delete_removes_the_bytes_and_repeats_without_complaint() {
+    let (_root, store) = store().await;
+    let id = BodyId::new();
+    store
+        .put(id, source(vec![vec![3; 1024]]))
+        .await
+        .expect("put");
+
+    store.delete(id).await.expect("first delete");
+    assert!(store.get(id).await.unwrap_err().is_no_such_body());
+
+    // Reclamation sweeps repeatedly and erasure may already have run.
+    store.delete(id).await.expect("second delete");
+    store
+        .delete(BodyId::new())
+        .await
+        .expect("delete of something never stored");
+}
+
+#[tokio::test]
+async fn enumerate_yields_every_body_with_its_size_and_age() {
+    let (_root, store) = store().await;
+    let before = SystemTime::now() - Duration::from_secs(1);
+
+    let mut expected: Vec<(BodyId, u64)> = Vec::new();
+    for n in 0..12u8 {
+        let id = BodyId::new();
+        let len = u64::from(n) * 1000;
+        store
+            .put(id, source(vec![vec![n; len as usize]]))
+            .await
+            .expect("put");
+        expected.push((id, len));
+    }
+
+    let mut held: Vec<(BodyId, u64)> = listing(&store)
+        .await
+        .into_iter()
+        .inspect(|body| {
+            // Reclamation needs an age to tell a genuine orphan from bytes
+            // whose record is about to be committed.
+            assert!(body.written_at >= before, "{:?}", body.written_at);
+            assert!(
+                body.written_at <= SystemTime::now() + Duration::from_secs(1),
+                "{:?}",
+                body.written_at
+            );
+        })
+        .map(|body| (body.id, body.len))
+        .collect();
+
+    held.sort_by_key(|(id, _)| *id.as_bytes());
+    expected.sort_by_key(|(id, _)| *id.as_bytes());
+    assert_eq!(held, expected);
+}
+
+#[tokio::test]
+async fn enumerate_stops_seeing_what_was_deleted() {
+    let (_root, store) = store().await;
+    let kept = BodyId::new();
+    let swept = BodyId::new();
+    store
+        .put(kept, source(vec![vec![1; 10]]))
+        .await
+        .expect("put");
+    store
+        .put(swept, source(vec![vec![2; 20]]))
+        .await
+        .expect("put");
+
+    store.delete(swept).await.expect("delete");
+
+    let held = listing(&store).await;
+    assert_eq!(held.len(), 1);
+    assert_eq!(held[0].id, kept);
+}
+
+#[tokio::test]
+async fn enumerate_is_lazy_and_never_reads_a_body() {
+    let (_root, store) = store().await;
+    let bytes = large_body();
+    for _ in 0..20 {
+        store
+            .put(BodyId::new(), source(vec![bytes.clone()]))
+            .await
+            .expect("put");
+    }
+
+    // Taking one item does not walk, stat, or read the rest. The size is
+    // reported without the bytes ever being opened, which is what keeps the
+    // sweep cheap enough to run on a schedule.
+    let first: Vec<_> = store.enumerate().take(1).collect().await;
+    assert_eq!(first.len(), 1);
+    assert_eq!(
+        first[0].as_ref().expect("entry").len,
+        bytes.len() as u64,
+        "size comes from the walk, not from reading"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_store_enumerates_to_nothing() {
+    let (_root, store) = store().await;
+    assert!(listing(&store).await.is_empty());
+}
+
+#[tokio::test]
+async fn a_store_that_cannot_be_reached_says_so_rather_than_saying_the_body_is_missing() {
+    let (root, store) = store().await;
+    let id = BodyId::new();
+    store
+        .put(id, source(vec![vec![5; 4096]]))
+        .await
+        .expect("put");
+
+    std::fs::remove_dir_all(root.path()).expect("take the store away");
+
+    let error = store.get(id).await.unwrap_err();
+    assert!(
+        error.is_currently_unavailable(),
+        "the body is currently unavailable, which is not the same as missing: {error:?}"
+    );
+    assert!(!error.is_no_such_body());
+}
+
+#[tokio::test]
+async fn a_store_that_cannot_be_reached_never_reports_bytes_as_already_gone() {
+    let (root, store) = store().await;
+    let id = BodyId::new();
+    store
+        .put(id, source(vec![vec![5; 4096]]))
+        .await
+        .expect("put");
+
+    std::fs::remove_dir_all(root.path()).expect("take the store away");
+
+    // Success here would let a sweep record an erasure that never happened.
+    let error = store.delete(id).await.unwrap_err();
+    assert!(error.is_currently_unavailable(), "{error:?}");
+
+    // And the sweep must not read an unreachable store as an empty one, which
+    // would make every body look unreferenced.
+    let listed: Vec<_> = store.enumerate().collect().await;
+    assert_eq!(listed.len(), 1);
+    assert!(
+        listed[0].as_ref().unwrap_err().is_currently_unavailable(),
+        "{:?}",
+        listed[0]
+    );
+}
+
+#[tokio::test]
+async fn a_put_that_cannot_reach_the_store_stores_nothing_and_says_it_is_unavailable() {
+    let (root, store) = store().await;
+    std::fs::remove_dir_all(root.path()).expect("take the store away");
+
+    let error = store
+        .put(BodyId::new(), source(vec![vec![1; 16]]))
+        .await
+        .unwrap_err();
+    assert!(error.is_currently_unavailable(), "{error:?}");
+}
+
+#[tokio::test]
+async fn many_bodies_land_at_once() {
+    let (_root, store) = store().await;
+    let store = std::sync::Arc::new(store);
+
+    let mut tasks = Vec::new();
+    for n in 0..32u8 {
+        let store = store.clone();
+        tasks.push(tokio::spawn(async move {
+            let id = BodyId::new();
+            store
+                .put(id, source(vec![vec![n; 1024 * (usize::from(n) + 1)]]))
+                .await
+                .expect("put");
+            id
+        }));
+    }
+
+    let mut ids = Vec::new();
+    for task in tasks {
+        ids.push(task.await.expect("task"));
+    }
+
+    let held = listing(&store).await;
+    assert_eq!(held.len(), ids.len());
+    for id in ids {
+        assert!(held.iter().any(|body| body.id == id));
+    }
+}
+
+/// The interface offers no way to make a body and a record atomic, and that is
+/// the point: a caller orders the two sides itself. This is the creation half
+/// of the rule, written as a caller would write it.
+#[tokio::test]
+async fn bytes_can_be_made_durable_before_any_record_points_at_them() {
+    let (_root, store) = store().await;
+    let id = BodyId::new();
+    let bytes = vec![42u8; 8192];
+
+    // Step one: the bytes. When this returns they are durable and readable,
+    // and nothing anywhere refers to them yet — which is exactly the orphan
+    // the sweep is allowed to collect if step two never happens.
+    store
+        .put(id, source(vec![bytes.clone()]))
+        .await
+        .expect("put");
+    assert_eq!(drain(store.get(id).await.expect("get")).await, bytes);
+
+    let orphans = listing(&store).await;
+    assert_eq!(orphans.len(), 1);
+    assert_eq!(orphans[0].id, id);
+
+    // Step two, the record, belongs to the write path and is not this lane's.
+    // The erasure half inverts the order, and `delete` tolerating an absent
+    // body is what lets it be retried until it takes.
+    store.delete(id).await.expect("erase the bytes");
+    store.delete(id).await.expect("and again, after a crash");
+    assert!(listing(&store).await.is_empty());
+}

--- a/crates/altaird/tests/object_store_boundary.rs
+++ b/crates/altaird/tests/object_store_boundary.rs
@@ -10,9 +10,24 @@
 //! the interface hands one out, and callers do the rest innocently. Or a
 //! caller can *reach around* — it never asks the store for anything and opens
 //! the file itself.
+//!
+//! Which crates the reaching-around check covers, and what that scope
+//! deliberately gives up, is on `crates_that_could_hold_an_object_store`. Read
+//! it before adding a crate to the workspace that touches the filesystem.
 
 use std::fs;
 use std::path::{Path, PathBuf};
+
+/// The crate the interface lives in, and the one this is a test of.
+const INSTANCE: &str = "altaird";
+
+/// Crates that are scanned even though they do not link the instance.
+///
+/// Empty, and here so that the answer to "my crate holds the object root but
+/// does not depend on `altaird`" is an entry rather than a puzzle. See
+/// [`crates_that_could_hold_an_object_store`] for when that applies. Names are
+/// directory names under `crates/`.
+const ALSO_SCANNED: &[&str] = &[];
 
 /// Files that may name a filesystem path or perform filesystem I/O.
 ///
@@ -53,14 +68,71 @@ fn crates_dir() -> PathBuf {
         .to_path_buf()
 }
 
-/// Every `.rs` file under `crates/*/src` and `crates/*/tests`, which is all
-/// the code that runs as part of the instance or its tests. Build scripts are
-/// out of scope on purpose: they run before anything exists and cannot reach a
-/// body.
+/// Which crates are scanned, and why it is not simply all of them.
+///
+/// In scope is every crate that could hold an [`ObjectStore`]: `altaird`,
+/// where the four operations live, and any workspace crate that depends on it.
+/// Cargo forbids dependency cycles, so a crate that does not depend on
+/// `altaird` cannot name the interface at all, which makes "this went round
+/// the interface" a sentence that cannot be said about it. Its filesystem work
+/// is its own business and belongs to whatever it is a component of.
+///
+/// `altair-conformance` is the live example and the reason this scope is
+/// written down. It runs a client under test as a subprocess and hands it a
+/// durable state directory and an ephemeral runtime one — a distinction that
+/// is load bearing for the scenario that tells a device restart from a process
+/// kill. That is filesystem work with nothing to do with file bodies, in a
+/// crate that links `altair-proto` and not the instance.
+///
+/// **What this deliberately gives up.** A crate that never links `altaird` and
+/// reads the body directory anyway — a backup or migration tool handed the
+/// object root — is not scanned and would not be caught. That is a different
+/// mistake from the one DR-003 is guarding here, which is the instance going
+/// round its own boundary, and it is a harder one to make by accident: such a
+/// tool has to be given the root from configuration, and being given it is
+/// itself the reviewable moment. If one is ever written, name it in
+/// [`ALSO_SCANNED`] and this check covers it again.
+fn crates_that_could_hold_an_object_store() -> Vec<PathBuf> {
+    let mut scanned = Vec::new();
+    for entry in fs::read_dir(crates_dir()).expect("read crates/") {
+        let dir = entry.expect("entry").path();
+        let Ok(manifest) = fs::read_to_string(dir.join("Cargo.toml")) else {
+            continue;
+        };
+        let name = dir
+            .file_name()
+            .expect("a crate directory has a name")
+            .to_string_lossy()
+            .to_string();
+
+        if name == INSTANCE || ALSO_SCANNED.contains(&name.as_str()) || links_instance(&manifest) {
+            scanned.push(dir);
+        }
+    }
+    assert!(
+        scanned.iter().any(|dir| dir.ends_with(INSTANCE)),
+        "the crate holding the interface is not being scanned, so this test asserts nothing"
+    );
+    scanned
+}
+
+/// Whether a manifest declares a dependency on the instance, in any of the
+/// three tables. Deliberately generous: a manifest that mentions `altaird` at
+/// all is scanned, because over-scanning costs someone an explanation and
+/// under-scanning costs the boundary.
+fn links_instance(manifest: &str) -> bool {
+    manifest.lines().map(str::trim).any(|line| {
+        (line.starts_with(INSTANCE) && line.contains('='))
+            || (line.starts_with('[') && line.contains(INSTANCE))
+    })
+}
+
+/// Every `.rs` file under `src` and `tests` of the crates in scope. Build
+/// scripts are excluded on purpose: they run before anything exists and cannot
+/// reach a body.
 fn instance_sources() -> Vec<PathBuf> {
     let mut found = Vec::new();
-    for crate_dir in fs::read_dir(crates_dir()).expect("read crates/") {
-        let crate_dir = crate_dir.expect("entry").path();
+    for crate_dir in crates_that_could_hold_an_object_store() {
         for area in ["src", "tests"] {
             collect(&crate_dir.join(area), &mut found);
         }
@@ -126,11 +198,36 @@ fn nothing_outside_the_object_store_touches_the_bytes() {
     assert!(
         violations.is_empty(),
         "the object store's four operations are the whole boundary (DR-003), and this code goes \
-         round them. Use `altaird::objects::ObjectStore`, or, if this file genuinely has business \
-         with the filesystem that is not a file body, add it to ALLOWED in {} and say why.\n\n{}",
+         round them. These files are scanned because their crate links `{INSTANCE}` and can \
+         therefore hold an ObjectStore. Use `altaird::objects::ObjectStore`, or, if the file \
+         genuinely has business with the filesystem that is not a file body, add it to ALLOWED in \
+         {} and say why.\n\n{}",
         file!(),
         violations.join("\n")
     );
+}
+
+/// The scope follows the dependency, so nothing is excluded by name and a
+/// crate joins the scan the moment it can hold an `ObjectStore`. A crate added
+/// to the workspace next year does not need anyone to remember this test
+/// exists.
+#[test]
+fn a_crate_is_scanned_the_moment_it_links_the_instance() {
+    assert!(links_instance(
+        "[dependencies]\naltaird = { path = \"../altaird\" }\n"
+    ));
+    assert!(links_instance(
+        "[dev-dependencies]\naltaird = { path = \"../altaird\", features = [\"testing\"] }\n"
+    ));
+    assert!(links_instance(
+        "[dependencies.altaird]\npath = \"../altaird\"\n"
+    ));
+
+    // And a crate that links only the contract is a component of something
+    // else, whose filesystem work is not this boundary's business.
+    assert!(!links_instance(
+        "[dependencies]\naltair-proto = { path = \"../altair-proto\" }\ntokio = \"1\"\n"
+    ));
 }
 
 fn object_store_source(name: &str) -> String {

--- a/crates/altaird/tests/object_store_boundary.rs
+++ b/crates/altaird/tests/object_store_boundary.rs
@@ -1,0 +1,221 @@
+//! "Nothing outside the interface reads a path" is a condition, so it is a
+//! test rather than a comment.
+//!
+//! DR-003 makes the four operations the whole boundary, and says why: the
+//! moment something reads a path directly, replacing what sits behind the
+//! interface stops being contained. A note asking people not to do that fails
+//! silently. This fails loudly, on the line that did it.
+//!
+//! Two checks, because there are two ways to break it. A path can *escape* —
+//! the interface hands one out, and callers do the rest innocently. Or a
+//! caller can *reach around* — it never asks the store for anything and opens
+//! the file itself.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Files that may name a filesystem path or perform filesystem I/O.
+///
+/// Adding to this list is the deliberate act the whole test exists to make
+/// visible: a reviewer sees the entry in the diff and has to agree that the
+/// file has business touching the disk. Paths are relative to `crates/`.
+const ALLOWED: &[&str] = &[
+    // The store itself, which is the only thing permitted to know where the
+    // bytes are.
+    "altaird/src/objects/",
+    // Its own tests, which create the roots they hand to `open`, and check
+    // that a failed upload left nothing on disk.
+    "altaird/tests/object_store.rs",
+    // This file, which reads sources in order to make the assertion.
+    "altaird/tests/object_store_boundary.rs",
+];
+
+/// Reaching the bytes needs one of these. Naming a path is enough on its own:
+/// a path that never gets opened here gets opened somewhere else later.
+const REACHING_AROUND: &[&str] = &[
+    "std::fs",
+    "tokio::fs",
+    "fs::",
+    "PathBuf",
+    "Path::",
+    "AsRef<Path>",
+    "&Path",
+    "File::open",
+    "File::create",
+    "read_to_string",
+    "read_dir",
+];
+
+fn crates_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("the crate sits inside crates/")
+        .to_path_buf()
+}
+
+/// Every `.rs` file under `crates/*/src` and `crates/*/tests`, which is all
+/// the code that runs as part of the instance or its tests. Build scripts are
+/// out of scope on purpose: they run before anything exists and cannot reach a
+/// body.
+fn instance_sources() -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    for crate_dir in fs::read_dir(crates_dir()).expect("read crates/") {
+        let crate_dir = crate_dir.expect("entry").path();
+        for area in ["src", "tests"] {
+            collect(&crate_dir.join(area), &mut found);
+        }
+    }
+    found.sort();
+    assert!(
+        found.len() > 3,
+        "the walk found almost nothing, so it is not testing anything: {found:?}"
+    );
+    found
+}
+
+fn collect(dir: &Path, found: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries {
+        let path = entry.expect("entry").path();
+        if path.is_dir() {
+            collect(&path, found);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            found.push(path);
+        }
+    }
+}
+
+fn relative(path: &Path) -> String {
+    path.strip_prefix(crates_dir())
+        .expect("under crates/")
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn is_allowed(path: &Path) -> bool {
+    let relative = relative(path);
+    ALLOWED.iter().any(|allowed| relative.starts_with(allowed))
+}
+
+/// Reach around the interface and this fails, naming the file and the line.
+#[test]
+fn nothing_outside_the_object_store_touches_the_bytes() {
+    let mut violations = Vec::new();
+
+    for path in instance_sources() {
+        if is_allowed(&path) {
+            continue;
+        }
+        let source = fs::read_to_string(&path).expect("read a source file");
+        for (number, line) in source.lines().enumerate() {
+            for token in REACHING_AROUND {
+                if line.contains(token) {
+                    violations.push(format!(
+                        "{}:{}: `{token}` in `{}`",
+                        relative(&path),
+                        number + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "the object store's four operations are the whole boundary (DR-003), and this code goes \
+         round them. Use `altaird::objects::ObjectStore`, or, if this file genuinely has business \
+         with the filesystem that is not a file body, add it to ALLOWED in {} and say why.\n\n{}",
+        file!(),
+        violations.join("\n")
+    );
+}
+
+fn object_store_source(name: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/objects")
+        .join(name);
+    fs::read_to_string(&path).unwrap_or_else(|_| panic!("read {}", path.display()))
+}
+
+/// The other half: a path cannot leak *out* of the interface either, because
+/// the interface never names one.
+#[test]
+fn no_path_escapes_the_interface() {
+    let interface = object_store_source("interface.rs");
+    for token in ["Path", "fs::", "File"] {
+        assert!(
+            !interface.contains(token),
+            "`{token}` appears in the object store interface. The four operations stop being the \
+             whole boundary the moment one of them hands a caller a path, so the boundary names \
+             no filesystem type at all — not in a signature, and not in a returned value."
+        );
+    }
+}
+
+/// Beneath the interface, paths are ordinary and expected. What must stay true
+/// is that only opening the store names one: it is the single place a path
+/// enters, and there is no way back out.
+#[test]
+fn the_filesystem_implementation_names_a_path_only_where_the_store_is_opened() {
+    let source = object_store_source("filesystem.rs");
+    let lines: Vec<&str> = source.lines().collect();
+    let mut violations = Vec::new();
+
+    let mut index = 0;
+    while index < lines.len() {
+        if lines[index].trim_start().starts_with("pub ") {
+            // Take the whole declaration, which may be wrapped over lines.
+            let start = index;
+            let mut declaration = String::new();
+            while index < lines.len() {
+                declaration.push_str(lines[index]);
+                declaration.push(' ');
+                if lines[index].contains('{') || lines[index].contains(';') {
+                    break;
+                }
+                index += 1;
+            }
+            if declaration.contains("Path") && !declaration.contains("fn open") {
+                violations.push(format!("{}: {}", start + 1, declaration.trim()));
+            }
+        }
+        index += 1;
+    }
+
+    assert!(
+        violations.is_empty(),
+        "the root directory is named once, when the store is opened, and never leaves again. \
+         These public items in filesystem.rs name a path:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// DR-003 decides an interface of *exactly* four operations, and its smallness
+/// is what makes replacing the filesystem contained work rather than a
+/// migration. A fifth is a decision, not an addition.
+#[test]
+fn the_interface_is_still_four_operations() {
+    let interface = object_store_source("interface.rs");
+    let (_, trait_body) = interface
+        .split_once("pub trait ObjectStore")
+        .expect("the trait is declared here");
+
+    let operations: Vec<&str> = trait_body
+        .lines()
+        .filter(|line| {
+            let indented = line.starts_with("    ") && !line.starts_with("     ");
+            let declaration = line.trim_start();
+            indented && (declaration.starts_with("fn ") || declaration.starts_with("async fn "))
+        })
+        .collect();
+
+    assert_eq!(
+        operations.len(),
+        4,
+        "put, get, delete, enumerate — and nothing else (DR-003). Found:\n{}",
+        operations.join("\n")
+    );
+}

--- a/crates/altaird/tests/object_store_boundary.rs
+++ b/crates/altaird/tests/object_store_boundary.rs
@@ -34,6 +34,23 @@ const ALSO_SCANNED: &[&str] = &[];
 /// Adding to this list is the deliberate act the whole test exists to make
 /// visible: a reviewer sees the entry in the diff and has to agree that the
 /// file has business touching the disk. Paths are relative to `crates/`.
+///
+/// **Source-scanning tests are a category, and they are listed rather than
+/// recognised.** This repository enforces several structural rules by walking
+/// its own sources — that the audience predicate exists exactly once, that
+/// nothing goes round the four operations — and every such test reads `.rs`
+/// files for a living, so each one trips every other one. That is a pattern
+/// now and it will keep happening, which is an argument for detecting the
+/// kind rather than naming the members. It is not detectable precisely
+/// enough. The nearest rule, "a test that reads `CARGO_MANIFEST_DIR`", would
+/// also exempt a write-path test that opens a body to check the bytes landed,
+/// and *that* test reaching round the interface is among the likeliest ways
+/// this boundary ever leaks. A false negative here is a leak; a false
+/// positive is one line and a sentence.
+///
+/// So the category is named here and its members are named below. When you
+/// add a source-scanning test, add it under that heading with what it scans
+/// and why it never touches a body.
 const ALLOWED: &[&str] = &[
     // The store itself, which is the only thing permitted to know where the
     // bytes are.
@@ -41,8 +58,17 @@ const ALLOWED: &[&str] = &[
     // Its own tests, which create the roots they hand to `open`, and check
     // that a failed upload left nothing on disk.
     "altaird/tests/object_store.rs",
+    //
+    // Source-scanning tests. Each reads this repository's own `.rs` files as
+    // text to assert a structural rule, and none of them opens anything under
+    // an object root.
+    //
     // This file, which reads sources in order to make the assertion.
     "altaird/tests/object_store_boundary.rs",
+    // Walks the tree asserting the audience predicate appears in exactly one
+    // place. Same technique as this file, for the same reason, on a different
+    // rule.
+    "altaird/tests/one_predicate.rs",
 ];
 
 /// Reaching the bytes needs one of these. Naming a path is enough on its own:
@@ -201,7 +227,8 @@ fn nothing_outside_the_object_store_touches_the_bytes() {
          round them. These files are scanned because their crate links `{INSTANCE}` and can \
          therefore hold an ObjectStore. Use `altaird::objects::ObjectStore`, or, if the file \
          genuinely has business with the filesystem that is not a file body, add it to ALLOWED in \
-         {} and say why.\n\n{}",
+         {} and say why. If it is a test that scans this repository's own sources to assert a \
+         structural rule, that is a known category with a heading of its own in that list.\n\n{}",
         file!(),
         violations.join("\n")
     );


### PR DESCRIPTION
Wave 1, lane 1.3 — the object store. Four operations behind an interface, filesystem underneath, per DR-003.

## Why the interface is the whole point

DR-003 does not choose a storage product; it chooses a **boundary**:

> **The interface is the decision.** It is small enough that replacing what sits behind it is a contained piece of work rather than a migration.
> **Nothing outside the interface may touch the bytes.** The moment something reads a path directly, the four operations stop being the whole boundary and the replacement stops being contained.

So "nothing outside the interface reads a path" is a done-when condition, and a comment saying *please don't* is not a deliverable. It needed to be executable.

## The interface

```rust
#[async_trait::async_trait]
pub trait ObjectStore: Send + Sync + 'static {
    async fn put(&self, id: BodyId, source: ByteSource) -> Result<u64, Error>;
    async fn get(&self, id: BodyId) -> Result<Body, Error>;
    async fn delete(&self, id: BodyId) -> Result<(), Error>;
    fn enumerate(&self) -> BodyListing<'_>;
}

pub enum Error { NoSuchBody, Unavailable(io::Error), Source(BoxError) }
```

`async-trait` rather than RPITIT, so the trait stays dyn-compatible and Wave 2 can hold `Arc<dyn ObjectStore>` — which is what makes "replace what sits behind it" a contained change instead of a generic-parameter refactor of every caller.

**`put` streams**, because `PutBody` is a streaming RPC and `&[u8]` would put every uploaded file in memory at the boundary. It is **idempotent by repeating the write, not by refusing it**: staged to a temp file, `fsync`, then `rename` into place. A re-upload therefore also *repairs* an attempt that was cut short, and no reader ever observes a partial body. Returning means durable — the file **and its parent directory** are `fsync`'d, because otherwise "bytes before the record" is a claim about a page cache.

**`delete` is idempotent** — bytes already gone is success, since reclamation sweeps repeatedly and erasure races it by design.

**`enumerate` streams and never opens a body.** One directory walk plus a stat each. It yields at most one error and then ends, because a *partial* listing is dangerous input to a sweep in a way that an error is not.

## The `Error` variants carry a distinction the product needs

`NoSuchBody` and `Unavailable` are separate because the component model says that when the object store is gone, the entity, its title, its relations and its derived text all remain available and only the body is **currently unavailable** — "a different statement from missing." One extra stat on the already-failing path buys that.

This also drove two decisions past what DR-003 literally says, both defensive:

- **`delete` does not return `Ok` when the store is unreachable.** Otherwise reclamation records an erasure that never happened.
- **`enumerate` does not return an empty stream when the store is unreachable.** Otherwise every body looks unreferenced, and a sweep deletes the lot.

## Enforcement, and proof it bites

`tests/object_store_boundary.rs`, four executable tests:

1. `nothing_outside_the_object_store_touches_the_bytes` — walks every `.rs` under `crates/*/src` and `crates/*/tests` against an explicit `ALLOWED` list, failing on `std::fs`, `tokio::fs`, `PathBuf`, `Path::`, `File::open`, `read_dir`, and friends. Adding to `ALLOWED` is the deliberate, reviewable act the test exists to force.
2. `no_path_escapes_the_interface` — `interface.rs` may not contain `Path`, `fs::`, or `File` **anywhere**. A path cannot leak out of a boundary that cannot name one.
3. `the_filesystem_implementation_names_a_path_only_where_the_store_is_opened` — the only `pub` item allowed to name a path is `fn open`.
4. `the_interface_is_still_four_operations` — DR-003 says *exactly* four; a fifth should be a decision, not an addition.

**Verified by the orchestrator, not self-reported.** Planting a path read in `main.rs`:

```
test nothing_outside_the_object_store_touches_the_bytes ... FAILED
  altaird/src/main.rs:7: `PathBuf` in `let p = std::path::PathBuf::from("/srv/altair/bodies").join("some-body");`
  altaird/src/main.rs:8: `std::fs` in `let _ = std::fs::read(p);`
```

Probe reverted; tree clean.

## One deviation worth your attention

**`StoredBody` carries `written_at`, a third field beyond identity and size.** This is a real finding about the ordering rules rather than a convenience.

Bytes are written *before* the record that points at them. So at any instant, some unreferenced bytes belong to a record that is milliseconds from committing. **A sweep that deletes everything unreferenced deletes a capture in flight.** With an age, Wave 2.4 can skip anything younger than a grace period.

The constant is 2.4's to set (that is its stated trigger). Being *able* to have one had to be decided here, and it is free from both a filesystem stat and an S3 `LastModified`.

## Verification

Rebased onto `a7033c1`. Run independently by the orchestrator:

```
$ cargo test --workspace
  tests/object_store.rs           16 passed
  tests/object_store_boundary.rs   4 passed
  tests/store.rs                   2 passed    tests/contract.rs   2 passed
$ cargo clippy --workspace --all-targets --all-features -- -D warnings   # clean
$ cargo fmt --all --check                                                # clean
```

The 16 behaviour tests include: a failed upload storing nothing and leaving no staged file; an unreachable store saying *currently unavailable* rather than missing; an unreachable store never reporting bytes as already gone; enumerate proven lazy (never reads a body); 32 concurrent puts; and the creation/erasure ordering written the way a caller would write it.

## Known limitations, stated rather than discovered later

- **Staging is not swept.** A process killed mid-`put` leaves one `<uuid>.part`. It is invisible to `enumerate`, so it never confuses reclamation, and costs only storage. A cleanup-at-open sweep needs an age constant (2.4's trigger) and is unsafe if two processes ever share a root — so it is flagged for 2.4 rather than guessed at here.
- **Durability is reasoned about, not crash-tested.** `fsync` calls are in place; power loss was not simulated. `[unverified]`
- **`sync_dir` is a no-op on non-Unix.** Opening a directory as a file is not portable. Linux and macOS get the full guarantee. The crate is not built for Windows today. `[unverified on non-Unix]`
- **Nothing is wired.** No config for the root, no construction in `main.rs`, no gRPC service — all Wave 2.3. `open()` reads no environment variable, so where bodies live is still an open decision.

## For Wave 2.3

`PutBody` maps directly: take `body_id` from the first chunk, map tonic's `Streaming` into a `ByteSource`, return the `u64` as `PutBodyAck.bytes_received`. Idempotent replay is already the store's behaviour, so a retried upload needs no special case.

One awkwardness stated plainly: **a body's identity is not derivable from an entity.** `BodyRequest` carries `entity_id`, and the entity → `body_id` mapping lives in the structured store. That lookup is 2.3's, and it is what the audience predicate has to sit inside before any `get` is issued. The object store has no audience notion and must not acquire one.
