### PR TITLE
Wave 1.2: divide a body into blocks, and carry block identity across an edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,8 @@ dependencies = [
  "altaird",
  "anyhow",
  "dotenvy",
+ "proptest",
+ "pulldown-cmark",
  "sqlx",
  "tokio",
  "uuid",
@@ -145,6 +147,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,7 +230,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -548,14 +565,26 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1200,6 +1229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1254,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -1331,6 +1388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,9 +1404,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -1353,7 +1432,26 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1361,6 +1459,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1475,6 +1582,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1746,7 +1865,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2100,6 +2219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2311,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2333,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2402,6 +2545,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,6 +2577,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/crates/altaird/Cargo.toml
+++ b/crates/altaird/Cargo.toml
@@ -11,6 +11,7 @@ testing = ["dep:dotenvy"]
 [dependencies]
 anyhow = "1.0.104"
 dotenvy = { version = "0.15.7", optional = true }
+pulldown-cmark = { version = "0.13.4", default-features = false }
 sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "uuid", "chrono", "macros", "migrate"] }
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros"] }
 uuid = { version = "1.24.1", features = ["v4"] }
@@ -18,3 +19,4 @@ uuid = { version = "1.24.1", features = ["v4"] }
 
 [dev-dependencies]
 altaird = { path = ".", features = ["testing"] }
+proptest = "1.11.0"

--- a/crates/altaird/src/body/divide.rs
+++ b/crates/altaird/src/body/divide.rs
@@ -1,0 +1,352 @@
+//! Dividing a body into blocks.
+//!
+//! # What this function owes
+//!
+//! From `docs/altair-substrate-spec.md`, "How a body divides into blocks":
+//!
+//! - *"The division is structural, and derived from the text alone."* — the
+//!   only input is the body. No clock, no locale, no hash iteration order, no
+//!   floating point, no configuration read at runtime. The parser options are
+//!   a fixed set ([`options`]) precisely because changing them
+//!   changes boundaries, which is a decision and not a knob.
+//! - *"Some constructs are atomic and never split, whatever blank lines they
+//!   contain and however large they are. A fenced code block, a diagram, a
+//!   table."* — this function descends into exactly one construct, the list,
+//!   and treats every other top-level construct as one block. A mermaid
+//!   diagram is a fenced code block and is covered by that rule.
+//! - *"Some constructs contain independently editable parts and split at them.
+//!   A list item is a block while the list holds together around it."*
+//! - *"Accepted limitation: a long unbroken stretch of prose is one block."* —
+//!   a paragraph is one block however long. This is correct, not a defect, and
+//!   [`crate::body`]'s tests pin it so a later reader does not helpfully split
+//!   on sentences.
+//!
+//! # Spans partition the body exactly
+//!
+//! Every byte of a non-blank body belongs to exactly one block. A block's
+//! [`Division::text`] is the verbatim source slice, and concatenating the
+//! blocks in order reproduces the body byte for byte. Nothing may foreclose
+//! export (DR-001), and a division that dropped the author's blank lines,
+//! indentation, or tight/loose list structure would be a lossy one.
+//!
+//! Whitespace between two blocks is attributed to the block before it; a
+//! leading gap is attributed to the block after it, because there is nothing
+//! before it. [`Division::content`] is the same slice with that surrounding
+//! blank space trimmed off, and is what identity matching compares — a block
+//! is not "reworded" because somebody pressed return underneath it.
+
+use std::ops::Range;
+
+use pulldown_cmark::{Event, Options, Parser, Tag};
+
+/// The parser options division is computed under.
+///
+/// This is a constant rather than a parameter. Two instances parsing under
+/// different options would compute different boundaries from the same text,
+/// which is the exact failure the "derived from the text alone" rule exists to
+/// prevent. Changing this set changes how existing bodies divide, so it is a
+/// decision with a migration attached, not a tuning knob.
+///
+/// - `ENABLE_TABLES` — a table is named in the spec as atomic, and without
+///   this a table is parsed as an ordinary paragraph of pipes.
+/// - `ENABLE_FOOTNOTES` — a footnote definition is a top-level construct; with
+///   the extension off it becomes an unremarkable paragraph, which is still one
+///   block, but with it on the definition stays whole when it spans a blank
+///   line.
+/// - `ENABLE_TASKLISTS` — `- [ ] milk` is a list item, and a shopping list is
+///   the named motivating case for splitting list items.
+fn options() -> Options {
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
+    options.insert(Options::ENABLE_FOOTNOTES);
+    options.insert(Options::ENABLE_TASKLISTS);
+    options
+}
+
+/// What kind of construct a block came from.
+///
+/// This is not persisted and does not cross the wire — the contract's `Block`
+/// carries an identifier and text and nothing else. It exists so that tests can
+/// assert atomicity directly rather than by inspecting text, and so a reader
+/// can see which rule produced a boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BlockKind {
+    Paragraph,
+    Heading,
+    /// A fenced code block. A mermaid diagram is one of these.
+    FencedCode,
+    IndentedCode,
+    Table,
+    BlockQuote,
+    HtmlBlock,
+    ThematicBreak,
+    FootnoteDefinition,
+    MetadataBlock,
+    DefinitionList,
+    /// An entry of a list, at any depth.
+    ListItem,
+    /// Content of a list item resuming after a nested list closed.
+    ListItemTail,
+}
+
+/// One block of a divided body.
+///
+/// Borrows the body it was divided from; `span` and `content` are byte ranges
+/// into that body.
+#[derive(Clone, Debug)]
+pub struct Division<'a> {
+    body: &'a str,
+    kind: BlockKind,
+    span: Range<usize>,
+    content: Range<usize>,
+}
+
+impl<'a> Division<'a> {
+    /// Which rule produced this block.
+    pub fn kind(&self) -> BlockKind {
+        self.kind
+    }
+
+    /// The block's byte range in the body. Spans are contiguous and cover the
+    /// whole body.
+    pub fn span(&self) -> Range<usize> {
+        self.span.clone()
+    }
+
+    /// The block's text, verbatim, including any blank space attributed to it.
+    ///
+    /// This is what a block row holds. Concatenating this over the blocks in
+    /// order reproduces the body exactly, which is what makes a body "its
+    /// blocks in order" true rather than approximately true.
+    pub fn text(&self) -> &'a str {
+        &self.body[self.span.clone()]
+    }
+
+    /// The block's byte range with surrounding blank space trimmed.
+    pub fn content_span(&self) -> Range<usize> {
+        self.content.clone()
+    }
+
+    /// The block's text with surrounding blank space trimmed.
+    ///
+    /// Identity matching compares this, so that adding a blank line after a
+    /// paragraph is not mistaken for rewriting it. Leading indentation on the
+    /// first line is *kept*, because indentation is what tells a nested list
+    /// item from a top-level one and an indented code block from a paragraph.
+    pub fn content(&self) -> &'a str {
+        &self.body[self.content.clone()]
+    }
+
+    /// True where this block is entirely blank space. Only possible for a body
+    /// that is entirely blank, which produces no blocks at all, so this is
+    /// always false in practice and exists for the property tests to say so.
+    pub fn is_blank(&self) -> bool {
+        self.content.is_empty()
+    }
+}
+
+/// Divide a body into blocks.
+///
+/// Pure: the same text always yields the same boundaries, on every machine and
+/// every run.
+///
+/// A body that is empty or entirely whitespace has no blocks. That is the one
+/// case where concatenating the blocks does not reproduce the input, and it is
+/// the right answer: an empty body has no independently addressable parts.
+pub fn divide(body: &str) -> Vec<Division<'_>> {
+    if body.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let starts = boundaries(body);
+    let mut blocks = Vec::with_capacity(starts.len());
+    for (index, (start, kind)) in starts.iter().enumerate() {
+        // Whitespace between blocks belongs to the block before it; the gap
+        // before the first block belongs to the first block, there being
+        // nothing before it. Together these make the spans a partition.
+        let from = if index == 0 { 0 } else { *start };
+        let to = starts
+            .get(index + 1)
+            .map(|(next, _)| *next)
+            .unwrap_or(body.len());
+        let content = trim_span(body, from..to);
+        blocks.push(Division {
+            body,
+            kind: *kind,
+            span: from..to,
+            content,
+        });
+    }
+    blocks
+}
+
+/// Reduce a stored block's text to the same form [`Division::content`] returns.
+///
+/// A block row holds the verbatim span. Identity matching compares content, so
+/// the stored side has to be reduced by the identical rule or the two sides are
+/// not comparable.
+pub fn content_of(text: &str) -> &str {
+    let range = trim_span(text, 0..text.len());
+    &text[range]
+}
+
+/// Which frame of the parse we are inside.
+///
+/// The walk descends into exactly one thing — a list, so that its items become
+/// blocks — and treats everything else as opaque. `Opaque` is what makes
+/// "atomic constructs never split" true by construction rather than by a rule
+/// applied afterwards: once inside a table, a quote, or a code block, no
+/// boundary can be emitted until it closes.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Frame {
+    List,
+    /// A list item. Carries whether a nested list has already closed inside it,
+    /// which decides whether the item's remaining content starts a new block.
+    Item {
+        after_sublist: bool,
+    },
+    Opaque,
+}
+
+fn boundaries(body: &str) -> Vec<(usize, BlockKind)> {
+    let mut starts: Vec<(usize, BlockKind)> = Vec::new();
+    let mut stack: Vec<Frame> = Vec::new();
+
+    let emit = |offset: usize, kind: BlockKind, starts: &mut Vec<(usize, BlockKind)>| {
+        let at = line_start(body, offset);
+        // Strictly increasing, defensively. A boundary that did not advance
+        // would produce an empty span and a block nobody can edit.
+        if starts.last().is_none_or(|(previous, _)| at > *previous) {
+            starts.push((at, kind));
+        }
+    };
+
+    for (event, range) in Parser::new_ext(body, options()).into_offset_iter() {
+        match event {
+            Event::Start(tag) => {
+                let frame = match (stack.last().copied(), &tag) {
+                    // A list is not itself a block. Its items are.
+                    (None | Some(Frame::Item { .. }), Tag::List(_)) => Frame::List,
+
+                    // Every other top-level construct is one block, whole.
+                    (None, _) => {
+                        emit(range.start, kind_of(&tag), &mut starts);
+                        Frame::Opaque
+                    }
+
+                    // "A list item is a block while the list holds together
+                    // around it." At any depth: a nested list splits into its
+                    // own items too, because a sectioned shopping list is still
+                    // a shopping list and two people adding to different
+                    // sections have to merge.
+                    (Some(Frame::List), Tag::Item) => {
+                        emit(range.start, BlockKind::ListItem, &mut starts);
+                        Frame::Item {
+                            after_sublist: false,
+                        }
+                    }
+                    (Some(Frame::List), _) => Frame::Opaque,
+
+                    // Content of an item before its first nested list belongs
+                    // to the item's own block. Content resuming after one
+                    // starts a further block, because it has no other block it
+                    // could belong to without reaching backwards past entries
+                    // that are not its own.
+                    (Some(Frame::Item { after_sublist }), _) => {
+                        if after_sublist {
+                            emit(range.start, BlockKind::ListItemTail, &mut starts);
+                        }
+                        Frame::Opaque
+                    }
+
+                    (Some(Frame::Opaque), _) => Frame::Opaque,
+                };
+                stack.push(frame);
+            }
+            Event::End(end) => {
+                let popped = stack.pop();
+                debug_assert!(popped.is_some(), "unbalanced end for {end:?}");
+                if popped == Some(Frame::List)
+                    && let Some(Frame::Item { after_sublist }) = stack.last_mut()
+                {
+                    *after_sublist = true;
+                }
+            }
+            // A thematic break is an event rather than a tag, so it needs the
+            // same treatment the tag arm gives every other top-level construct.
+            Event::Rule => match stack.last().copied() {
+                None => emit(range.start, BlockKind::ThematicBreak, &mut starts),
+                Some(Frame::Item {
+                    after_sublist: true,
+                }) => emit(range.start, BlockKind::ListItemTail, &mut starts),
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    starts
+}
+
+fn kind_of(tag: &Tag<'_>) -> BlockKind {
+    use pulldown_cmark::CodeBlockKind;
+    match tag {
+        Tag::Paragraph => BlockKind::Paragraph,
+        Tag::Heading { .. } => BlockKind::Heading,
+        Tag::BlockQuote(_) => BlockKind::BlockQuote,
+        Tag::CodeBlock(CodeBlockKind::Fenced(_)) => BlockKind::FencedCode,
+        Tag::CodeBlock(CodeBlockKind::Indented) => BlockKind::IndentedCode,
+        Tag::HtmlBlock => BlockKind::HtmlBlock,
+        Tag::Table(_) => BlockKind::Table,
+        Tag::FootnoteDefinition(_) => BlockKind::FootnoteDefinition,
+        Tag::MetadataBlock(_) => BlockKind::MetadataBlock,
+        Tag::DefinitionList => BlockKind::DefinitionList,
+        Tag::Item => BlockKind::ListItem,
+        // A list is never emitted as a block, and every remaining tag is
+        // inline and cannot reach here without an enclosing block frame.
+        _ => BlockKind::Paragraph,
+    }
+}
+
+/// The start of the line containing `offset`, provided everything between is
+/// blank.
+///
+/// The parser reports an indented code block from the first non-space byte and
+/// a nested list item from its marker, both of which drop the indentation that
+/// says what the construct is. Backing up to the line start restores it, which
+/// is what keeps division lossless.
+fn line_start(body: &str, offset: usize) -> usize {
+    let before = &body[..offset];
+    let line = before.rfind('\n').map(|at| at + 1).unwrap_or(0);
+    if before[line..].chars().all(|c| c == ' ' || c == '\t') {
+        line
+    } else {
+        offset
+    }
+}
+
+/// Trim blank space from both ends of a span, keeping the indentation of the
+/// first line that has content.
+fn trim_span(body: &str, span: Range<usize>) -> Range<usize> {
+    let slice = &body[span.clone()];
+    let Some(first) = slice.find(|c: char| !c.is_whitespace()) else {
+        return span.start..span.start;
+    };
+    let start = span.start + line_start(slice, first);
+    let end = span.start + slice.trim_end().len();
+    start..end.max(start)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_start_backs_up_over_blank_prefix_only() {
+        // The marker of an indented list item backs up over its indentation.
+        assert_eq!(line_start("  - a", 2), 0);
+        // Anything else on the line before it does not.
+        assert_eq!(line_start("x - a", 2), 2);
+        assert_eq!(line_start("p\n  - a", 4), 2);
+    }
+}

--- a/crates/altaird/src/body/identity.rs
+++ b/crates/altaird/src/body/identity.rs
@@ -1,0 +1,453 @@
+//! Carrying block identity across a body write.
+//!
+//! # What this owes
+//!
+//! *"A block is recognisable as the same block after the text around it
+//! changes, and after edits to its own text. This is what anchors and
+//! reconciliation both depend on, and the second half is what a block anchor
+//! relies on: rewording an entry does not detach a relation anchored to the
+//! entry itself."* — `docs/altair-substrate-spec.md`.
+//!
+//! Two consequences fall straight out of that sentence and rule out the two
+//! obvious implementations:
+//!
+//! - Identity cannot be a hash of the block's text, because the text changes
+//!   and the identity must not.
+//! - Identity cannot be the block's position, because reordering a list must
+//!   not renumber every entry's relations onto their neighbours.
+//!
+//! # The algorithm
+//!
+//! Three passes over the blocks the store already holds and the blocks the
+//! incoming body divides into. Each pass claims pairs; a claimed block takes no
+//! further part.
+//!
+//! 1. **Exact content.** An incoming block whose content is byte-identical to
+//!    an unclaimed stored block's content takes that block's identity. Where
+//!    several stored blocks have the same content — two identical shopping list
+//!    entries — the one nearest in position wins, and on a tie the earlier one.
+//!    This pass alone covers insertion, deletion, and reordering around a
+//!    block, which is why it runs first and unconditionally.
+//!
+//! 2. **Similarity.** Every remaining (stored, incoming) pair is scored over
+//!    character trigrams and the pairs at or above the threshold are taken
+//!    greedily, best first. This is the pass that survives rewording.
+//!
+//! 3. **The remainder is new.** An incoming block that matched nothing gets a
+//!    fresh UUIDv4. A stored block that matched nothing is reported as removed;
+//!    a relation anchored to it loses its anchor and survives, which is the
+//!    rule the substrate spec already states for a removed block.
+//!
+//! # Where "this is now a different block" sits, and why there
+//!
+//! Two conditions, both integer ratios so that "exactly at the threshold"
+//! decides the same way on every machine:
+//!
+//! - **Overlap ≥ [`SIMILARITY_THRESHOLD`] (1/2).** Of the trigrams of the
+//!   *shorter* of the two texts, at least half appear in the longer.
+//! - **Length ratio ≥ [`LENGTH_RATIO_FLOOR`] (1/4).** The shorter text is at
+//!   least a quarter the length of the longer.
+//!
+//! The measure is the overlap coefficient — `|A ∩ B| / min(|A|, |B|)` — rather
+//! than the more usual Sørensen–Dice, and the length floor is what makes that
+//! safe. Dice divides by the *combined* size, so it falls away sharply when one
+//! side grows: `- eggs` reworded to `- half a dozen eggs` scores 0.48 under
+//! Dice and would become a new block, losing its relations, for an edit that is
+//! obviously the same entry with more said about it. Expanding or trimming an
+//! entry is the commonest edit there is, so a measure that punishes it is the
+//! wrong measure. Overlap ignores the excess; the length floor puts a bound on
+//! how much excess is credible. (The floor never rejects a pair Dice would have
+//! accepted: below a ratio of 1/4, Dice cannot exceed 0.4.)
+//!
+//! Trigrams are padded at both ends, so two texts must begin alike *and* end
+//! alike to score highly. That is what stops a short block from matching any
+//! long block that happens to contain its words.
+//!
+//! Which side of the threshold to err toward is settled by which error is
+//! worse. Refusing a match that should have held costs an anchor: the relation
+//! survives without one, which the substrate spec already describes as an
+//! ordinary outcome, and the block simply reads as new. Accepting a match that
+//! should not have held silently moves somebody's relation onto text they did
+//! not write, and nothing tells them. So the thresholds are set to admit the
+//! ordinary shapes of an edit and refuse a replacement, and where a case is
+//! genuinely ambiguous the answer is "new block".
+//!
+//! # Failure modes, stated rather than discovered later
+//!
+//! - **Short, similar entries cross-match.** `- eggs` and `- legs` score
+//!   exactly at the threshold and match. Short blocks are where trigrams carry
+//!   least information; the positional tiebreak reduces the damage and does not
+//!   remove it.
+//! - **A wholesale rewrite produces a new block**, and its relations lose their
+//!   anchors. Deliberate, per the reasoning above.
+//! - **A block split in two** matches at most one of the halves — whichever
+//!   scores higher, with ties broken toward the earlier position. The other
+//!   half is new. There is no notion of one block becoming two.
+//! - **Two blocks merged into one** carries the identity of whichever original
+//!   the merged text resembles more. The other is reported removed.
+//! - **Structure is not consulted.** Matching sees text only, never position
+//!   except as a tiebreak and never the surrounding blocks. A block replaced
+//!   wholesale between two unchanged neighbours is a new block, even though a
+//!   person reading the diff would call it an edit. Consulting neighbours would
+//!   catch that case and would also carry an identity onto text with nothing in
+//!   common with the original, which is the error this refuses to make.
+//! - **Greedy is not optimal.** A globally better assignment can exist. Greedy
+//!   is chosen because it is deterministic, explicable, and stable under small
+//!   edits; an optimal assignment is neither cheap nor obviously more correct
+//!   when the scores are this close together.
+//! - **Very large bodies skip pass 2.** See [`MAX_SIMILARITY_PAIRS`].
+
+use std::collections::BTreeMap;
+
+use uuid::Uuid;
+
+use super::divide::{content_of, divide};
+
+/// The trigram overlap at or above which a rewritten block keeps its identity,
+/// as an exact ratio. See the module documentation for why it sits here.
+pub const SIMILARITY_THRESHOLD: (u128, u128) = (1, 2);
+
+/// How far apart in length two texts may be and still be one block reworded,
+/// as an exact ratio of shorter to longer. Overlap alone would let a short
+/// block match an arbitrarily long one; this bounds it.
+pub const LENGTH_RATIO_FLOOR: (u128, u128) = (1, 4);
+
+/// Above this many candidate pairs, the similarity pass is skipped and every
+/// unmatched incoming block is new.
+///
+/// The pass is quadratic in unmatched blocks. A body large enough to reach this
+/// bound has had almost every one of its thousands of blocks rewritten in a
+/// single write, which is a paste of a different document rather than an edit.
+/// Skipping is still deterministic — the bound is a count, not a clock.
+pub const MAX_SIMILARITY_PAIRS: usize = 250_000;
+
+/// A block as the store holds it, in position order.
+///
+/// `text` is the verbatim span, which is what a block row holds. Matching
+/// reduces it with [`content_of`] so both sides are compared by the same rule.
+#[derive(Clone, Debug)]
+pub struct StoredBlock {
+    pub id: Uuid,
+    pub text: String,
+}
+
+/// Where a resolved block's identity came from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Origin {
+    /// The identity of a block the store already held.
+    Carried,
+    /// A fresh identity. Nothing in the store resembled this text.
+    Created,
+}
+
+/// One block of the incoming body, with the identity it will be written under.
+#[derive(Clone, Debug)]
+pub struct ResolvedBlock {
+    pub id: Uuid,
+    /// Zero-based, dense, in body order.
+    pub position: usize,
+    /// The verbatim text to store.
+    pub text: String,
+    pub origin: Origin,
+    /// True where the stored text differs from `text`, or the block is new.
+    /// A change set carries the identities of the blocks that changed, so this
+    /// is the thing that decides what goes in it.
+    pub text_changed: bool,
+    /// True where a carried block's position moved. A move is a change to the
+    /// body, not to the block's text, and the two are reported separately
+    /// because a client comparing its own unsent edit cares about the second.
+    pub moved: bool,
+}
+
+/// The outcome of matching an incoming body against the blocks already held.
+#[derive(Clone, Debug)]
+pub struct Reconciliation {
+    /// The incoming body's blocks, in order, with identities settled.
+    pub blocks: Vec<ResolvedBlock>,
+    /// Stored blocks nothing in the incoming body matched, in position order.
+    /// Their rows go, and a relation anchored to one loses its anchor and
+    /// survives.
+    pub removed: Vec<Uuid>,
+}
+
+/// Divide `body` and match it against the blocks the store holds.
+///
+/// `stored` is in position order; its index is the block's position.
+pub fn reconcile(stored: &[StoredBlock], body: &str) -> Reconciliation {
+    reconcile_with(stored, body, Uuid::new_v4)
+}
+
+/// [`reconcile`], with the source of new identifiers supplied.
+///
+/// Every identifier is a random UUIDv4 generated by whatever brings the thing
+/// into existence (DR-007), so the production caller passes [`Uuid::new_v4`].
+/// This form exists so a test can assert *which* blocks were created without
+/// the assertion depending on randomness. Nothing reads an identifier, here or
+/// anywhere: matching looks only at text and position.
+pub fn reconcile_with(
+    stored: &[StoredBlock],
+    body: &str,
+    mut new_id: impl FnMut() -> Uuid,
+) -> Reconciliation {
+    let incoming = divide(body);
+    let stored_content: Vec<&str> = stored.iter().map(|b| content_of(&b.text)).collect();
+    let incoming_content: Vec<&str> = incoming.iter().map(|b| b.content()).collect();
+
+    // `matched[i]` is the stored index the incoming block at `i` claimed.
+    let mut matched: Vec<Option<usize>> = vec![None; incoming.len()];
+    let mut claimed: Vec<bool> = vec![false; stored.len()];
+
+    match_exact(
+        &stored_content,
+        &incoming_content,
+        &mut matched,
+        &mut claimed,
+    );
+    match_similar(
+        &stored_content,
+        &incoming_content,
+        &mut matched,
+        &mut claimed,
+    );
+
+    let blocks = incoming
+        .iter()
+        .enumerate()
+        .map(|(position, block)| match matched[position] {
+            Some(from) => ResolvedBlock {
+                id: stored[from].id,
+                position,
+                text: block.text().to_owned(),
+                origin: Origin::Carried,
+                text_changed: stored[from].text != block.text(),
+                moved: from != position,
+            },
+            None => ResolvedBlock {
+                id: new_id(),
+                position,
+                text: block.text().to_owned(),
+                origin: Origin::Created,
+                text_changed: true,
+                moved: false,
+            },
+        })
+        .collect();
+
+    let removed = stored
+        .iter()
+        .zip(&claimed)
+        .filter(|(_, claimed)| !**claimed)
+        .map(|(block, _)| block.id)
+        .collect();
+
+    Reconciliation { blocks, removed }
+}
+
+/// Pass 1: byte-identical content, nearest position first.
+///
+/// This is the pass that makes identity survive edits to a block's
+/// *neighbours*: inserting, deleting, or reordering around a block leaves its
+/// own text untouched, so it matches here regardless of where it moved to.
+fn match_exact(
+    stored: &[&str],
+    incoming: &[&str],
+    matched: &mut [Option<usize>],
+    claimed: &mut [bool],
+) {
+    // BTreeMap, not HashMap: the values are read in order and nothing about
+    // this function may depend on a hash seed.
+    let mut by_content: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+    for (index, content) in stored.iter().enumerate() {
+        by_content.entry(content).or_default().push(index);
+    }
+
+    for (position, content) in incoming.iter().enumerate() {
+        let Some(candidates) = by_content.get(content) else {
+            continue;
+        };
+        let best = candidates
+            .iter()
+            .copied()
+            .filter(|index| !claimed[*index])
+            .min_by_key(|index| (index.abs_diff(position), *index));
+        if let Some(index) = best {
+            claimed[index] = true;
+            matched[position] = Some(index);
+        }
+    }
+}
+
+/// Pass 2: trigram overlap, greedy, best first.
+///
+/// This is the pass that makes identity survive edits to a block's *own* text.
+fn match_similar(
+    stored: &[&str],
+    incoming: &[&str],
+    matched: &mut [Option<usize>],
+    claimed: &mut [bool],
+) {
+    let free_stored: Vec<usize> = (0..stored.len()).filter(|i| !claimed[*i]).collect();
+    let free_incoming: Vec<usize> = (0..incoming.len())
+        .filter(|i| matched[*i].is_none())
+        .collect();
+
+    if free_stored.is_empty() || free_incoming.is_empty() {
+        return;
+    }
+    if free_stored.len().saturating_mul(free_incoming.len()) > MAX_SIMILARITY_PAIRS {
+        return;
+    }
+
+    let stored_grams: Vec<Vec<[char; 3]>> =
+        free_stored.iter().map(|i| trigrams(stored[*i])).collect();
+    let incoming_grams: Vec<Vec<[char; 3]>> = free_incoming
+        .iter()
+        .map(|i| trigrams(incoming[*i]))
+        .collect();
+
+    // (numerator, denominator, positional distance, incoming position, stored
+    // position). Held as an exact ratio: comparing `a/b` against `c/d` by cross
+    // multiplication in u128 has no rounding, so two machines cannot disagree
+    // about which of two near-equal pairs is better.
+    let mut pairs: Vec<(u128, u128, usize, usize, usize)> = Vec::new();
+    for (a, stored_index) in free_stored.iter().enumerate() {
+        for (b, incoming_index) in free_incoming.iter().enumerate() {
+            let (shorter, longer) = {
+                let (x, y) = (
+                    stored_grams[a].len() as u128,
+                    incoming_grams[b].len() as u128,
+                );
+                (x.min(y), x.max(y))
+            };
+            if shorter == 0 || !at_least(shorter, longer, LENGTH_RATIO_FLOOR) {
+                continue;
+            }
+            let common = intersection(&stored_grams[a], &incoming_grams[b]);
+            let (numerator, denominator) = (common as u128, shorter);
+            if !at_least(numerator, denominator, SIMILARITY_THRESHOLD) {
+                continue;
+            }
+            pairs.push((
+                numerator,
+                denominator,
+                stored_index.abs_diff(*incoming_index),
+                *incoming_index,
+                *stored_index,
+            ));
+        }
+    }
+
+    // Best score first; then the pair that moved least; then body order. Every
+    // key is an integer, so the order is total and identical everywhere.
+    pairs.sort_by(|left, right| {
+        (right.0 * left.1)
+            .cmp(&(left.0 * right.1))
+            .then(left.2.cmp(&right.2))
+            .then(left.3.cmp(&right.3))
+            .then(left.4.cmp(&right.4))
+    });
+
+    for (_, _, _, incoming_index, stored_index) in pairs {
+        if matched[incoming_index].is_none() && !claimed[stored_index] {
+            matched[incoming_index] = Some(stored_index);
+            claimed[stored_index] = true;
+        }
+    }
+}
+
+/// `numerator / denominator >= threshold`, in integers.
+fn at_least(numerator: u128, denominator: u128, threshold: (u128, u128)) -> bool {
+    numerator * threshold.1 >= threshold.0 * denominator
+}
+
+/// Character trigrams of `text`, sorted, with duplicates kept.
+///
+/// Sorted rather than hashed so the multiset intersection below is a linear
+/// merge with no map iteration in it. Padded at both ends so that a very short
+/// block still yields trigrams to compare — without padding, a two-character
+/// entry has none at all and could never match anything.
+///
+/// Characters, not bytes: a trigram must not straddle a UTF-8 boundary or an
+/// accented word would score against itself as though it were half a word. No
+/// case folding and no normalisation — a block is matched against the text as
+/// written, and folding is one more rule two implementations could disagree on.
+fn trigrams(text: &str) -> Vec<[char; 3]> {
+    const PAD: char = '\u{2}';
+    let chars: Vec<char> = std::iter::repeat_n(PAD, 2)
+        .chain(text.chars())
+        .chain(std::iter::repeat_n(PAD, 2))
+        .collect();
+    let mut grams: Vec<[char; 3]> = chars.windows(3).map(|w| [w[0], w[1], w[2]]).collect();
+    grams.sort_unstable();
+    grams
+}
+
+/// Size of the multiset intersection of two sorted trigram lists.
+fn intersection(left: &[[char; 3]], right: &[[char; 3]]) -> usize {
+    let (mut i, mut j, mut common) = (0, 0, 0);
+    while i < left.len() && j < right.len() {
+        match left[i].cmp(&right[j]) {
+            std::cmp::Ordering::Less => i += 1,
+            std::cmp::Ordering::Greater => j += 1,
+            std::cmp::Ordering::Equal => {
+                common += 1;
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+    common
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The overlap of a text with itself is one.
+    fn overlap(left: &str, right: &str) -> (usize, usize) {
+        let (a, b) = (trigrams(left), trigrams(right));
+        (intersection(&a, &b), a.len().min(b.len()))
+    }
+
+    #[test]
+    fn overlap_of_identical_text_is_one() {
+        let (common, shorter) = overlap("milk", "milk");
+        assert_eq!(common, shorter);
+    }
+
+    /// The case that chose overlap over Sørensen–Dice. Dice scores this 0.48
+    /// and would make it a new block.
+    #[test]
+    fn an_expanded_entry_scores_above_the_threshold() {
+        let (common, shorter) = overlap("- eggs", "- half a dozen eggs");
+        assert!(
+            at_least(common as u128, shorter as u128, SIMILARITY_THRESHOLD),
+            "{common}/{shorter}"
+        );
+    }
+
+    #[test]
+    fn two_unrelated_entries_score_below_the_threshold() {
+        let (common, shorter) = overlap("- milk", "- bread");
+        assert!(
+            !at_least(common as u128, shorter as u128, SIMILARITY_THRESHOLD),
+            "{common}/{shorter}"
+        );
+    }
+
+    #[test]
+    fn threshold_compares_as_an_exact_ratio() {
+        assert!(at_least(1, 2, SIMILARITY_THRESHOLD));
+        assert!(!at_least(499, 1000, SIMILARITY_THRESHOLD));
+        assert!(at_least(501, 1000, SIMILARITY_THRESHOLD));
+    }
+
+    #[test]
+    fn trigrams_are_sorted_and_character_aligned() {
+        let grams = trigrams("café");
+        assert!(grams.windows(2).all(|w| w[0] <= w[1]));
+        // Characters, not bytes: "café" is five bytes and four characters, and
+        // padding two either side gives one trigram per character plus two.
+        assert_eq!(grams.len(), "café".chars().count() + 2);
+    }
+}

--- a/crates/altaird/src/body/mod.rs
+++ b/crates/altaird/src/body/mod.rs
@@ -1,0 +1,25 @@
+//! Bodies: how text divides into blocks, and how block identity survives an edit.
+//!
+//! A body is a single markdown field. The substrate spec makes the *block*, not
+//! the field, the smallest independently addressable part of a body, because
+//! "treating the field as the unit would make two people working on different
+//! paragraphs of a shared plan look like a disagreement".
+//!
+//! Two things live here and nothing else:
+//!
+//! - [`divide`] — a pure function from text to boundaries. "The division is
+//!   structural, and derived from the text alone." It reads no clock, no
+//!   locale, no environment, and no randomness.
+//! - [`reconcile`] — the matching step that carries identity forward. "A block
+//!   is recognisable as the same block after the text around it changes, and
+//!   after edits to its own text."
+//!
+//! DR-004 puts both at the instance: a client submits the whole body and the
+//! instance divides it, so the division rule has exactly one implementation and
+//! devices cannot disagree about the units reconciliation is decided in.
+
+pub mod divide;
+pub mod identity;
+
+pub use divide::{BlockKind, Division, content_of, divide};
+pub use identity::{Origin, Reconciliation, ResolvedBlock, StoredBlock, reconcile, reconcile_with};

--- a/crates/altaird/src/lib.rs
+++ b/crates/altaird/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod body;
 pub mod store;
 
 #[cfg(feature = "testing")]

--- a/crates/altaird/tests/body_division.rs
+++ b/crates/altaird/tests/body_division.rs
@@ -1,0 +1,364 @@
+//! Division: the boundary rules, and the properties that hold for every body.
+//!
+//! The plan calls block division "the most testable component in the system and
+//! the easiest to get subtly wrong", so this file is weighted accordingly. Each
+//! test names the sentence it enforces.
+
+use altaird::body::{BlockKind, divide};
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Boundary rules, stated one at a time
+// ---------------------------------------------------------------------------
+
+fn kinds(body: &str) -> Vec<BlockKind> {
+    divide(body).iter().map(|b| b.kind()).collect()
+}
+
+fn contents(body: &str) -> Vec<String> {
+    divide(body)
+        .iter()
+        .map(|b| b.content().to_owned())
+        .collect()
+}
+
+/// "Accepted limitation: a long unbroken stretch of prose is one block."
+///
+/// This test exists to be *failed by a helpful improvement*. Anyone who makes
+/// division split on sentences to let two people merge edits to one paragraph
+/// has reintroduced the interleaving the substrate spec rejects by name, and
+/// this is where they find out.
+#[test]
+fn a_long_unbroken_stretch_of_prose_is_one_block() {
+    let prose = "Sentence one is here. Sentence two follows it. ".repeat(200);
+    let blocks = divide(&prose);
+    assert_eq!(blocks.len(), 1, "long prose must not subdivide");
+    assert_eq!(blocks[0].kind(), BlockKind::Paragraph);
+    assert_eq!(blocks[0].content(), prose.trim_end());
+}
+
+/// "Some constructs are atomic and never split, whatever blank lines they
+/// contain and however large they are. A fenced code block, a diagram, a
+/// table."
+#[test]
+fn a_fenced_code_block_is_one_block_however_many_blank_lines_it_holds() {
+    let body = "before\n\n```rust\nfn a() {}\n\n\nfn b() {}\n\n- not a list item\n\n# not a heading\n```\n\nafter\n";
+    assert_eq!(
+        kinds(body),
+        vec![
+            BlockKind::Paragraph,
+            BlockKind::FencedCode,
+            BlockKind::Paragraph
+        ]
+    );
+    assert!(contents(body)[1].contains("- not a list item"));
+}
+
+/// A diagram is a fenced code block, and these documents are full of them.
+#[test]
+fn a_mermaid_diagram_is_one_block() {
+    let body = "```mermaid\nflowchart LR\n    A --- R\n\n    R --- B\n```\n";
+    let blocks = divide(body);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].kind(), BlockKind::FencedCode);
+}
+
+#[test]
+fn a_table_is_one_block() {
+    let body = "| a | b |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |\n";
+    let blocks = divide(body);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].kind(), BlockKind::Table);
+}
+
+/// A block quote holds quoted material. Splitting it would let half of one
+/// quotation merge with half of another, which is the same failure the spec
+/// names for a diagram.
+#[test]
+fn a_block_quote_is_one_block_including_a_list_inside_it() {
+    let body = "> a warning\n>\n> - one\n> - two\n";
+    let blocks = divide(body);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].kind(), BlockKind::BlockQuote);
+}
+
+/// "Some constructs contain independently editable parts and split at them. A
+/// list item is a block ... two people adding to a shared shopping list is
+/// among the most likely concurrent edits in a household, and it has to merge."
+#[test]
+fn each_list_item_is_its_own_block() {
+    let body = "- milk\n- eggs\n- bread\n";
+    assert_eq!(contents(body), vec!["- milk", "- eggs", "- bread"]);
+    assert_eq!(kinds(body), vec![BlockKind::ListItem; 3]);
+}
+
+#[test]
+fn task_list_items_split_too() {
+    let body = "- [ ] milk\n- [x] eggs\n";
+    assert_eq!(contents(body), vec!["- [ ] milk", "- [x] eggs"]);
+}
+
+#[test]
+fn ordered_list_items_split_too() {
+    let body = "1. first\n2. second\n";
+    assert_eq!(contents(body), vec!["1. first", "2. second"]);
+}
+
+/// A sectioned shopping list is still a shopping list, and two people adding to
+/// different sections still have to merge.
+#[test]
+fn nested_list_items_split_and_keep_their_indentation() {
+    let body = "- produce\n  - apples\n  - pears\n- dairy\n  - milk\n";
+    assert_eq!(
+        contents(body),
+        vec![
+            "- produce",
+            "  - apples",
+            "  - pears",
+            "- dairy",
+            "  - milk"
+        ]
+    );
+}
+
+/// A list item's own content is one block, whatever it holds, until a nested
+/// list opens inside it. Content resuming after that nested list has no block
+/// it could join without reaching back past entries that are not its own, so it
+/// starts one.
+#[test]
+fn an_item_is_one_block_until_a_nested_list_opens_and_content_after_one_starts_another() {
+    let body = "- lead line\n\n  second paragraph of the same entry\n- plain\n";
+    assert_eq!(
+        contents(body),
+        vec![
+            "- lead line\n\n  second paragraph of the same entry",
+            "- plain"
+        ],
+        "a multi-paragraph item with no nested list is one block"
+    );
+
+    let with_sublist = "- lead line\n  - nested\n\n  resumed content\n";
+    assert_eq!(
+        contents(with_sublist),
+        vec!["- lead line", "  - nested", "  resumed content"]
+    );
+    assert_eq!(
+        kinds(with_sublist),
+        vec![
+            BlockKind::ListItem,
+            BlockKind::ListItem,
+            BlockKind::ListItemTail
+        ]
+    );
+}
+
+/// An item holding a fenced code block does not split at it: the fence is part
+/// of the entry, and the entry is the independently editable part.
+#[test]
+fn a_list_item_holding_a_fence_is_still_one_block() {
+    let body = "- run this:\n\n  ```sh\n  ls\n\n  pwd\n  ```\n- and this\n";
+    let blocks = divide(body);
+    assert_eq!(blocks.len(), 2);
+    assert!(blocks[0].content().contains("pwd"));
+    assert_eq!(blocks[1].content(), "- and this");
+}
+
+#[test]
+fn headings_thematic_breaks_and_indented_code_are_each_one_block() {
+    let body = "# Title\n\ntext\n\n---\n\n    indented code\n    second line\n\n## Next\n";
+    assert_eq!(
+        kinds(body),
+        vec![
+            BlockKind::Heading,
+            BlockKind::Paragraph,
+            BlockKind::ThematicBreak,
+            BlockKind::IndentedCode,
+            BlockKind::Heading,
+        ]
+    );
+    assert_eq!(
+        contents(body)[3],
+        "    indented code\n    second line",
+        "indentation is what makes it code and must survive"
+    );
+}
+
+/// A body arrives as whatever the person's editor produced. Windows line
+/// endings divide the same way and reassemble unchanged — division does not
+/// normalise the text, because normalising it would be an edit nobody made.
+#[test]
+fn carriage_returns_divide_the_same_way_and_survive_reassembly() {
+    let body = "# Title\r\n\r\n- milk\r\n- eggs\r\n\r\nA paragraph.\r\n";
+    assert_eq!(
+        kinds(body),
+        vec![
+            BlockKind::Heading,
+            BlockKind::ListItem,
+            BlockKind::ListItem,
+            BlockKind::Paragraph,
+        ]
+    );
+    let rebuilt: String = divide(body).iter().map(|b| b.text()).collect();
+    assert_eq!(rebuilt, body);
+}
+
+#[test]
+fn an_empty_or_blank_body_has_no_blocks() {
+    assert!(divide("").is_empty());
+    assert!(divide("   \n\n\t\n").is_empty());
+}
+
+/// Nothing may foreclose export (DR-001). A body is its blocks in order, so
+/// concatenating the stored text has to give the body back byte for byte —
+/// including the author's blank lines and whether a list was tight or loose.
+#[test]
+fn concatenating_the_blocks_reproduces_the_body_exactly() {
+    let body = "# Title\n\n\n\nA paragraph.\n\n- tight\n- list\n\n- loose\n\n- list\n\n```\ncode\n```\n\n\n";
+    let rebuilt: String = divide(body).iter().map(|b| b.text()).collect();
+    assert_eq!(rebuilt, body);
+}
+
+/// A boundary is deterministic, so a golden fixture is a legitimate assertion
+/// rather than a brittle one. If this changes, the division rule changed, and
+/// every body already stored divides differently from the day it was written.
+#[test]
+fn a_mixed_document_divides_into_exactly_these_boundaries() {
+    let body = "Intro paragraph.\n\n- top one\n  - nested a\n  - nested b\n\n  trailing of top one\n- top two\n\n```rust\nfn f() {\n\n}\n```\n\n| a | b |\n|---|---|\n| 1 | 2 |\n\n> quote\n>\n> more\n\n    indented code\n\n---\n\n# Heading\n";
+    let blocks = divide(body);
+    let observed: Vec<(BlockKind, &str)> = blocks.iter().map(|b| (b.kind(), b.content())).collect();
+    assert_eq!(
+        observed,
+        vec![
+            (BlockKind::Paragraph, "Intro paragraph."),
+            (BlockKind::ListItem, "- top one"),
+            (BlockKind::ListItem, "  - nested a"),
+            (BlockKind::ListItem, "  - nested b"),
+            (BlockKind::ListItemTail, "  trailing of top one"),
+            (BlockKind::ListItem, "- top two"),
+            (BlockKind::FencedCode, "```rust\nfn f() {\n\n}\n```"),
+            (BlockKind::Table, "| a | b |\n|---|---|\n| 1 | 2 |"),
+            (BlockKind::BlockQuote, "> quote\n>\n> more"),
+            (BlockKind::IndentedCode, "    indented code"),
+            (BlockKind::ThematicBreak, "---"),
+            (BlockKind::Heading, "# Heading"),
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+/// Bodies with markdown structure in them. Arbitrary `String` finds panics;
+/// this finds boundary bugs, because an arbitrary string is almost never a
+/// fenced code block.
+fn fragment() -> impl Strategy<Value = String> {
+    prop_oneof![
+        "[a-z ]{1,40}".prop_map(|s| format!("{}\n", s.trim())),
+        "[a-z ]{1,20}".prop_map(|s| format!("# {}\n", s.trim())),
+        "[a-z ]{1,20}".prop_map(|s| format!("- {}\n- second\n", s.trim())),
+        "[a-z ]{1,20}".prop_map(|s| format!("- outer\n  - {}\n", s.trim())),
+        "[a-z \n]{1,40}".prop_map(|s| format!("```\n{s}\n```\n")),
+        Just("| a | b |\n|---|---|\n| 1 | 2 |\n".to_owned()),
+        Just("> quoted\n>\n> more\n".to_owned()),
+        Just("    indented\n".to_owned()),
+        Just("---\n".to_owned()),
+    ]
+}
+
+fn body() -> impl Strategy<Value = String> {
+    prop::collection::vec((fragment(), 1usize..4), 0..8).prop_map(|parts| {
+        parts
+            .into_iter()
+            .map(|(text, blanks)| format!("{}{}", text, "\n".repeat(blanks - 1)))
+            .collect()
+    })
+}
+
+proptest! {
+    /// **The property test the plan asks for**: the same text always yields the
+    /// same boundaries.
+    ///
+    /// Repeating the call inside one process is a real check, not a tautology:
+    /// two `HashMap`s built in the same process have different random states,
+    /// so any dependence on hash iteration order shows up here. Nothing else in
+    /// division reads state — no clock, no locale, no environment, no
+    /// randomness, and no floating point — so this plus review is the whole of
+    /// what determinism needs.
+    #[test]
+    fn the_same_text_always_yields_the_same_boundaries(body in body()) {
+        let first: Vec<_> = divide(&body).iter().map(|b| (b.kind(), b.span())).collect();
+        let second: Vec<_> = divide(&body).iter().map(|b| (b.kind(), b.span())).collect();
+        prop_assert_eq!(first, second);
+    }
+
+    /// The same, for text that was never meant to be markdown at all.
+    #[test]
+    fn arbitrary_text_divides_deterministically_and_without_panicking(body in ".{0,400}") {
+        let first: Vec<_> = divide(&body).iter().map(|b| (b.kind(), b.span())).collect();
+        let second: Vec<_> = divide(&body).iter().map(|b| (b.kind(), b.span())).collect();
+        prop_assert_eq!(first, second);
+    }
+
+    /// Spans partition the body: contiguous, in order, covering every byte.
+    /// This is what makes "a body is its blocks in order" exactly true.
+    #[test]
+    fn spans_partition_the_body(body in body()) {
+        let blocks = divide(&body);
+        if blocks.is_empty() {
+            prop_assert!(body.trim().is_empty());
+            return Ok(());
+        }
+        prop_assert_eq!(blocks[0].span().start, 0);
+        prop_assert_eq!(blocks[blocks.len() - 1].span().end, body.len());
+        for pair in blocks.windows(2) {
+            prop_assert_eq!(pair[0].span().end, pair[1].span().start);
+            prop_assert!(pair[0].span().start < pair[0].span().end);
+        }
+        let rebuilt: String = blocks.iter().map(|b| b.text()).collect();
+        prop_assert_eq!(rebuilt, body);
+    }
+
+    /// The same, for arbitrary text.
+    #[test]
+    fn arbitrary_text_partitions_too(body in ".{0,400}") {
+        let blocks = divide(&body);
+        if blocks.is_empty() {
+            prop_assert!(body.trim().is_empty());
+            return Ok(());
+        }
+        let rebuilt: String = blocks.iter().map(|b| b.text()).collect();
+        prop_assert_eq!(rebuilt, body);
+    }
+
+    /// Content is the span with surrounding blank space removed, is never
+    /// empty, and never loses the indentation of its first line.
+    #[test]
+    fn content_is_the_span_without_surrounding_blank_space(body in body()) {
+        for block in divide(&body) {
+            let span = block.span();
+            let content = block.content_span();
+            prop_assert!(span.start <= content.start && content.end <= span.end);
+            prop_assert!(!block.content().is_empty());
+            prop_assert_eq!(block.content(), block.content().trim_end());
+            prop_assert!(body[span.start..content.start].trim().is_empty());
+            prop_assert!(body[content.end..span.end].trim().is_empty());
+        }
+    }
+
+    /// Division is a function of the text and nothing else, so identical text
+    /// appearing in two different documents divides identically. A body built
+    /// by concatenating fragments contains each fragment's own division.
+    #[test]
+    fn a_fenced_block_never_splits_however_it_is_surrounded(
+        prefix in body(),
+        inner in "[a-z \n]{0,60}",
+    ) {
+        let fence = format!("```\n{inner}\n```\n");
+        let combined = format!("{prefix}\n{fence}\n");
+        let last = divide(&combined)
+            .into_iter()
+            .rfind(|b| b.kind() == BlockKind::FencedCode);
+        prop_assert_eq!(last.map(|b| b.content().to_owned()), Some(fence.trim_end().to_owned()));
+    }
+}

--- a/crates/altaird/tests/body_identity.rs
+++ b/crates/altaird/tests/body_identity.rs
@@ -1,0 +1,567 @@
+//! The mutation suite: identity surviving rewording, reordering, insertion and
+//! deletion around a block.
+//!
+//! *"A block is recognisable as the same block after the text around it
+//! changes, and after edits to its own text."* — `docs/altair-substrate-spec.md`.
+//!
+//! Every test here mutates a body, reconciles the mutation against the blocks
+//! held before it, and asserts which identities came through. Identifiers are
+//! never inspected for meaning (DR-007); they are only ever compared for
+//! equality with one held from before the mutation.
+
+use std::cell::Cell;
+
+use altaird::body::{Origin, Reconciliation, StoredBlock, divide, reconcile, reconcile_with};
+use proptest::prelude::*;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/// The blocks an instance would hold after first accepting `body`.
+fn store(body: &str) -> Vec<StoredBlock> {
+    divide(body)
+        .iter()
+        .map(|block| StoredBlock {
+            id: Uuid::new_v4(),
+            text: block.text().to_owned(),
+        })
+        .collect()
+}
+
+/// The identity of the stored block whose content is `content`.
+fn id_of(stored: &[StoredBlock], content: &str) -> Uuid {
+    let mut found = stored
+        .iter()
+        .filter(|b| b.text.trim() == content)
+        .map(|b| b.id);
+    let id = found.next().unwrap_or_else(|| {
+        panic!(
+            "no stored block with content {content:?}; have {:?}",
+            stored.iter().map(|b| b.text.trim()).collect::<Vec<_>>()
+        )
+    });
+    assert!(found.next().is_none(), "content {content:?} is not unique");
+    id
+}
+
+/// The identity the reconciled body gave to the block whose content is
+/// `content`.
+fn resolved_id(outcome: &Reconciliation, content: &str) -> Uuid {
+    let mut found = outcome
+        .blocks
+        .iter()
+        .filter(|b| b.text.trim() == content)
+        .map(|b| b.id);
+    let id = found.next().unwrap_or_else(|| {
+        panic!(
+            "no resolved block with content {content:?}; have {:?}",
+            outcome
+                .blocks
+                .iter()
+                .map(|b| b.text.trim())
+                .collect::<Vec<_>>()
+        )
+    });
+    assert!(found.next().is_none(), "content {content:?} is not unique");
+    id
+}
+
+const LIST: &str = "- milk\n- eggs\n- bread\n";
+
+// ---------------------------------------------------------------------------
+// The four named mutations
+// ---------------------------------------------------------------------------
+
+/// **Rewording.** The named case in the spec: "rewording an entry does not
+/// detach a relation anchored to the entry itself".
+///
+/// This is also the test that rules out hashing the text as an identity.
+#[test]
+fn identity_survives_rewording_a_block() {
+    let stored = store(LIST);
+    let eggs = id_of(&stored, "- eggs");
+
+    let outcome = reconcile(&stored, "- milk\n- six eggs\n- bread\n");
+
+    assert_eq!(resolved_id(&outcome, "- six eggs"), eggs);
+    assert!(outcome.removed.is_empty());
+    let reworded = &outcome.blocks[1];
+    assert_eq!(reworded.origin, Origin::Carried);
+    assert!(reworded.text_changed);
+    assert!(!reworded.moved);
+}
+
+/// **Reordering.** This is the test that rules out position as an identity.
+#[test]
+fn identity_survives_reordering() {
+    let stored = store(LIST);
+    let (milk, eggs, bread) = (
+        id_of(&stored, "- milk"),
+        id_of(&stored, "- eggs"),
+        id_of(&stored, "- bread"),
+    );
+
+    let outcome = reconcile(&stored, "- bread\n- milk\n- eggs\n");
+
+    assert_eq!(
+        outcome.blocks.iter().map(|b| b.id).collect::<Vec<_>>(),
+        vec![bread, milk, eggs]
+    );
+    assert!(outcome.removed.is_empty());
+    assert!(outcome.blocks.iter().all(|b| b.origin == Origin::Carried));
+    assert!(
+        outcome.blocks.iter().all(|b| !b.text_changed),
+        "reordering changes no block's text"
+    );
+    assert!(outcome.blocks.iter().all(|b| b.moved));
+}
+
+/// **Insertion around a block.**
+#[test]
+fn identity_survives_insertion_around_a_block() {
+    let stored = store(LIST);
+    let (milk, eggs, bread) = (
+        id_of(&stored, "- milk"),
+        id_of(&stored, "- eggs"),
+        id_of(&stored, "- bread"),
+    );
+
+    let outcome = reconcile(
+        &stored,
+        "- flour\n- milk\n- eggs\n- salt\n- bread\n- yeast\n",
+    );
+
+    assert_eq!(resolved_id(&outcome, "- milk"), milk);
+    assert_eq!(resolved_id(&outcome, "- eggs"), eggs);
+    assert_eq!(resolved_id(&outcome, "- bread"), bread);
+    assert!(outcome.removed.is_empty());
+    assert_eq!(
+        outcome
+            .blocks
+            .iter()
+            .filter(|b| b.origin == Origin::Created)
+            .count(),
+        3
+    );
+}
+
+/// **Deletion around a block.**
+#[test]
+fn identity_survives_deletion_around_a_block() {
+    let stored = store(LIST);
+    let (milk, eggs, bread) = (
+        id_of(&stored, "- milk"),
+        id_of(&stored, "- eggs"),
+        id_of(&stored, "- bread"),
+    );
+
+    let outcome = reconcile(&stored, "- eggs\n");
+
+    assert_eq!(outcome.blocks.len(), 1);
+    assert_eq!(outcome.blocks[0].id, eggs);
+    assert_eq!(outcome.blocks[0].origin, Origin::Carried);
+    assert_eq!(outcome.removed, vec![milk, bread]);
+}
+
+/// The mutations together, which is what a real concurrent edit looks like:
+/// somebody reordered the list, reworded one entry, added one, and removed one.
+#[test]
+fn identity_survives_all_four_mutations_at_once() {
+    let stored = store("- milk\n- eggs\n- bread\n- butter\n");
+    let (milk, eggs, butter) = (
+        id_of(&stored, "- milk"),
+        id_of(&stored, "- eggs"),
+        id_of(&stored, "- butter"),
+    );
+    let bread = id_of(&stored, "- bread");
+
+    let outcome = reconcile(&stored, "- butter\n- half a dozen eggs\n- milk\n- tea\n");
+
+    assert_eq!(resolved_id(&outcome, "- butter"), butter);
+    assert_eq!(resolved_id(&outcome, "- half a dozen eggs"), eggs);
+    assert_eq!(resolved_id(&outcome, "- milk"), milk);
+    assert_eq!(outcome.removed, vec![bread]);
+    assert_eq!(
+        outcome
+            .blocks
+            .iter()
+            .filter(|b| b.origin == Origin::Created)
+            .count(),
+        1
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Where "this is now a different block" sits
+// ---------------------------------------------------------------------------
+
+/// A rewrite that keeps half the text keeps the identity.
+#[test]
+fn a_modest_rewrite_keeps_the_identity() {
+    let body = "The quarterly plan covers the garden and the shed.\n";
+    let stored = store(body);
+    let original = stored[0].id;
+
+    let outcome = reconcile(
+        &stored,
+        "The quarterly plan covers the garden and the greenhouse.\n",
+    );
+
+    assert_eq!(outcome.blocks[0].id, original);
+    assert_eq!(outcome.blocks[0].origin, Origin::Carried);
+    assert!(outcome.removed.is_empty());
+}
+
+/// A wholesale replacement is a new block, and the old one is reported removed
+/// so that a relation anchored to it can lose its anchor and survive.
+///
+/// This is the deliberate half of the threshold. Carrying an identity onto text
+/// nobody derived from the original would move somebody's relation onto words
+/// they did not write, silently.
+#[test]
+fn a_wholesale_replacement_is_a_new_block() {
+    let stored = store("The quarterly plan covers the garden and the shed.\n");
+    let original = stored[0].id;
+
+    let outcome = reconcile(&stored, "Reminder: the car needs its MOT before Friday.\n");
+
+    assert_eq!(outcome.blocks[0].origin, Origin::Created);
+    assert_ne!(outcome.blocks[0].id, original);
+    assert_eq!(outcome.removed, vec![original]);
+}
+
+/// The documented consequence of matching on text alone: a block replaced
+/// wholesale between two unchanged neighbours is still a new block, even though
+/// a person reading the diff would call it an edit.
+///
+/// This is pinned rather than fixed. Reading the neighbours would catch this
+/// case, and would also carry an identity onto text with nothing in common with
+/// the original — which is the error worth refusing, because it moves somebody's
+/// relation silently. Losing an anchor is loud by comparison: the relation is
+/// still there, unanchored.
+#[test]
+fn a_replacement_between_unchanged_neighbours_is_still_a_new_block() {
+    let stored =
+        store("First about the garden.\n\nSecond about the shed.\n\nThird about the car.\n");
+    let middle = stored[1].id;
+
+    let outcome = reconcile(
+        &stored,
+        "First about the garden.\n\nRing the vet on Tuesday.\n\nThird about the car.\n",
+    );
+
+    assert_eq!(outcome.blocks[1].origin, Origin::Created);
+    assert_eq!(outcome.removed, vec![middle]);
+}
+
+/// The length floor: overlap alone would let a short entry match any long block
+/// that starts and ends the way it does.
+#[test]
+fn a_short_entry_does_not_match_a_far_longer_block() {
+    let stored = store("- tea\n");
+    let original = stored[0].id;
+
+    let outcome = reconcile(
+        &stored,
+        "- tea leaves, coffee beans, oat milk, two loaves, a dozen eggs and some tea\n",
+    );
+
+    assert_eq!(outcome.blocks[0].origin, Origin::Created);
+    assert_eq!(outcome.removed, vec![original]);
+}
+
+/// Emptying a body removes every block. Nothing is carried onto nothing.
+#[test]
+fn emptying_the_body_removes_every_block() {
+    let stored = store(LIST);
+    let outcome = reconcile(&stored, "");
+    assert!(outcome.blocks.is_empty());
+    assert_eq!(outcome.removed.len(), 3);
+}
+
+/// The first write to an entity has nothing to match against.
+#[test]
+fn a_first_body_creates_every_block() {
+    let outcome = reconcile(&[], LIST);
+    assert_eq!(outcome.blocks.len(), 3);
+    assert!(outcome.blocks.iter().all(|b| b.origin == Origin::Created));
+    assert!(outcome.blocks.iter().all(|b| b.text_changed));
+    assert!(outcome.removed.is_empty());
+}
+
+/// "A list item is a block **while the list holds together around it**." When
+/// the list stops holding together — the markers go and the entries become
+/// paragraphs — the entries are still the same entries, and similarity carries
+/// them across. Nothing special-cases the transition; it falls out of matching
+/// on text.
+#[test]
+fn identity_survives_the_list_ceasing_to_be_a_list() {
+    let stored = store("- collect the parcel\n- book the service\n");
+    let (parcel, service) = (
+        id_of(&stored, "- collect the parcel"),
+        id_of(&stored, "- book the service"),
+    );
+
+    let outcome = reconcile(&stored, "collect the parcel\n\nbook the service\n");
+
+    assert_eq!(resolved_id(&outcome, "collect the parcel"), parcel);
+    assert_eq!(resolved_id(&outcome, "book the service"), service);
+    assert!(outcome.removed.is_empty());
+}
+
+/// Two identical entries are not one entry. Each keeps a distinct identity, and
+/// the nearer one wins so an edit does not shuffle relations between them.
+#[test]
+fn duplicate_entries_keep_distinct_identities_and_match_the_nearer_one() {
+    let stored = store("- milk\n- eggs\n- milk\n");
+    let first = stored[0].id;
+    let last = stored[2].id;
+    assert_ne!(first, last);
+
+    let outcome = reconcile(&stored, "- milk\n- eggs\n- milk\n- bread\n");
+
+    assert_eq!(outcome.blocks[0].id, first);
+    assert_eq!(outcome.blocks[2].id, last);
+    assert!(outcome.removed.is_empty());
+}
+
+/// Editing one paragraph leaves every other paragraph's identity alone, which
+/// is the whole reason division exists: "a relation formed in one paragraph is
+/// undisturbed when someone rewrites another".
+#[test]
+fn rewriting_one_paragraph_disturbs_no_other() {
+    let body = "First paragraph about the garden.\n\nSecond paragraph about the shed.\n\nThird paragraph about the car.\n";
+    let stored = store(body);
+    let first = stored[0].id;
+    let third = stored[2].id;
+
+    let outcome = reconcile(
+        &stored,
+        "First paragraph about the garden.\n\nA completely unrelated statement regarding taxes.\n\nThird paragraph about the car.\n",
+    );
+
+    assert_eq!(outcome.blocks[0].id, first);
+    assert!(!outcome.blocks[0].text_changed);
+    assert_eq!(outcome.blocks[2].id, third);
+    assert!(!outcome.blocks[2].text_changed);
+}
+
+/// Adding a blank line under a paragraph is not an edit to that paragraph's
+/// content. The block's stored text changes, because the body changed and the
+/// body has to reassemble byte for byte; its identity and its content do not.
+#[test]
+fn surrounding_blank_lines_do_not_reword_a_block() {
+    let stored = store("one\n\ntwo\n");
+    let (first, second) = (stored[0].id, stored[1].id);
+
+    let outcome = reconcile(&stored, "one\n\n\n\ntwo\n");
+
+    assert_eq!(outcome.blocks[0].id, first);
+    assert_eq!(outcome.blocks[1].id, second);
+    assert!(outcome.removed.is_empty());
+}
+
+/// An atomic construct is matched as one thing, so editing a line inside a
+/// fenced block keeps the whole block's identity rather than producing a new
+/// one for the edited region.
+#[test]
+fn editing_inside_a_fence_keeps_the_fence_block() {
+    let stored = store("```rust\nfn main() {\n    println!(\"one\");\n}\n```\n");
+    let original = stored[0].id;
+
+    let outcome = reconcile(
+        &stored,
+        "```rust\nfn main() {\n    println!(\"two\");\n}\n```\n",
+    );
+
+    assert_eq!(outcome.blocks.len(), 1);
+    assert_eq!(outcome.blocks[0].id, original);
+    assert!(outcome.blocks[0].text_changed);
+}
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+/// Matching is deterministic given the same inputs. New identifiers are random
+/// by DR-007, so the source of them is supplied here; everything else about the
+/// outcome must be identical run to run.
+#[test]
+fn matching_the_same_pair_twice_gives_the_same_answer() {
+    let stored = store("- milk\n- eggs\n- bread\n- butter\n");
+    let body = "- butter\n- half a dozen eggs\n- milk\n- tea\n";
+
+    let run = || {
+        let counter = Cell::new(0u128);
+        reconcile_with(&stored, body, || {
+            counter.set(counter.get() + 1);
+            Uuid::from_u128(counter.get())
+        })
+    };
+
+    let first = run();
+    let second = run();
+    assert_eq!(
+        first.blocks.iter().map(|b| b.id).collect::<Vec<_>>(),
+        second.blocks.iter().map(|b| b.id).collect::<Vec<_>>()
+    );
+    assert_eq!(first.removed, second.removed);
+}
+
+// ---------------------------------------------------------------------------
+// Properties over the mutations
+// ---------------------------------------------------------------------------
+
+/// Distinct one-line paragraphs, so that a body's blocks are unambiguous and a
+/// mutation can be aimed at exactly one of them.
+fn entries() -> impl Strategy<Value = Vec<String>> {
+    prop::collection::vec(0usize..1000, 2..8).prop_map(|numbers| {
+        let mut seen = Vec::new();
+        for n in numbers {
+            if !seen.contains(&n) {
+                seen.push(n);
+            }
+        }
+        seen.into_iter()
+            .map(|n| format!("entry number {n} of this note"))
+            .collect()
+    })
+}
+
+fn assemble(entries: &[String]) -> String {
+    entries
+        .iter()
+        .map(|e| format!("{e}\n\n"))
+        .collect::<String>()
+}
+
+proptest! {
+    /// Inserting a block anywhere leaves every existing identity in place and
+    /// removes nothing.
+    #[test]
+    fn insertion_anywhere_preserves_every_identity(
+        entries in entries(),
+        at in 0usize..16,
+    ) {
+        let stored = store(&assemble(&entries));
+        let before: Vec<Uuid> = stored.iter().map(|b| b.id).collect();
+
+        let mut mutated = entries.clone();
+        mutated.insert(at % (entries.len() + 1), "a newly inserted line".to_owned());
+        let outcome = reconcile(&stored, &assemble(&mutated));
+
+        let after: Vec<Uuid> = outcome.blocks.iter().map(|b| b.id).collect();
+        prop_assert!(outcome.removed.is_empty());
+        prop_assert!(before.iter().all(|id| after.contains(id)));
+        prop_assert_eq!(after.len(), before.len() + 1);
+    }
+
+    /// Deleting one block leaves every other identity in place, and reports
+    /// exactly the deleted one as removed.
+    #[test]
+    fn deletion_preserves_every_surviving_identity(
+        entries in entries(),
+        at in 0usize..16,
+    ) {
+        let stored = store(&assemble(&entries));
+        let index = at % entries.len();
+        let removed_id = stored[index].id;
+
+        let mut mutated = entries.clone();
+        mutated.remove(index);
+        let outcome = reconcile(&stored, &assemble(&mutated));
+
+        prop_assert_eq!(&outcome.removed, &vec![removed_id]);
+        for (position, block) in outcome.blocks.iter().enumerate() {
+            let expected = if position < index { position } else { position + 1 };
+            prop_assert_eq!(block.id, stored[expected].id);
+            prop_assert_eq!(block.origin, Origin::Carried);
+        }
+    }
+
+    /// Reordering carries every identity with its text, wherever it went.
+    #[test]
+    fn reordering_carries_every_identity_with_its_text(
+        entries in entries(),
+        rotate in 1usize..8,
+    ) {
+        let stored = store(&assemble(&entries));
+        let shift = rotate % entries.len().max(1);
+
+        let mut mutated = entries.clone();
+        mutated.rotate_left(shift);
+        let outcome = reconcile(&stored, &assemble(&mutated));
+
+        prop_assert!(outcome.removed.is_empty());
+        for (position, block) in outcome.blocks.iter().enumerate() {
+            let origin = (position + shift) % entries.len();
+            prop_assert_eq!(block.id, stored[origin].id, "block {} came from {}", position, origin);
+            prop_assert!(!block.text_changed);
+        }
+    }
+
+    /// Rewording one block keeps that block's identity and disturbs no other.
+    /// The edit here appends to an entry, which is the shape of a real one: a
+    /// person adds a word rather than replacing the line.
+    #[test]
+    fn rewording_one_block_disturbs_no_other(
+        entries in entries(),
+        at in 0usize..16,
+    ) {
+        let stored = store(&assemble(&entries));
+        let index = at % entries.len();
+
+        let mut mutated = entries.clone();
+        mutated[index] = format!("{} and one more clause", entries[index]);
+        let outcome = reconcile(&stored, &assemble(&mutated));
+
+        prop_assert!(outcome.removed.is_empty());
+        for (position, block) in outcome.blocks.iter().enumerate() {
+            prop_assert_eq!(block.id, stored[position].id);
+            prop_assert_eq!(block.origin, Origin::Carried);
+            prop_assert_eq!(block.text_changed, position == index);
+        }
+    }
+
+    /// A body written again unchanged carries every identity, changes nothing,
+    /// and moves nothing. Reconciliation must be idempotent or a replayed
+    /// intent would churn the store.
+    #[test]
+    fn rewriting_an_unchanged_body_changes_nothing(entries in entries()) {
+        let body = assemble(&entries);
+        let stored = store(&body);
+        let outcome = reconcile(&stored, &body);
+
+        prop_assert!(outcome.removed.is_empty());
+        for (position, block) in outcome.blocks.iter().enumerate() {
+            prop_assert_eq!(block.id, stored[position].id);
+            prop_assert!(!block.text_changed);
+            prop_assert!(!block.moved);
+        }
+    }
+
+    /// Every incoming block gets exactly one identity, positions are dense and
+    /// in order, no identity is used twice, and no identity is both carried and
+    /// reported removed.
+    #[test]
+    fn every_block_gets_exactly_one_identity(entries in entries(), extra in entries()) {
+        let stored = store(&assemble(&entries));
+        let outcome = reconcile(&stored, &assemble(&extra));
+
+        let mut ids: Vec<Uuid> = outcome.blocks.iter().map(|b| b.id).collect();
+        let count = ids.len();
+        ids.sort();
+        ids.dedup();
+        prop_assert_eq!(ids.len(), count, "an identity was used twice");
+
+        for (position, block) in outcome.blocks.iter().enumerate() {
+            prop_assert_eq!(block.position, position);
+            prop_assert!(!outcome.removed.contains(&block.id));
+        }
+
+        let carried = outcome.blocks.iter().filter(|b| b.origin == Origin::Carried).count();
+        prop_assert_eq!(carried + outcome.removed.len(), stored.len());
+    }
+}


### PR DESCRIPTION
Wave 1, lane 1.2 — a pure function over text, plus the matching step that carries identity forward.

## Why determinism is the product, not a property

The substrate is blunt about the stakes:

> **The division is structural, and derived from the text alone.** Every device computes the same blocks from the same content, or two clients disagree about the units and reconciliation is incoherent.

So anything that could vary between runs — hash iteration order, locale, a clock, floating point — is a defect rather than a smell. That constraint drove most of the decisions below.

**Parser: `pulldown-cmark 0.13.4`, `default-features = false`.** Chosen over `comrak` because `into_offset_iter()` reports a **byte range** for every construct, which is what makes an exact byte partition possible at all — comrak's AST carries line/column positions, so reassembly would have to re-derive offsets. The extension set is fixed in code (`ENABLE_TABLES | ENABLE_FOOTNOTES | ENABLE_TASKLISTS`) and documented as **load-bearing state, not a knob**: changing it re-divides every already-stored body, so it is a migration.

## The division rules, each traced to a sentence

| Rule | From |
|---|---|
| Only the text is read — no clock, locale, environment, randomness, floating point | *"derived from the text alone"* |
| Every top-level construct is one whole block; the walk descends into **lists only**, so atomicity holds by construction rather than by a rule applied afterwards | *"Some constructs are atomic and never split, whatever blank lines they contain and however large they are"* |
| Each list item is a block, **at any depth** | *"A list item is a block while the list holds together around it"* |
| A paragraph is one block however long | *"Accepted limitation: a long unbroken stretch of prose is one block"* |
| Spans partition the body exactly; block text is the verbatim slice; concatenation reproduces the body byte-for-byte | *"a body is its blocks in order"* + DR-001's export guarantee |

**A list that stops holding together** (markers removed, entries become paragraphs) is not special-cased — it re-divides as paragraphs and identity carries across by similarity. Pinned by `identity_survives_the_list_ceasing_to_be_a_list`.

## Identity matching

Three passes; a claimed block takes no further part.

1. **Exact content, nearest position.** `BTreeMap`, not `HashMap` — no hash-seed dependence. **This pass alone covers insertion, deletion and reordering**, which is why it is first and unconditional.
2. **Similarity**, greedy best-first, sort key all integers.
3. **Remainder is new** (fresh UUIDv4, DR-007); unclaimed stored blocks are reported in `removed`.

**Metric: trigram overlap coefficient `|A∩B| / min(|A|,|B|)`, threshold ≥ 1/2, plus a length-ratio floor of 1/4.** Character trigrams, padded both ends so two texts must begin *and* end alike. Scores compared as exact integer ratios in `u128` — **no floating point anywhere**.

**Why overlap rather than the conventional Sørensen–Dice**, which is the one real divergence from the obvious choice: Dice divides by *combined* size, so it collapses when one side grows. `- eggs` → `- half a dozen eggs` scores **0.48** under Dice — a new block, anchors lost, for the commonest edit there is. Overlap ignores the excess and the length floor bounds how much excess is credible. Below ratio 1/4 Dice cannot exceed 0.4, so the floor never rejects a pair Dice would have accepted: this is a strict relaxation, not a different trade. There is a unit test carrying that reasoning.

**Where "this is now a different block" sits** is settled by which error is worse, not by tuning. A refused match costs an anchor, and the substrate already describes a relation surviving without its anchor as an ordinary outcome. An accepted match that should not have held moves somebody's relation onto text they did not write, and tells nobody. **So ambiguity resolves to "new block."**

A "gap anchoring" fourth pass was built and then **rejected** — it would catch a wholesale replacement between two unchanged neighbours, but it carries identity onto text with nothing in common with the original. Pinned by `a_replacement_between_unchanged_neighbours_is_still_a_new_block`.

## Verification

Rebased onto `a7033c1`. Run by the orchestrator:

```
$ cargo test --workspace
  tests/body_division.rs  22 passed    tests/body_identity.rs  23 passed
  unittests (altaird)      6 passed    tests/store.rs           2 passed
$ cargo clippy --workspace --all-targets --all-features -- -D warnings   # clean
$ cargo fmt --all --check                                                # clean
```

**Cross-process determinism, verified independently rather than accepted.** I built a throwaway probe against the public API and ran it over this repo's own corpus — 22 files, 2,745 blocks — under a deliberately hostile locale:

```
$ ./det_probe docs/*.md conformance/scenarios.md CLAUDE.md proto/…/altair.proto | sha256sum
886593f08af5318135c9b2ed1b0c360bea9a0ce6400caeab7a80eff4a0ab1965  -

$ LC_ALL=tr_TR.UTF-8 TZ=Pacific/Kiritimati ./det_probe … | sha256sum
886593f08af5318135c9b2ed1b0c360bea9a0ce6400caeab7a80eff4a0ab1965  -
```

Turkish specifically, because that is where case folding differs — the algorithm does no folding, and this demonstrates it. The same probe asserted `concat(blocks) == body` on every file and did not fire. Probe removed; not committed (a test reading `docs/` would couple the suite to prose).

The mutation suite covers each named mutation as **both** an example test and a property over generated bodies:

| Mutation | Example | Property |
|---|---|---|
| Rewording | `identity_survives_rewording_a_block` | `rewording_one_block_disturbs_no_other` |
| Reordering | `identity_survives_reordering` | `reordering_carries_every_identity_with_its_text` |
| Insertion around a block | `identity_survives_insertion_around_a_block` | `insertion_anywhere_preserves_every_identity` |
| Deletion around a block | `identity_survives_deletion_around_a_block` | `deletion_preserves_every_surviving_identity` |
| All four at once | `identity_survives_all_four_mutations_at_once` | — |

Plus atomicity (`a_mermaid_diagram_is_one_block`, `a_table_is_one_block`, `a_fenced_code_block_is_one_block_however_many_blank_lines_it_holds`), the pinned limitation (`a_long_unbroken_stretch_of_prose_is_one_block`), and a golden fixture that fails loudly if any boundary rule changes.

## ⚠️ One boundary rule is not traceable to the spec

The substrate says a list item is a block. It does **not** say what happens to content that resumes *inside an item after a nested list*. This lane made it a further block (`ListItemTail`), reasoning that it has no block it could join without reaching backwards past entries that are not its own.

This is the one rule with no sentence behind it. If the substrate is ever amended here, that is the line to amend.

## For Wave 2

- **Store the verbatim span, not a trimmed form.** Only the span makes `flatten(blocks) == body` byte-exact, which `entity_version` holding "the body flattened rather than its blocks" and DR-001's export guarantee both rest on. Storing the trimmed form silently normalises blank lines and tight/loose list structure on every write.
- **`ResolvedBlock` carries `text_changed` and `moved` separately — do not collapse them.** A reorder changes the body without changing any block's text, and DR-004's change set carries "the identities of the blocks that changed".
- **`Reconciliation.removed` is the trigger for anchor loss**, and it surfaces something worth a 2.1 test: the schema comment at `0001_initial.sql:485` notes that a relation losing its anchor may then collide with an existing unanchored relation between the same pair. That collision is reachable from **ordinary body edits**, not only from explicit relation deletion.
- **`block_position_unique` is `DEFERRABLE INITIALLY DEFERRED` and needs to be** — reconcile returns dense positions and reordering routinely passes through states that violate uniqueness. Do not "tidy" it.
- Reconciliation is idempotent, so a replayed intent does not churn block rows.

## Known limitations, stated

- Short similar entries cross-match: `- eggs` / `- legs` score exactly at threshold. Positional tiebreak reduces it; it does not remove it.
- A block split in two matches at most one half; two merged carries whichever the merged text resembles more. There is no concept of one block becoming two.
- Structure is not consulted — a wholesale replacement between unchanged neighbours is a new block, by choice (above).
- `MAX_SIMILARITY_PAIRS = 250_000` skips pass 2 on absurd bodies. Still deterministic — the bound is a count, not a clock. `[unverified]` — no test exercises it.
- No benchmark. The largest document here (~400 blocks) runs the full suite in 50 ms; the pathological case was not measured.