### PR TITLE
Wave 1.4: validate tokens, resolve a claim to a membership, and keep the wait silent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,8 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "jsonwebtoken",
+ "proptest",
+ "pulldown-cmark",
  "ring",
  "serde",
  "serde_json",
@@ -154,6 +156,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,7 +239,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -575,14 +592,26 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1307,6 +1336,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1361,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -1438,6 +1495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,9 +1511,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -1460,7 +1539,26 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1468,6 +1566,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1595,6 +1702,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schannel"
@@ -1910,7 +2029,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2304,6 +2423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2390,6 +2515,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,6 +2537,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2606,6 +2749,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,6 +2781,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,16 @@ version = "0.0.0"
 dependencies = [
  "altaird",
  "anyhow",
+ "base64",
  "dotenvy",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "jsonwebtoken",
+ "ring",
+ "serde",
+ "serde_json",
  "sqlx",
  "tokio",
  "uuid",
@@ -234,6 +243,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +333,12 @@ checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
@@ -542,8 +567,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -716,6 +743,24 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -916,6 +961,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1158,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1196,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking"
@@ -1139,6 +1230,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1198,6 +1299,12 @@ checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -1442,12 +1549,25 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1477,10 +1597,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1569,6 +1721,18 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "slab"
@@ -1881,6 +2045,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2123,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/altaird/Cargo.toml
+++ b/crates/altaird/Cargo.toml
@@ -11,10 +11,20 @@ testing = ["dep:dotenvy"]
 [dependencies]
 anyhow = "1.0.104"
 dotenvy = { version = "0.15.7", optional = true }
+http-body-util = "0.1.3"
+hyper = { version = "1.8.1", features = ["client", "http1"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["http1", "logging", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+hyper-util = { version = "0.1.19", features = ["client", "client-legacy", "http1", "tokio"] }
+jsonwebtoken = "9.3.1"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "uuid", "chrono", "macros", "migrate"] }
-tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "time"] }
 uuid = { version = "1.24.1", features = ["v4"] }
 
 
 [dev-dependencies]
 altaird = { path = ".", features = ["testing"] }
+base64 = "0.22.1"
+ring = "0.17.14"
+tokio = { version = "1.53.1", features = ["io-util", "net"] }

--- a/crates/altaird/src/auth/jwks.rs
+++ b/crates/altaird/src/auth/jwks.rs
@@ -1,0 +1,283 @@
+//! The provider's signing keys: where they come from, and how long a copy
+//! stays good.
+//!
+//! # The policy, and why it is this one
+//!
+//! **A cached key set has no expiry.** It goes stale — after
+//! [`DEFAULT_REFRESH_AFTER`] the cache will try for a newer copy — but stale
+//! is not empty. A failed refresh leaves the previous set in place and
+//! validation carries on against it. This is what "key caching survives the
+//! provider being briefly unreachable" means: an Authentik restart, a
+//! certificate renewal, or a container reschedule must not turn every
+//! household member's session off.
+//!
+//! **A key the cache has not seen is what actually triggers a fetch.** Key
+//! rotation shows up as a `kid` in a header that the cached set does not
+//! contain, so an unseen `kid` prompts one refresh attempt and the token is
+//! then validated against whatever came back. That is rotation handled
+//! without polling.
+//!
+//! **Attempts are rate-limited** by [`DEFAULT_MIN_REFETCH_INTERVAL`], because
+//! the unseen-`kid` trigger is reachable by anyone who can send a request.
+//! Without the limit, a stream of forged headers each carrying a fresh random
+//! `kid` would turn the instance into a load generator pointed at its own
+//! identity provider.
+//!
+//! **A refresh that fails is not a fault and signals nothing.** No outcome
+//! here is an error: `key_for` returns `None`, the caller reads that as
+//! unauthenticated, and unauthenticated is a wait. A provider that is briefly
+//! away, a cold start before the first successful fetch, and an unseen `kid`
+//! that the refresh did not produce are all the same silence, and all of them
+//! clear by the ordinary path continuing to run.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use http_body_util::{BodyExt, Empty, Limited};
+use hyper::body::Bytes;
+use hyper::header::ACCEPT;
+use hyper::{Method, Request, Uri};
+use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
+use jsonwebtoken::jwk::{Jwk, JwkSet, PublicKeyUse};
+
+/// How long a fetched key set is used before the cache tries for a newer one.
+pub const DEFAULT_REFRESH_AFTER: Duration = Duration::from_secs(15 * 60);
+
+/// The floor between two fetch attempts, however many requests ask for a key
+/// the cache does not hold.
+pub const DEFAULT_MIN_REFETCH_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How long a single fetch may take before it is abandoned.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The largest document the instance will read from the provider.
+const MAX_JWKS_BYTES: usize = 1 << 20;
+
+/// The provider could not be asked, or did not answer usefully.
+///
+/// Deliberately opaque and deliberately not an `Error` any caller handles:
+/// this never escapes the cache. It exists so a failed fetch can be told from
+/// a successful one internally, and nothing more.
+#[derive(Debug)]
+pub struct JwksUnavailable(String);
+
+impl std::fmt::Display for JwksUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "the signing keys could not be fetched: {}", self.0)
+    }
+}
+
+impl std::error::Error for JwksUnavailable {}
+
+impl JwksUnavailable {
+    fn new(reason: impl std::fmt::Display) -> Self {
+        Self(reason.to_string())
+    }
+}
+
+type JwksFuture<'a> = Pin<Box<dyn Future<Output = Result<JwkSet, JwksUnavailable>> + Send + 'a>>;
+
+/// Where a key set comes from.
+///
+/// A trait so tests can stand up a provider without a network, and so an
+/// operator's deployment could later supply keys from a file without the
+/// validation path knowing.
+pub trait JwksSource: Send + Sync + 'static {
+    fn fetch(&self) -> JwksFuture<'_>;
+}
+
+/// The provider's JWKS endpoint over HTTP.
+///
+/// Uses rustls with the ring provider, which is the one crypto stack already
+/// in this binary — `sqlx` brings the same one, and `jsonwebtoken` verifies
+/// signatures with it too.
+pub struct HttpJwks {
+    uri: Uri,
+    client: Client<hyper_rustls::HttpsConnector<HttpConnector>, Empty<Bytes>>,
+}
+
+impl HttpJwks {
+    /// # Errors
+    ///
+    /// If the URI does not parse, or no trust store can be loaded. Both are
+    /// misconfiguration found at startup, not conditions a request meets.
+    pub fn new(jwks_uri: &str) -> anyhow::Result<Self> {
+        let uri: Uri = jwks_uri.parse()?;
+
+        let builder = hyper_rustls::HttpsConnectorBuilder::new();
+        // The operator's own CA is the ordinary case for a self-hosted
+        // provider, so the system trust store is tried first. Bundled roots
+        // are the fallback for an image that ships without one.
+        let connector = match builder.with_native_roots() {
+            Ok(b) => b.https_or_http().enable_http1().build(),
+            Err(_) => hyper_rustls::HttpsConnectorBuilder::new()
+                .with_webpki_roots()
+                .https_or_http()
+                .enable_http1()
+                .build(),
+        };
+
+        let client = Client::builder(TokioExecutor::new()).build(connector);
+        Ok(Self { uri, client })
+    }
+
+    async fn get(&self) -> Result<JwkSet, JwksUnavailable> {
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri(self.uri.clone())
+            .header(ACCEPT, "application/json")
+            .body(Empty::<Bytes>::new())
+            .map_err(JwksUnavailable::new)?;
+
+        let response = tokio::time::timeout(FETCH_TIMEOUT, self.client.request(request))
+            .await
+            .map_err(|_| JwksUnavailable::new("the request timed out"))?
+            .map_err(JwksUnavailable::new)?;
+
+        if !response.status().is_success() {
+            return Err(JwksUnavailable::new(format!(
+                "the provider answered {}",
+                response.status()
+            )));
+        }
+
+        let body = Limited::new(response.into_body(), MAX_JWKS_BYTES);
+        let bytes = tokio::time::timeout(FETCH_TIMEOUT, body.collect())
+            .await
+            .map_err(|_| JwksUnavailable::new("the body timed out"))?
+            .map_err(|e| JwksUnavailable::new(e.to_string()))?
+            .to_bytes();
+
+        serde_json::from_slice(&bytes).map_err(JwksUnavailable::new)
+    }
+}
+
+impl JwksSource for HttpJwks {
+    fn fetch(&self) -> JwksFuture<'_> {
+        Box::pin(self.get())
+    }
+}
+
+#[derive(Default)]
+struct State {
+    keys: Option<Arc<JwkSet>>,
+    fetched_at: Option<Instant>,
+    last_attempt: Option<Instant>,
+}
+
+/// The cached copy of the provider's keys.
+pub struct KeyCache {
+    source: Arc<dyn JwksSource>,
+    state: Mutex<State>,
+    refresh_after: Duration,
+    min_refetch_interval: Duration,
+}
+
+impl KeyCache {
+    #[must_use]
+    pub fn new(source: Arc<dyn JwksSource>) -> Self {
+        Self {
+            source,
+            state: Mutex::new(State::default()),
+            refresh_after: DEFAULT_REFRESH_AFTER,
+            min_refetch_interval: DEFAULT_MIN_REFETCH_INTERVAL,
+        }
+    }
+
+    /// Override the refresh policy. Tests compress it; nothing else should.
+    #[must_use]
+    pub fn with_policy(mut self, refresh_after: Duration, min_refetch_interval: Duration) -> Self {
+        self.refresh_after = refresh_after;
+        self.min_refetch_interval = min_refetch_interval;
+        self
+    }
+
+    /// The key a header named, if this instance can produce it.
+    ///
+    /// `None` where the header carried no `kid` and the set holds more than
+    /// one key: guessing which key signed a token is how a revoked key stays
+    /// useful. A set holding exactly one key needs no `kid`, which keeps a
+    /// minimal provider working.
+    pub async fn key_for(&self, kid: Option<&str>) -> Option<Jwk> {
+        let (found, stale, may_attempt) = {
+            let state = self.lock();
+            let now = Instant::now();
+            let found = state.keys.as_deref().and_then(|set| select(set, kid));
+            let stale = state
+                .fetched_at
+                .is_none_or(|at| now.duration_since(at) >= self.refresh_after);
+            let may_attempt = state
+                .last_attempt
+                .is_none_or(|at| now.duration_since(at) >= self.min_refetch_interval);
+            (found, stale, may_attempt)
+        };
+
+        // The common path: a key we hold, from a copy that is still fresh.
+        // No network, no lock held across an await.
+        if found.is_some() && !stale {
+            return found;
+        }
+
+        if may_attempt {
+            self.refresh().await;
+        } else {
+            return found;
+        }
+
+        let state = self.lock();
+        // A refresh that failed left the previous set in place, so this is
+        // still the survive-an-outage path.
+        state
+            .keys
+            .as_deref()
+            .and_then(|set| select(set, kid))
+            .or(found)
+    }
+
+    async fn refresh(&self) {
+        let fetched = self.source.fetch().await;
+        let now = Instant::now();
+
+        let mut state = self.lock();
+        state.last_attempt = Some(now);
+        if let Ok(set) = fetched {
+            state.keys = Some(Arc::new(set));
+            state.fetched_at = Some(now);
+        }
+        // On failure: keys, and the time they were fetched, are left exactly
+        // as they were. The provider being away is not a reason to forget
+        // what it already told us.
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, State> {
+        // A panic while holding this lock would poison it; the state behind
+        // it is a cache, so continuing with it is strictly better than
+        // turning every session off.
+        self.state.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+/// Pick the key a header named, ignoring any key the provider published for
+/// encryption rather than signing.
+fn select(set: &JwkSet, kid: Option<&str>) -> Option<Jwk> {
+    let signing = || {
+        set.keys
+            .iter()
+            .filter(|k| !matches!(k.common.public_key_use, Some(PublicKeyUse::Encryption)))
+    };
+
+    match kid {
+        Some(kid) => signing()
+            .find(|k| k.common.key_id.as_deref() == Some(kid))
+            .cloned(),
+        None => {
+            let mut only = signing();
+            let first = only.next()?;
+            only.next().is_none().then(|| first.clone())
+        }
+    }
+}

--- a/crates/altaird/src/auth/mod.rs
+++ b/crates/altaird/src/auth/mod.rs
@@ -1,0 +1,413 @@
+//! Token validation and membership resolution.
+//!
+//! Governed by DR-005: **the instance validates; it does not authenticate.**
+//! It fetches and caches the provider's signing keys, verifies a signature,
+//! and reads claims. There are no passwords here, no account creation, no
+//! recovery, and no user list. A subject claim that matches no membership is
+//! an outcome, never an invitation to create one.
+//!
+//! # The outcome is data, not an error
+//!
+//! [`Authenticator::authenticate`] returns `Result<Authentication, Fault>`,
+//! and the two channels mean sharply different things:
+//!
+//! * [`Authentication`] is what the *credential* produced. Every property of
+//!   a token — absent, malformed, expired, not yet valid, wrong issuer, wrong
+//!   audience, unverifiable signature, a subject this instance holds no
+//!   membership for — lands in [`Authentication::Unauthenticated`]. Per
+//!   DR-005 that is a **wait**: the outbox holds, nothing is dropped, nothing
+//!   signals, and the ordinary path clears it by continuing to run.
+//! * [`Fault`] is the instance describing *itself*. The only thing that can
+//!   produce one is the structured store being unavailable while resolving a
+//!   membership. **No property of a token can produce an `Err`.** That is the
+//!   whole point: a caller that matches on the outcome cannot accidentally
+//!   fold an expired session in with a genuine failure, which is how a
+//!   capture disappears while the interface stays silent.
+//!
+//! A refusal — the third outcome the substrate names, and the one that
+//! signals — is deliberately *not* modelled here. A refusal is a statement
+//! about a request, and this boundary never sees a request; a request that is
+//! refused was authenticated first. Refusal belongs to the write path.
+//!
+//! # Unauthenticated reaches no query surface
+//!
+//! This is a type-level guarantee rather than a convention. [`Member`] has
+//! private fields and no public constructor: the only code in the crate that
+//! can build one is [`Authenticator::authenticate`], on the branch where a
+//! signature verified and a claim resolved. Any surface that needs a member
+//! takes a `&Member`, and an unauthenticated request cannot produce the value
+//! required to call it. (`Member::for_test` exists behind the `testing`
+//! feature, which the binary never enables.)
+//!
+//! # Forged and expired are the same value
+//!
+//! `Unauthenticated` carries no reason, so a forged token and an expired one
+//! are literally indistinguishable to a caller and on the wire. Three things
+//! in the documents force this:
+//!
+//! 1. DR-005's obligation is unconditional — *"a request whose token fails
+//!    validation is unauthenticated and reaches no query surface"*. A forged
+//!    signature is a validation failure, so it is unauthenticated, and DR-005
+//!    defines unauthenticated as the wait.
+//! 2. The design refuses to leak elsewhere on exactly this pattern: nothing
+//!    distinguishes an entity that does not exist from one the member cannot
+//!    see, including the gRPC status. Telling a caller *which half* of
+//!    validation failed is the same class of disclosure.
+//! 3. The benign cause of a signature failure is self-clearing. A provider
+//!    that rotated its keys leaves honest clients holding tokens signed by a
+//!    key that no longer verifies, and their ordinary refresh fixes it. If
+//!    that signalled, a routine rotation would raise a fault at a person —
+//!    a wrong signal, which the substrate says costs attention. Silence costs
+//!    an attacker nothing, because an attacker already knows what they sent.
+//!
+//! So "a forged token produces nothing" means exactly that: no membership, no
+//! reason, no information — the same value an expired one produces.
+
+mod jwks;
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
+use serde::Deserialize;
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+pub use jwks::{HttpJwks, JwksSource, JwksUnavailable, KeyCache};
+
+/// Signature algorithms this instance will consider.
+///
+/// Asymmetric only. A JWKS entry is an RSA or EC public key, and an HMAC
+/// algorithm arriving in a header would ask the instance to verify with a
+/// public key used as a shared secret — the classic confusion. `jsonwebtoken`
+/// rejects the family mismatch on its own; naming the set here means such a
+/// header never reaches that check.
+const PERMITTED_ALGORITHMS: &[Algorithm] = &[
+    Algorithm::RS256,
+    Algorithm::RS384,
+    Algorithm::RS512,
+    Algorithm::PS256,
+    Algorithm::PS384,
+    Algorithm::PS512,
+    Algorithm::ES256,
+    Algorithm::ES384,
+];
+
+/// Tolerance for clock skew between this instance and the provider.
+///
+/// Not configurable. Token lifetimes are Authentik's configuration per
+/// DR-005; this is not a lifetime, it is an allowance for two machines
+/// disagreeing about the second.
+const SKEW_LEEWAY_SECONDS: i64 = 60;
+
+/// A validated member identity.
+///
+/// Constructible only by [`Authenticator::authenticate`]. Holding one is
+/// proof that a signature verified against the provider's keys and that the
+/// subject claim resolved to a membership that has not departed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Member {
+    membership_id: Uuid,
+    household_id: Uuid,
+    subject: String,
+    administrator: bool,
+}
+
+impl Member {
+    /// The internal identity. This is what authorship, assignment, and
+    /// audience reference — never the subject.
+    #[must_use]
+    pub fn membership_id(&self) -> Uuid {
+        self.membership_id
+    }
+
+    #[must_use]
+    pub fn household_id(&self) -> Uuid {
+        self.household_id
+    }
+
+    /// The external key the token carried. Diagnostics only; nothing
+    /// downstream should key on it.
+    #[must_use]
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    #[must_use]
+    pub fn is_administrator(&self) -> bool {
+        self.administrator
+    }
+
+    /// Build a member without a token, for tests in other lanes.
+    ///
+    /// Behind the `testing` feature, which the binary never enables, so the
+    /// unforgeability of `Member` holds in every shipped build.
+    #[cfg(feature = "testing")]
+    #[must_use]
+    pub fn for_test(
+        membership_id: Uuid,
+        household_id: Uuid,
+        subject: impl Into<String>,
+        administrator: bool,
+    ) -> Self {
+        Self {
+            membership_id,
+            household_id,
+            subject: subject.into(),
+            administrator,
+        }
+    }
+}
+
+/// What a presented credential produced.
+///
+/// Exhaustive by construction. See the module documentation for why there is
+/// no third variant and why `Unauthenticated` carries no reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+pub enum Authentication {
+    /// The signature verified and the subject named a living membership.
+    Member(Member),
+    /// No usable claim. **A wait, not a fault**: nothing signals, the outbox
+    /// holds, and the ordinary path clears it by continuing to run.
+    Unauthenticated,
+}
+
+impl Authentication {
+    #[must_use]
+    pub fn member(&self) -> Option<&Member> {
+        match self {
+            Self::Member(m) => Some(m),
+            Self::Unauthenticated => None,
+        }
+    }
+
+    #[must_use]
+    pub fn is_unauthenticated(&self) -> bool {
+        matches!(self, Self::Unauthenticated)
+    }
+}
+
+/// The instance failing, never the credential failing.
+#[derive(Debug)]
+pub enum Fault {
+    /// The structured store could not be reached or read.
+    Store(sqlx::Error),
+}
+
+impl std::fmt::Display for Fault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Store(e) => write!(f, "the structured store was unavailable: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Fault {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Store(e) => Some(e),
+        }
+    }
+}
+
+/// Where "now" comes from, so expiry is testable without sleeping.
+pub trait Clock: Send + Sync + 'static {
+    /// Seconds since the Unix epoch.
+    fn now_unix(&self) -> i64;
+}
+
+/// The wall clock.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_unix(&self) -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
+    }
+}
+
+/// The one issuer this instance accepts, and the audience it requires.
+///
+/// Whether the instance ever accepts more than one issuer is deliberately not
+/// decided (DR-005), so there is no machinery for a second here.
+#[derive(Debug, Clone)]
+pub struct IssuerConfig {
+    pub issuer: String,
+    pub audience: String,
+}
+
+/// Turns a presented credential into an [`Authentication`].
+pub struct Authenticator {
+    config: IssuerConfig,
+    keys: KeyCache,
+    pool: PgPool,
+    clock: Arc<dyn Clock>,
+}
+
+/// The claims this instance reads. Everything else the provider sends is
+/// ignored — the instance owns no user list and has no use for a profile.
+#[derive(Debug, Deserialize)]
+struct Claims {
+    sub: String,
+    exp: i64,
+    nbf: Option<i64>,
+}
+
+impl Authenticator {
+    pub fn new(config: IssuerConfig, keys: KeyCache, pool: PgPool) -> Self {
+        Self {
+            config,
+            keys,
+            pool,
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    /// Replace the clock. Tests move time; nothing else should.
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    /// Validate a credential and resolve it to a membership.
+    ///
+    /// `credential` is the bare token, as produced by [`bearer_token`].
+    /// `None` — no credential at all — is [`Authentication::Unauthenticated`]
+    /// without touching the key cache or the store.
+    ///
+    /// # Errors
+    ///
+    /// Only [`Fault::Store`], and only once a signature has already verified.
+    pub async fn authenticate(&self, credential: Option<&str>) -> Result<Authentication, Fault> {
+        let Some(token) = credential.map(str::trim).filter(|t| !t.is_empty()) else {
+            return Ok(Authentication::Unauthenticated);
+        };
+
+        let Some(claims) = self.verified_claims(token).await else {
+            return Ok(Authentication::Unauthenticated);
+        };
+
+        self.resolve(&claims.sub).await
+    }
+
+    /// Signature, issuer, audience, and time. `None` for any failure, with no
+    /// record of which — see the module documentation.
+    async fn verified_claims(&self, token: &str) -> Option<Claims> {
+        let header = decode_header(token).ok()?;
+        if !PERMITTED_ALGORITHMS.contains(&header.alg) {
+            return None;
+        }
+
+        let jwk = self.keys.key_for(header.kid.as_deref()).await?;
+
+        // If the provider declared an algorithm for this key, the header must
+        // agree with it. A key is published for one purpose.
+        if let Some(declared) = jwk.common.key_algorithm
+            && !declares(declared, header.alg)
+        {
+            return None;
+        }
+
+        let key = DecodingKey::from_jwk(&jwk).ok()?;
+
+        let mut validation = Validation::new(header.alg);
+        validation.set_issuer(&[self.config.issuer.as_str()]);
+        validation.set_audience(&[self.config.audience.as_str()]);
+        // `exp` is demanded, but compared against the injected clock below
+        // rather than against `SystemTime::now()` buried in the library —
+        // otherwise expiry could only be tested by sleeping.
+        validation.set_required_spec_claims(&["exp", "iss", "aud", "sub"]);
+        validation.validate_exp = false;
+        validation.validate_nbf = false;
+
+        let claims = decode::<Claims>(token, &key, &validation).ok()?.claims;
+
+        let now = self.clock.now_unix();
+        if claims.exp.saturating_add(SKEW_LEEWAY_SECONDS) < now {
+            return None;
+        }
+        if let Some(nbf) = claims.nbf
+            && nbf.saturating_sub(SKEW_LEEWAY_SECONDS) > now
+        {
+            return None;
+        }
+
+        Some(claims)
+    }
+
+    /// The subject is the external key onto the membership, which is the
+    /// internal thing (DR-005).
+    ///
+    /// A departed membership does not resolve. The schema's note that
+    /// "references to this membership survive it" is about rows that already
+    /// point at it — authorship never changes and an audience entry stays
+    /// where it is — not about the person still being able to act. Departure
+    /// is the household withdrawing someone, and audience enforcement built
+    /// on member identity would be meaningless if it did not take effect.
+    /// A departed subject produces the same nothing an unknown subject does,
+    /// because saying which would tell someone outside the household about
+    /// its state.
+    async fn resolve(&self, subject: &str) -> Result<Authentication, Fault> {
+        let row = sqlx::query(
+            "SELECT id, household_id, administrator \
+             FROM membership \
+             WHERE subject = $1 AND departed_at IS NULL",
+        )
+        .bind(subject)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Fault::Store)?;
+
+        let Some(row) = row else {
+            return Ok(Authentication::Unauthenticated);
+        };
+
+        Ok(Authentication::Member(Member {
+            membership_id: row.try_get("id").map_err(Fault::Store)?,
+            household_id: row.try_get("household_id").map_err(Fault::Store)?,
+            subject: subject.to_owned(),
+            administrator: row.try_get("administrator").map_err(Fault::Store)?,
+        }))
+    }
+}
+
+/// Whether a JWK's declared algorithm is the one a header claimed.
+///
+/// Written out rather than derived from a string, because `jsonwebtoken`
+/// models the two enumerations separately and anything that maps them through
+/// their text is a rename away from silently accepting a mismatch. Anything
+/// outside [`PERMITTED_ALGORITHMS`] is false by construction.
+fn declares(declared: jsonwebtoken::jwk::KeyAlgorithm, alg: Algorithm) -> bool {
+    use jsonwebtoken::jwk::KeyAlgorithm as Declared;
+
+    matches!(
+        (declared, alg),
+        (Declared::RS256, Algorithm::RS256)
+            | (Declared::RS384, Algorithm::RS384)
+            | (Declared::RS512, Algorithm::RS512)
+            | (Declared::PS256, Algorithm::PS256)
+            | (Declared::PS384, Algorithm::PS384)
+            | (Declared::PS512, Algorithm::PS512)
+            | (Declared::ES256, Algorithm::ES256)
+            | (Declared::ES384, Algorithm::ES384)
+    )
+}
+
+/// The bare token out of an `authorization` header value.
+///
+/// Tolerates any casing of the scheme, which is what RFC 9110 requires and
+/// what clients on four platforms would otherwise get wrong in four ways.
+#[must_use]
+pub fn bearer_token(authorization: Option<&str>) -> Option<&str> {
+    let value = authorization?.trim();
+    let (scheme, token) = value.split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+    let token = token.trim();
+    (!token.is_empty()).then_some(token)
+}

--- a/crates/altaird/src/lib.rs
+++ b/crates/altaird/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod store;
 
 #[cfg(feature = "testing")]

--- a/crates/altaird/tests/token_validation.rs
+++ b/crates/altaird/tests/token_validation.rs
@@ -1,0 +1,887 @@
+//! Token validation, end to end, against a provider that exists only here.
+//!
+//! Every key is generated in-process and every token is minted here, so the
+//! suite runs offline and nothing resembling a private key is ever committed.
+//! Time is injected rather than slept through: an expiry test that sleeps is
+//! a test that fails on a loaded CI runner.
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use altaird::auth::{
+    Authentication, Authenticator, Clock, Fault, HttpJwks, IssuerConfig, KeyCache, bearer_token,
+};
+use altaird::testing::TestDb;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use ring::rand::SystemRandom;
+use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair, KeyPair};
+use serde_json::{Value, json};
+use sqlx::postgres::PgPool;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+
+const ISSUER: &str = "https://auth.example.test/application/o/altair/";
+const AUDIENCE: &str = "altair";
+
+/// A fixed "now" the tests move around. Far enough from zero that a token can
+/// expire without the arithmetic going negative.
+const NOW: i64 = 1_780_000_000;
+
+// ---------------------------------------------------------------------------
+// A signing key, generated per test
+// ---------------------------------------------------------------------------
+
+struct TestKey {
+    kid: String,
+    encoding: EncodingKey,
+    x: String,
+    y: String,
+}
+
+fn generate(kid: &str) -> TestKey {
+    let rng = SystemRandom::new();
+    let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
+        .expect("generate a key pair");
+    let pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8.as_ref(), &rng)
+        .expect("read the key pair back");
+
+    // Uncompressed SEC1 point: 0x04 || X || Y, 32 bytes each on P-256.
+    let point = pair.public_key().as_ref();
+    assert_eq!(point.len(), 65, "unexpected public point encoding");
+
+    TestKey {
+        kid: kid.to_owned(),
+        encoding: EncodingKey::from_ec_der(pkcs8.as_ref()),
+        x: URL_SAFE_NO_PAD.encode(&point[1..33]),
+        y: URL_SAFE_NO_PAD.encode(&point[33..65]),
+    }
+}
+
+impl TestKey {
+    fn jwk(&self) -> Value {
+        json!({
+            "kty": "EC",
+            "crv": "P-256",
+            "alg": "ES256",
+            "use": "sig",
+            "kid": self.kid,
+            "x": self.x,
+            "y": self.y,
+        })
+    }
+
+    /// Mint a token, optionally lying about which key signed it.
+    fn mint_as(&self, kid: &str, claims: &Value) -> String {
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(kid.to_owned());
+        jsonwebtoken::encode(&header, claims, &self.encoding).expect("mint")
+    }
+
+    fn mint(&self, claims: &Value) -> String {
+        self.mint_as(&self.kid, claims)
+    }
+}
+
+fn jwks(keys: &[&TestKey]) -> String {
+    json!({ "keys": keys.iter().map(|k| k.jwk()).collect::<Vec<_>>() }).to_string()
+}
+
+fn claims(subject: &str, exp: i64) -> Value {
+    json!({ "iss": ISSUER, "aud": AUDIENCE, "sub": subject, "iat": exp - 3600, "exp": exp })
+}
+
+// ---------------------------------------------------------------------------
+// A provider that can be taken away
+// ---------------------------------------------------------------------------
+
+struct FakeProvider {
+    addr: SocketAddr,
+    body: Arc<Mutex<String>>,
+    fetches: Arc<AtomicUsize>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl FakeProvider {
+    async fn serving(body: String) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let body = Arc::new(Mutex::new(body));
+        let fetches = Arc::new(AtomicUsize::new(0));
+
+        let (b, f) = (Arc::clone(&body), Arc::clone(&fetches));
+        let task = tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                let (b, f) = (Arc::clone(&b), Arc::clone(&f));
+                tokio::spawn(async move {
+                    let mut request = Vec::new();
+                    let mut chunk = [0u8; 512];
+                    while !request.windows(4).any(|w| w == b"\r\n\r\n") {
+                        match socket.read(&mut chunk).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => request.extend_from_slice(&chunk[..n]),
+                        }
+                    }
+                    f.fetch_add(1, Ordering::SeqCst);
+                    let payload = b.lock().expect("body").clone();
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                         content-length: {}\r\nconnection: close\r\n\r\n{payload}",
+                        payload.len()
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.shutdown().await;
+                });
+            }
+        });
+
+        Self {
+            addr,
+            body,
+            fetches,
+            task: Some(task),
+        }
+    }
+
+    fn uri(&self) -> String {
+        format!("http://{}/jwks", self.addr)
+    }
+
+    fn now_serving(&self, body: String) {
+        *self.body.lock().expect("body") = body;
+    }
+
+    fn fetches(&self) -> usize {
+        self.fetches.load(Ordering::SeqCst)
+    }
+
+    /// Take the provider away. The port stops accepting, so the next fetch
+    /// fails the way a restarted Authentik does.
+    async fn go_away(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for FakeProvider {
+    fn drop(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Injected time
+// ---------------------------------------------------------------------------
+
+struct TestClock(AtomicI64);
+
+impl TestClock {
+    fn at(seconds: i64) -> Arc<Self> {
+        Arc::new(Self(AtomicI64::new(seconds)))
+    }
+
+    fn advance(&self, seconds: i64) {
+        self.0.fetch_add(seconds, Ordering::SeqCst);
+    }
+}
+
+impl Clock for TestClock {
+    fn now_unix(&self) -> i64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Assembly
+// ---------------------------------------------------------------------------
+
+fn authenticator(
+    pool: PgPool,
+    jwks_uri: &str,
+    clock: Arc<TestClock>,
+    refresh_after: Duration,
+    min_refetch: Duration,
+) -> Authenticator {
+    let source = Arc::new(HttpJwks::new(jwks_uri).expect("build the jwks client"));
+    let keys = KeyCache::new(source).with_policy(refresh_after, min_refetch);
+    let config = IssuerConfig {
+        issuer: ISSUER.to_owned(),
+        audience: AUDIENCE.to_owned(),
+    };
+    Authenticator::new(config, keys, pool).with_clock(clock)
+}
+
+/// Default policy for tests that are not about caching: never treat a cached
+/// set as fresh, never rate-limit. Every call is allowed to reach the
+/// provider, which is the least forgiving setting.
+fn eager(pool: PgPool, jwks_uri: &str, clock: Arc<TestClock>) -> Authenticator {
+    authenticator(pool, jwks_uri, clock, Duration::ZERO, Duration::ZERO)
+}
+
+async fn seed_household(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO household (id, name, created_at) VALUES ($1, 'test', now())")
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("seed household");
+    id
+}
+
+async fn seed_member(pool: &PgPool, household: Uuid, subject: &str, departed: bool) -> Uuid {
+    let id = Uuid::new_v4();
+    let sql = if departed {
+        "INSERT INTO membership \
+         (id, household_id, subject, display_name, administrator, joined_at, departed_at) \
+         VALUES ($1, $2, $3, 'Test', false, now(), now())"
+    } else {
+        "INSERT INTO membership \
+         (id, household_id, subject, display_name, administrator, joined_at, departed_at) \
+         VALUES ($1, $2, $3, 'Test', false, now(), NULL)"
+    };
+    sqlx::query(sql)
+        .bind(id)
+        .bind(household)
+        .bind(subject)
+        .execute(pool)
+        .await
+        .expect("seed membership");
+    id
+}
+
+// ---------------------------------------------------------------------------
+// Done when: a valid token resolves to a membership
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_valid_token_resolves_to_a_membership() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    let membership = seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    let token = key.mint(&claims("sub-alice", NOW + 3600));
+    let outcome = auth.authenticate(Some(&token)).await.expect("no fault");
+
+    let member = outcome.member().expect("a membership");
+    assert_eq!(member.membership_id(), membership);
+    assert_eq!(member.household_id(), household);
+    assert_eq!(member.subject(), "sub-alice");
+    assert!(!member.is_administrator());
+}
+
+#[tokio::test]
+async fn a_bearer_header_carries_the_credential() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    let token = key.mint(&claims("sub-alice", NOW + 3600));
+    let header = format!("bearer {token}");
+    let outcome = auth
+        .authenticate(bearer_token(Some(&header)))
+        .await
+        .expect("no fault");
+
+    assert!(
+        outcome.member().is_some(),
+        "a lowercase scheme is still bearer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Done when: an expired token produces the wait outcome
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn an_expired_token_is_the_wait_outcome() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let clock = TestClock::at(NOW);
+    let auth = eager(db.pool.clone(), &provider.uri(), Arc::clone(&clock));
+
+    let token = key.mint(&claims("sub-alice", NOW + 3600));
+    assert!(
+        auth.authenticate(Some(&token))
+            .await
+            .expect("no fault")
+            .member()
+            .is_some(),
+        "the token is good before it expires"
+    );
+
+    // Past expiry, and past the skew allowance. No sleeping.
+    clock.advance(3600 + 120);
+
+    let outcome = auth.authenticate(Some(&token)).await.expect("no fault");
+    assert_eq!(
+        outcome,
+        Authentication::Unauthenticated,
+        "an expired session is a wait, and a wait is an outcome rather than an error"
+    );
+}
+
+#[tokio::test]
+async fn a_token_within_the_skew_allowance_still_resolves() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let clock = TestClock::at(NOW);
+    let auth = eager(db.pool.clone(), &provider.uri(), Arc::clone(&clock));
+
+    let token = key.mint(&claims("sub-alice", NOW));
+    clock.advance(30);
+
+    assert!(
+        auth.authenticate(Some(&token))
+            .await
+            .expect("no fault")
+            .member()
+            .is_some(),
+        "two machines disagreeing by half a minute is not an expired session"
+    );
+}
+
+#[tokio::test]
+async fn a_token_that_is_not_yet_valid_is_the_wait_outcome() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    let mut c = claims("sub-alice", NOW + 7200);
+    c["nbf"] = json!(NOW + 3600);
+    let token = key.mint(&c);
+
+    assert_eq!(
+        auth.authenticate(Some(&token)).await.expect("no fault"),
+        Authentication::Unauthenticated
+    );
+}
+
+#[tokio::test]
+async fn an_absent_credential_is_the_wait_outcome() {
+    let db = TestDb::new().await;
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    assert_eq!(
+        auth.authenticate(None).await.expect("no fault"),
+        Authentication::Unauthenticated
+    );
+    assert_eq!(
+        auth.authenticate(Some("   ")).await.expect("no fault"),
+        Authentication::Unauthenticated
+    );
+    assert_eq!(
+        provider.fetches(),
+        0,
+        "no credential means no reason to ask the provider anything"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Done when: a forged token produces nothing
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_forged_token_produces_nothing() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let published = generate("key-1");
+    let attacker = generate("key-1-impostor");
+    let provider = FakeProvider::serving(jwks(&[&published])).await;
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    // Signed by a key the provider never published, but claiming the kid of
+    // one it did. Everything except the signature is impeccable.
+    let forged = attacker.mint_as("key-1", &claims("sub-alice", NOW + 3600));
+
+    let outcome = auth.authenticate(Some(&forged)).await.expect("no fault");
+    assert_eq!(outcome, Authentication::Unauthenticated);
+    assert!(outcome.member().is_none(), "no membership from a forgery");
+}
+
+#[tokio::test]
+async fn a_forgery_and_an_expiry_are_the_same_value() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let published = generate("key-1");
+    let attacker = generate("key-1-impostor");
+    let provider = FakeProvider::serving(jwks(&[&published])).await;
+    let clock = TestClock::at(NOW);
+    let auth = eager(db.pool.clone(), &provider.uri(), Arc::clone(&clock));
+
+    let expired = published.mint(&claims("sub-alice", NOW - 3600));
+    let forged = attacker.mint_as("key-1", &claims("sub-alice", NOW + 3600));
+
+    let from_expiry = auth.authenticate(Some(&expired)).await.expect("no fault");
+    let from_forgery = auth.authenticate(Some(&forged)).await.expect("no fault");
+
+    assert_eq!(
+        from_expiry, from_forgery,
+        "nothing distinguishes which half of validation failed, here or on the wire"
+    );
+}
+
+#[tokio::test]
+async fn a_token_shaped_like_nonsense_produces_nothing() {
+    let db = TestDb::new().await;
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    for garbage in ["not a token", "a.b.c", "...", "eyJhbGciOiJub25lIn0..", ""] {
+        assert_eq!(
+            auth.authenticate(Some(garbage)).await.expect("no fault"),
+            Authentication::Unauthenticated,
+            "{garbage:?} produced something"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_symmetric_signature_over_the_public_key_produces_nothing() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    // The algorithm-confusion attack: present the published public key back
+    // as though it were an HMAC secret.
+    let secret = format!("{}{}", key.x, key.y);
+    let mut header = Header::new(Algorithm::HS256);
+    header.kid = Some("key-1".to_owned());
+    let token = jsonwebtoken::encode(
+        &header,
+        &claims("sub-alice", NOW + 3600),
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("mint");
+
+    assert_eq!(
+        auth.authenticate(Some(&token)).await.expect("no fault"),
+        Authentication::Unauthenticated
+    );
+}
+
+#[tokio::test]
+async fn another_issuer_and_another_audience_produce_nothing() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    let mut wrong_issuer = claims("sub-alice", NOW + 3600);
+    wrong_issuer["iss"] = json!("https://elsewhere.example.test/");
+    let mut wrong_audience = claims("sub-alice", NOW + 3600);
+    wrong_audience["aud"] = json!("something-else");
+
+    for c in [wrong_issuer, wrong_audience] {
+        assert_eq!(
+            auth.authenticate(Some(&key.mint(&c)))
+                .await
+                .expect("no fault"),
+            Authentication::Unauthenticated
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Claim to membership
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_subject_with_no_membership_produces_nothing_and_creates_nothing() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    let token = key.mint(&claims("sub-a-stranger", NOW + 3600));
+    assert_eq!(
+        auth.authenticate(Some(&token)).await.expect("no fault"),
+        Authentication::Unauthenticated
+    );
+
+    let members: i64 = sqlx::query_scalar("SELECT count(*) FROM membership")
+        .fetch_one(&db.pool)
+        .await
+        .expect("count");
+    assert_eq!(
+        members, 1,
+        "an unknown subject is an outcome, never an invitation to create a membership"
+    );
+}
+
+#[tokio::test]
+async fn a_departed_membership_does_not_resolve() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    let departed = seed_member(&db.pool, household, "sub-departed", true).await;
+
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    let token = key.mint(&claims("sub-departed", NOW + 3600));
+    assert_eq!(
+        auth.authenticate(Some(&token)).await.expect("no fault"),
+        Authentication::Unauthenticated,
+        "departure withdraws the ability to act, whatever references survive"
+    );
+
+    // The row itself is untouched: references to it survive departure.
+    let still_there: i64 = sqlx::query_scalar("SELECT count(*) FROM membership WHERE id = $1")
+        .bind(departed)
+        .fetch_one(&db.pool)
+        .await
+        .expect("count");
+    assert_eq!(still_there, 1);
+}
+
+#[tokio::test]
+async fn an_administrator_is_reported_as_one() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO membership \
+         (id, household_id, subject, administrator, joined_at) \
+         VALUES ($1, $2, 'sub-admin', true, now())",
+    )
+    .bind(id)
+    .bind(household)
+    .execute(&db.pool)
+    .await
+    .expect("seed");
+
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    let token = key.mint(&claims("sub-admin", NOW + 3600));
+    let outcome = auth.authenticate(Some(&token)).await.expect("no fault");
+    assert!(outcome.member().expect("a membership").is_administrator());
+}
+
+// ---------------------------------------------------------------------------
+// Unauthenticated reaches no query surface
+// ---------------------------------------------------------------------------
+
+/// The type system already makes this hard to get wrong — nothing can build a
+/// `Member` except a successful validation — but a type argument is not a
+/// runnable test. This one puts a store that cannot answer behind the
+/// validator: a forged token must still produce the wait outcome, while a
+/// valid one must fault. The pair is only explicable if the forged token
+/// never reached the store.
+#[tokio::test]
+async fn an_unvalidated_credential_never_reaches_the_store() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let published = generate("key-1");
+    let attacker = generate("key-1-impostor");
+    let provider = FakeProvider::serving(jwks(&[&published])).await;
+    let auth = authenticator(
+        db.pool.clone(),
+        &provider.uri(),
+        TestClock::at(NOW),
+        Duration::from_secs(3600),
+        Duration::ZERO,
+    );
+
+    let good = published.mint(&claims("sub-alice", NOW + 3600));
+    let forged = attacker.mint_as("key-1", &claims("sub-alice", NOW + 3600));
+
+    // Prime the key cache while everything still works.
+    assert!(
+        auth.authenticate(Some(&good))
+            .await
+            .expect("no fault")
+            .member()
+            .is_some()
+    );
+
+    db.pool.close().await;
+
+    assert_eq!(
+        auth.authenticate(Some(&forged)).await.expect("no fault"),
+        Authentication::Unauthenticated,
+        "a forgery is answered without the store being consulted"
+    );
+
+    match auth.authenticate(Some(&good)).await {
+        Err(Fault::Store(_)) => {}
+        other => panic!("a valid token should have reached the store: {other:?}"),
+    }
+}
+
+/// The other half of the same claim: the outcome of a bad credential is never
+/// on the error channel, so a caller cannot confuse a wait with a fault.
+#[tokio::test]
+async fn no_property_of_a_token_produces_an_error() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let published = generate("key-1");
+    let attacker = generate("key-1-impostor");
+    let provider = FakeProvider::serving(jwks(&[&published])).await;
+    let clock = TestClock::at(NOW);
+    let auth = eager(db.pool.clone(), &provider.uri(), Arc::clone(&clock));
+
+    let mut wrong_issuer = claims("sub-alice", NOW + 3600);
+    wrong_issuer["iss"] = json!("https://elsewhere.example.test/");
+
+    let candidates = vec![
+        published.mint(&claims("sub-alice", NOW - 86_400)),
+        published.mint(&claims("sub-nobody", NOW + 3600)),
+        published.mint(&wrong_issuer),
+        published.mint_as("key-unknown", &claims("sub-alice", NOW + 3600)),
+        attacker.mint_as("key-1", &claims("sub-alice", NOW + 3600)),
+        "garbage".to_owned(),
+    ];
+
+    for token in candidates {
+        let outcome = auth.authenticate(Some(&token)).await;
+        assert!(
+            matches!(outcome, Ok(Authentication::Unauthenticated)),
+            "a token property reached the error channel"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Key caching
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn cached_keys_survive_the_provider_being_unreachable() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let key = generate("key-1");
+    let mut provider = FakeProvider::serving(jwks(&[&key])).await;
+    // The least forgiving policy: the cached set is stale on every call, so
+    // every call tries the provider and every call must survive it failing.
+    let auth = eager(db.pool.clone(), &provider.uri(), TestClock::at(NOW));
+
+    let token = key.mint(&claims("sub-alice", NOW + 3600));
+    assert!(
+        auth.authenticate(Some(&token))
+            .await
+            .expect("no fault")
+            .member()
+            .is_some(),
+        "primed while the provider was up"
+    );
+    assert_eq!(provider.fetches(), 1);
+
+    provider.go_away().await;
+
+    for attempt in 0..3 {
+        let outcome = auth.authenticate(Some(&token)).await.expect("no fault");
+        assert!(
+            outcome.member().is_some(),
+            "attempt {attempt}: an Authentik restart must not turn every session off"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_cold_start_with_no_keys_is_the_wait_outcome() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let key = generate("key-1");
+    let mut provider = FakeProvider::serving(jwks(&[&key])).await;
+    let uri = provider.uri();
+    provider.go_away().await;
+
+    let auth = eager(db.pool.clone(), &uri, TestClock::at(NOW));
+    let token = key.mint(&claims("sub-alice", NOW + 3600));
+
+    assert_eq!(
+        auth.authenticate(Some(&token)).await.expect("no fault"),
+        Authentication::Unauthenticated,
+        "never having reached the provider is a wait, not a fault"
+    );
+}
+
+#[tokio::test]
+async fn an_unseen_key_id_prompts_a_refresh() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let old = generate("key-1");
+    let new = generate("key-2");
+    let provider = FakeProvider::serving(jwks(&[&old])).await;
+    // Cached keys stay fresh for an hour, so only an unseen kid can be what
+    // sends this to the provider a second time.
+    let auth = authenticator(
+        db.pool.clone(),
+        &provider.uri(),
+        TestClock::at(NOW),
+        Duration::from_secs(3600),
+        Duration::ZERO,
+    );
+
+    let before = old.mint(&claims("sub-alice", NOW + 3600));
+    assert!(
+        auth.authenticate(Some(&before))
+            .await
+            .expect("no fault")
+            .member()
+            .is_some()
+    );
+    assert_eq!(provider.fetches(), 1);
+
+    provider.now_serving(jwks(&[&new]));
+
+    let after = new.mint(&claims("sub-alice", NOW + 3600));
+    assert!(
+        auth.authenticate(Some(&after))
+            .await
+            .expect("no fault")
+            .member()
+            .is_some(),
+        "a rotation is noticed by the kid arriving, without polling"
+    );
+    assert_eq!(provider.fetches(), 2);
+}
+
+#[tokio::test]
+async fn an_unseen_key_id_with_the_provider_away_produces_nothing() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let old = generate("key-1");
+    let new = generate("key-2");
+    let mut provider = FakeProvider::serving(jwks(&[&old])).await;
+    let auth = authenticator(
+        db.pool.clone(),
+        &provider.uri(),
+        TestClock::at(NOW),
+        Duration::from_secs(3600),
+        Duration::ZERO,
+    );
+
+    let known = old.mint(&claims("sub-alice", NOW + 3600));
+    assert!(
+        auth.authenticate(Some(&known))
+            .await
+            .expect("no fault")
+            .member()
+            .is_some()
+    );
+
+    provider.go_away().await;
+
+    let unknown = new.mint(&claims("sub-alice", NOW + 3600));
+    assert_eq!(
+        auth.authenticate(Some(&unknown)).await.expect("no fault"),
+        Authentication::Unauthenticated,
+        "a key that cannot be fetched is a wait, not a fault"
+    );
+    assert!(
+        auth.authenticate(Some(&known))
+            .await
+            .expect("no fault")
+            .member()
+            .is_some(),
+        "and the keys already held are untouched by the failed refresh"
+    );
+}
+
+#[tokio::test]
+async fn fetches_are_rate_limited_against_a_stream_of_unknown_key_ids() {
+    let db = TestDb::new().await;
+    let household = seed_household(&db.pool).await;
+    seed_member(&db.pool, household, "sub-alice", false).await;
+
+    let key = generate("key-1");
+    let provider = FakeProvider::serving(jwks(&[&key])).await;
+    let auth = authenticator(
+        db.pool.clone(),
+        &provider.uri(),
+        TestClock::at(NOW),
+        Duration::from_secs(3600),
+        Duration::from_secs(60),
+    );
+
+    for n in 0..50 {
+        let token = key.mint_as(&format!("invented-{n}"), &claims("sub-alice", NOW + 3600));
+        assert_eq!(
+            auth.authenticate(Some(&token)).await.expect("no fault"),
+            Authentication::Unauthenticated
+        );
+    }
+
+    assert_eq!(
+        provider.fetches(),
+        1,
+        "anyone who can send a header could otherwise point this instance at its own provider"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Header parsing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bearer_tokens_are_read_out_of_a_header() {
+    assert_eq!(bearer_token(Some("Bearer abc")), Some("abc"));
+    assert_eq!(bearer_token(Some("bearer abc")), Some("abc"));
+    assert_eq!(bearer_token(Some("BEARER  abc  ")), Some("abc"));
+    assert_eq!(bearer_token(None), None);
+    assert_eq!(bearer_token(Some("")), None);
+    assert_eq!(bearer_token(Some("abc")), None);
+    assert_eq!(bearer_token(Some("Basic abc")), None);
+    assert_eq!(bearer_token(Some("Bearer ")), None);
+}


### PR DESCRIPTION
Wave 1, lane 1.4 — JWKS fetch and cache, signature verification, claim to membership.

## Why the outcome type is the design

DR-005 is unusually specific about what this boundary owes:

> **An absent or expired token is a typed outcome, not a page.** It is unauthenticated, which is a wait: the outbox holds, nothing is dropped, nothing signals… A refusal is a different outcome and signals. **The distinction is carried by the protocol rather than inferred by the client.**

If expiry surfaced as `Err(...)` alongside genuine faults, every caller would re-derive the wait/fault distinction from an error string, and one of them would get it wrong — which means a capture disappearing while the interface stays silent. So:

```rust
pub enum Authentication {
    Member(Member),      // signature verified, subject named a living membership
    Unauthenticated,     // a WAIT, not a fault. Silent. The outbox holds.
}

pub enum Fault { Store(sqlx::Error) }   // the instance failing, never the credential
```

`authenticate()` returns `Result<Authentication, Fault>`. **No property of a token can reach the `Err` channel** — there is a test asserting exactly that (`no_property_of_a_token_produces_an_error`).

## A forgery and an expiry are the same value

Deliberate, and argued from three places rather than assumed:

1. DR-005's obligation is unconditional — *"a request whose token fails validation is unauthenticated and reaches no query surface"* — and it carves out no exception for forgery.
2. The design already refuses this class of disclosure. The schema: *"Nothing distinguishes an entity that does not exist from one the submitting member cannot see, here or on the wire."* Telling a caller **which half** of validation failed is the same shape of leak.
3. The substrate's "unknown conditions are faults" rule does not bite, because a signature failure's benign cause **is** self-clearing: a provider that rotated keys leaves honest clients holding tokens signed by a key that no longer verifies, and ordinary refresh fixes it. Signalling would raise a fault at a person over routine maintenance. Silence costs an attacker nothing — they already know what they sent.

`Unauthenticated` is therefore a unit variant carrying no reason, and `a_forgery_and_an_expiry_are_the_same_value` asserts the two outcomes are `assert_eq!`.

## 🔗 Independent convergence with lane 1.1 on departed members

Worth flagging, because the two lanes reached it separately with no contact.

**PR #6 (lane 1.1) explicitly hands this over as an unclosed obligation.** Its predicate does not check `departed_at`, on the reasoning that participation is a fact about the *requester* and constant across every candidate. It encodes the contract in the type — constructing a `MemberId` asserts current participation — and says plainly: *"If token validation resolves a departed membership, the predicate will admit them. No document states where that check lives."*

**This lane independently decided a departed membership does not resolve**, arguing from the same schema comment in the opposite direction: *"References to this membership survive it"* is about rows already pointing at it (authorship never changes, an audience entry stays where it is), not about the person still being able to act.

The check is `SELECT … WHERE subject = $1 AND departed_at IS NULL`, covered by `a_departed_membership_does_not_resolve`, which also asserts the row itself is untouched.

Two lanes converging on the same boundary without coordination is a severity signal in the *good* direction — but **the obligation is now discharged by code and by nothing in the documents.** That is worth writing down somewhere normative before Wave 2.

## JWKS caching, and one security decision past the brief

- **A cached key set has no expiry.** It goes *stale* after 15 minutes; stale is not empty.
- **A failed refresh leaves the previous set and its fetch time untouched.** An Authentik restart or certificate renewal must not sign every household member out. Tested at the least forgiving setting — `refresh_after = ZERO`, so the set is stale on every call and every call tries a provider that has been taken away.
- **Provider unreachable never escapes as an error.** `key_for` returns `None`, the caller reads unauthenticated, unauthenticated is a wait.
- **An unseen `kid` prompts exactly one refresh**, which is how rotation is noticed without polling. If it fails, the previously held keys keep working.

**Refresh attempts are rate-limited to one per 60s**, and this one is not in the brief. The unseen-`kid` path is reachable by anyone who can send a header — without a limit, a stream of forged headers each carrying a random `kid` turns the instance into a load generator aimed at its own identity provider. `fetches_are_rate_limited_against_a_stream_of_unknown_key_ids`: 50 invented `kid`s produce exactly 1 fetch.

Also: keys marked `"use": "enc"` are skipped; a declared `alg` must match via an explicit table rather than string comparison; permitted algorithms are asymmetric only, so an HMAC token signed with the *published public key* is rejected before it reaches the library's family check.

## Enforcement of "unauthenticated reaches no query surface"

**Structural.** `Member` has private fields and no public constructor. The only code that can build one is the branch reached after a signature verified and a claim resolved. A surface taking `&Member` cannot be called by an unauthenticated request — it cannot express the call.

One qualification, stated rather than buried: `Member::for_test` exists behind `#[cfg(feature = "testing")]`. I verified the feature is **not** in `default` (`testing = ["dep:dotenvy"]` only), so no shipped binary gets it.

Because a type argument is not a runnable test, `an_unvalidated_credential_never_reaches_the_store` proves the ordering behaviourally: prime the cache, `pool.close()`, then assert a forged token still yields `Ok(Unauthenticated)` while a valid one yields `Err(Fault::Store(_))`. Only a forgery that never reached the store explains that pair.

## Crypto stack — one provider, deliberately

`jsonwebtoken` is pinned at **9.3.1**, not the current 11. Versions 10 and 11 dropped the ring backend, offering only `aws_lc_rs` or a pure-Rust stack. Either would put a **second** crypto implementation in a binary that already has ring via `sqlx`'s `tls-rustls-ring`. Same reasoning chose `hyper-rustls` over `reqwest`, whose rustls feature forces `aws-lc-rs`.

Verified independently: `grep -c aws-lc Cargo.lock` → **0**.

This is a crypto-stack decision, so it is called out rather than taken silently. Moving to jsonwebtoken 11 and accepting aws-lc-rs is a small change if you prefer it.

## Verification

Rebased onto `a7033c1`. Run by the orchestrator, not self-reported:

```
$ cargo test --workspace
  tests/token_validation.rs  22 passed     tests/store.rs      2 passed
  tests/contract.rs           2 passed
$ cargo clippy --workspace --all-targets --all-features -- -D warnings   # clean
$ cargo fmt --all --check                                                # clean
```

The three done-when conditions, each a named test: `a_valid_token_resolves_to_a_membership` (asserts membership id, household, subject, administrator against the seeded row), `an_expired_token_is_the_wait_outcome` (advances an **injected clock** past `exp` + 60s skew — no sleeping anywhere in the suite), `a_forged_token_produces_nothing` (signs with a key the provider never published while claiming a published `kid`).

## Deviations and open items

- **Two variants, not the three my brief asked for.** Refusal is a statement about a *request*, and this boundary never sees one — anything refused was authenticated first. A refusal variant here would be dead code or would pull the write path's outcome vocabulary into lane 1.4, which is 2.1's to own.
- **Own `exp`/`nbf` comparison**, because `jsonwebtoken` reads `SystemTime::now()` with no injection point, so expiry could otherwise only be tested by sleeping. Signature, issuer and audience remain the library's.
- **No server wiring, no config loading, no tonic interceptor.** There is no gRPC service to attach to yet. The `Status` mapping is documented in the PR branch rather than implemented — critically, `Status::unauthenticated` must carry **no message distinguishing why**, or the leak this lane closed reopens at the wire.
- **No logging.** A failed JWKS refresh is silent to the operator as well as the client. Correct for the client; an operator probably wants it. No logging framework exists in the crate yet and picking one is a project-wide call.
- `[unverified]` — never run against a real Authentik. Tests use EC P-256; Authentik's default RS256 is permitted by the code and handled by `DecodingKey::from_jwk`, but no test mints an RSA token (RSA keygen per test is slow enough to erode the verify-often cadence).
