### PR TITLE
Wave 1.5: the outbox conformance scenarios, executable and red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,36 @@ jobs:
       - run: docker compose up -d --wait
       - run: cargo test --workspace
 
+  # The outbox conformance scenarios, which are SUPPOSED to fail.
+  #
+  # `conformance/scenarios.md` specifies an outbox that Wave 4.1 writes; Wave
+  # 1.5 wrote the suite that judges it. Until the outbox exists every scenario
+  # runs against a stub client and fails, and that red is the deliverable. It is
+  # `continue-on-error` so it never blocks a merge, and it is here rather than
+  # nowhere so the red stays visible on every pull request and the count is
+  # watched as it comes down. Do not "fix" it by deleting it — see
+  # crates/altair-conformance/README.md.
+  conformance:
+    name: conformance (red until Wave 4.1)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      # See the note in the test job.
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/mise
+            ~/.rustup
+          key: toolchain-${{ runner.os }}-${{ hashFiles('mise.toml') }}
+      - uses: jdx/mise-action@v2
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+      # No database, no Authentik, no real instance: the suite stands up its own
+      # fake instance on a local port and needs nothing else.
+      - run: mise run conformance
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "altair-conformance"
+version = "0.0.0"
+dependencies = [
+ "altair-proto",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "uuid",
+]
+
+[[package]]
 name = "altair-proto"
 version = "0.0.0"
 dependencies = [

--- a/crates/altair-conformance/Cargo.toml
+++ b/crates/altair-conformance/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "altair-conformance"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[features]
+# The scenarios are gated off by default; the crate's own tests are not.
+#
+# `conformance/scenarios.md` specifies an outbox that Wave 4.1 writes. Until it
+# exists every scenario fails, and that red is the deliverable of Wave 1.5. A
+# red suite inside the default `cargo test --workspace` would make `main`
+# unmergeable, so the scenarios sit behind this feature and are run on purpose:
+# `mise run conformance`.
+run-conformance = []
+
+[dependencies]
+altair-proto = { path = "../altair-proto" }
+prost = "0.14.4"
+prost-types = "0.14.4"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
+tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "net", "io-util", "time", "sync"] }
+tokio-stream = { version = "0.1.18", features = ["net"] }
+tonic = "0.14.6"
+uuid = { version = "1.24.1", features = ["v4"] }

--- a/crates/altair-conformance/README.md
+++ b/crates/altair-conformance/README.md
@@ -1,0 +1,46 @@
+# altair-conformance
+
+The outbox conformance suite: `conformance/scenarios.md`, made executable.
+
+## This suite is expected to fail. Do not delete it, and do not "fix" it
+
+The outbox does not exist yet. Wave 4.1 writes it. Wave 1.5 wrote the scenarios that judge it, because DR-006's obligation is that they exist before the *second* implementation — and they may as well exist before the first.
+
+Every scenario runs against a stub client, `altair-null-client`, which implements nothing. Each one drives that process through its steps and then fails on the behaviour it is about. **A red suite is the deliverable.** As Wave 4.1 lands behaviour, scenarios turn green one at a time, and that gradient is the whole value. Anything that makes a scenario pass without an outbox behind it destroys it.
+
+## Running it
+
+The scenarios sit behind the `run-conformance` feature, off by default, so `cargo test --workspace` stays green and `main` stays mergeable. The red is one command away and is meant to be looked at:
+
+```bash
+mise run conformance
+```
+
+CI runs the same thing in a job named `conformance (red until Wave 4.1)`, marked `continue-on-error`, so the red is visible on every pull request without blocking a merge.
+
+What runs in the *default* suite, and is expected to be green:
+
+- `tests/coverage.rs` — every scenario in the document has exactly one test, every test names a real scenario, and each test is named for its id.
+- `tests/harness.rs` — the fake instance's behaviours, the process channel, and the difference between a skip and a pass.
+
+If `tests/harness.rs` goes red, the harness is broken. If `tests/scenarios.rs` goes red, that is the expected state until Wave 4.1.
+
+## What Wave 4.1 changes
+
+One function, in `tests/scenarios.rs`:
+
+```rust
+fn client_under_test() -> Arc<dyn ClientUnderTest> {
+    Arc::new(NullClient::at(env!("CARGO_BIN_EXE_altair-null-client")))
+}
+```
+
+Point it at an adapter over the terminal client's outbox and the suite starts judging the real thing. The adapter is a process that speaks one newline-delimited JSON channel — an `Action` in on stdin, a `Reply` out on stdout — and it is a separate operating system process because sections B and F kill it without warning.
+
+## Two boundaries, and nothing else
+
+`conformance/scenarios.md` observes what the person sees and what reaches the instance, and says in as many words that what the outbox holds internally, how it stores it, and what it is called are not conformance concerns. Nothing in this crate reads the client's storage or its queue. If a scenario appears to need that, the boundary has been modelled wrong.
+
+## The Kotlin mirror
+
+DR-006 says the outbox is implemented twice and the scenarios are written once. The harness, therefore, is implemented twice as well, and the second time it should be transcription rather than reinterpretation. That is why the fake instance's control surface is one flat enum and two entry points, why the client channel is line-delimited JSON, and why there is no builder and no generic anywhere a transcriber would have to interpret one.

--- a/crates/altair-conformance/README.md
+++ b/crates/altair-conformance/README.md
@@ -18,6 +18,8 @@ mise run conformance
 
 CI runs the same thing in a job named `conformance (red until Wave 4.1)`, marked `continue-on-error`, so the red is visible on every pull request without blocking a merge.
 
+libtest has no third verdict, so a scenario a client legitimately skips — the substrate puts everything above the capture floor at the client's discretion — would otherwise be reported `ok` next to one that passed. The task prints a ledger at the end saying which each was, and anything absent from it failed.
+
 What runs in the *default* suite, and is expected to be green:
 
 - `tests/coverage.rs` — every scenario in the document has exactly one test, every test names a real scenario, and each test is named for its id.

--- a/crates/altair-conformance/src/bin/altair-null-client.rs
+++ b/crates/altair-conformance/src/bin/altair-null-client.rs
@@ -1,0 +1,57 @@
+//! A client under test that implements nothing.
+//!
+//! It reads actions and answers, truthfully, that nothing happened: no capture
+//! is accepted, no entity is present, nothing is shown to the person. It never
+//! opens a connection to the instance and never writes to its state directory.
+//!
+//! That is the Wave 1 deliverable. Every scenario in `conformance/scenarios.md`
+//! drives this process through its steps and fails on the step that asks for
+//! outbox behaviour. Wave 4.1 replaces it, one behaviour at a time, and the
+//! suite goes green in the same order.
+
+use std::io::{BufRead, Write};
+
+use altair_conformance::client::{Action, Reply};
+
+fn main() {
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { return };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let reply = match serde_json::from_str::<Action>(&line) {
+            Ok(action) => answer(&action),
+            Err(error) => Reply::Error {
+                message: format!("unreadable action: {error}"),
+            },
+        };
+        let Ok(encoded) = serde_json::to_string(&reply) else {
+            return;
+        };
+        if writeln!(stdout, "{encoded}").is_err() || stdout.flush().is_err() {
+            return;
+        }
+    }
+}
+
+fn answer(action: &Action) -> Reply {
+    match action {
+        // Nothing is captured, so nothing is accepted and nothing is refused
+        // either: the person is simply shown nothing.
+        Action::Capture { .. } | Action::Edit { .. } | Action::Bind { .. } => Reply::Nothing,
+        Action::Open { label } => Reply::Entity {
+            label: label.clone(),
+            present: false,
+            entity_id: Vec::new(),
+            title: None,
+            body: None,
+            bytes: None,
+        },
+        Action::Showing => Reply::Showing {
+            signals: Vec::new(),
+        },
+        Action::DrainEvents => Reply::Events { events: Vec::new() },
+    }
+}

--- a/crates/altair-conformance/src/client.rs
+++ b/crates/altair-conformance/src/client.rs
@@ -1,0 +1,258 @@
+//! The client under test, as the harness is allowed to see it.
+//!
+//! `conformance/scenarios.md` observes two boundaries and no others: what the
+//! person sees, and what reaches the instance. This module is the first of
+//! them. Nothing here reaches into the client's storage, its queue, or its
+//! internals — every type below names something a person could point at.
+//!
+//! Wave 4.1 supplies the real implementation of [`ClientUnderTest`]. In Wave 1
+//! the only implementor is [`crate::null::NullClient`], which does nothing,
+//! which is why every scenario fails.
+//!
+//! # The shape, and why it is this shape
+//!
+//! A client under test is a **separate operating system process**. It has to
+//! be: sections B and F kill it without warning, and a `Drop` impl or a
+//! cooperative shutdown would not test what those scenarios test.
+//!
+//! The harness drives that process over one newline delimited JSON channel:
+//! an [`Action`] in on stdin, a [`Reply`] out on stdout, one line each, in
+//! lockstep. That is deliberately the most boring protocol available, because
+//! DR-006 requires this harness to exist a second time in Kotlin and a
+//! transcription must not become a reinterpretation.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// What a client offers above the capture floor.
+///
+/// The substrate puts the floor at creation and makes everything above it a
+/// platform decision, so scenarios that edit, or that capture files, or that
+/// capture before binding, apply only where the client offers those. A client
+/// that declines them is conforming and skips them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Offers {
+    /// A5's floor is always offered; this names A3's case: capture before the
+    /// device has ever been bound to a household.
+    pub unbound_capture: bool,
+    /// Editing an entity while the instance is unreachable. Sections C, E and
+    /// G lean on it.
+    pub offline_edit: bool,
+    /// Capturing a file, meaning bytes that travel through `PutBody`.
+    pub file_capture: bool,
+}
+
+impl Offers {
+    /// Everything above the floor. What the Wave 4.1 terminal client is
+    /// expected to offer.
+    #[must_use]
+    pub const fn everything() -> Self {
+        Self {
+            unbound_capture: true,
+            offline_edit: true,
+            file_capture: true,
+        }
+    }
+
+    /// The floor and nothing else. A conforming client, with more skips.
+    #[must_use]
+    pub const fn capture_only() -> Self {
+        Self {
+            unbound_capture: false,
+            offline_edit: false,
+            file_capture: false,
+        }
+    }
+}
+
+/// Everything a launched client is told about the world.
+///
+/// Two directories, and the difference between them is load bearing. B1 kills
+/// a process; B2 restarts a device. A device restart additionally loses
+/// everything ephemeral, so the harness models it by wiping `runtime_dir` and
+/// keeping `state_dir`. A client that keeps durable state in `runtime_dir`
+/// passes B1 and fails B2, which is the distinction B2 exists to draw.
+#[derive(Debug, Clone)]
+pub struct ClientEnvironment {
+    /// Where the fake instance answers, as a URL.
+    pub instance_url: String,
+    /// Durable storage. Survives a process kill and a device restart.
+    pub state_dir: PathBuf,
+    /// Ephemeral storage. Survives a process kill; wiped by a device restart.
+    pub runtime_dir: PathBuf,
+    /// The token the client should present. Opaque; the fake instance never
+    /// verifies a signature, it only records what it was handed.
+    pub token: String,
+}
+
+/// A harness chosen name for one thing the person captured.
+///
+/// The person's own way of returning to something is not a UUID, and the
+/// harness needs one anyway, so the client under test is asked to remember the
+/// label it was given alongside the capture. That is an obligation of the
+/// adapter the client exposes for testing, not of the product.
+pub type Label = String;
+
+/// What the person captures.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CaptureContent {
+    /// A5: an identity, a type, and a timestamp, and nothing else.
+    Bare,
+    /// A note. `title` doubles as the correlation handle at the instance
+    /// boundary, because a title is a thing that crosses the wire.
+    Note { title: String, body: String },
+    /// A file, meaning bytes that must reach `PutBody` before the intent that
+    /// names them.
+    File { media_type: String, bytes: Vec<u8> },
+}
+
+/// Something the harness asks the person's surface to do, or to show.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum Action {
+    /// The person captures.
+    Capture {
+        label: Label,
+        content: CaptureContent,
+    },
+    /// The person edits something they captured, giving it a new title.
+    Edit { label: Label, title: String },
+    /// The device is bound to a household as this member. A3's second half.
+    Bind { member_id: Vec<u8> },
+    /// The person returns to something they captured. Answers what they see.
+    Open { label: Label },
+    /// Everything the client is currently showing the person and has not
+    /// withdrawn. Section F is almost entirely assertions over this.
+    Showing,
+    /// Person facing events since the last drain. F9 needs to know that a
+    /// standing fault did not repeat, which the standing surface cannot say.
+    DrainEvents,
+}
+
+/// One thing the client is currently showing the person.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Signal {
+    pub kind: SignalKind,
+    /// Whatever the platform's surface puts in front of the person. A terminal
+    /// and an Android client word it differently and both conform; showing
+    /// nothing is what is not permitted.
+    pub text: String,
+    /// A number the signal states. F7 permits exactly one number here — how
+    /// many the instance refused — and forbids every other.
+    pub quantity: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SignalKind {
+    /// A condition that will not clear by the ordinary path continuing to run.
+    Fault,
+    /// Anything else the client puts in front of the person. Section F mostly
+    /// asserts that this list is empty.
+    Other,
+}
+
+/// A person facing event, as distinct from a standing signal.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum Event {
+    SignalRaised { text: String },
+    SignalCleared { text: String },
+}
+
+/// What the client answers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "reply", rename_all = "snake_case")]
+pub enum Reply {
+    /// The capture is theirs. Nothing about the network or credentials
+    /// participated in this, and it is durable already.
+    Accepted { label: Label },
+    /// The client would not take it, and says why, at the moment of the
+    /// attempt. A4 and F5.
+    Refused { condition: String },
+    /// The action produced nothing the person can see.
+    Nothing,
+    /// What the person sees when they return to something.
+    Entity {
+        label: Label,
+        present: bool,
+        /// The entity's public identity. Not internal state: identity is
+        /// client assigned, crosses the wire, and G3 is about it changing.
+        #[serde(default)]
+        entity_id: Vec<u8>,
+        #[serde(default)]
+        title: Option<String>,
+        #[serde(default)]
+        body: Option<String>,
+        #[serde(default)]
+        bytes: Option<Vec<u8>>,
+    },
+    /// Answer to [`Action::Showing`].
+    Showing { signals: Vec<Signal> },
+    /// Answer to [`Action::DrainEvents`].
+    Events { events: Vec<Event> },
+    /// The adapter itself broke. Never a conforming answer to anything.
+    Error { message: String },
+}
+
+/// Something went wrong reaching the client, as opposed to the client
+/// answering badly. Always a harness fault, never a conformance verdict.
+#[derive(Debug)]
+pub enum ClientError {
+    /// The client did not answer within the harness's patience.
+    Silent,
+    /// The process is gone.
+    Gone,
+    /// The channel carried something that is not a [`Reply`].
+    Unreadable(String),
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Silent => write!(f, "the client under test did not answer in time"),
+            Self::Gone => write!(f, "the client under test is not running"),
+            Self::Unreadable(s) => {
+                write!(f, "the client under test said something unreadable: {s}")
+            }
+            Self::Io(e) => write!(f, "i/o with the client under test: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ClientError {}
+
+/// How the harness starts a client. Implemented once per client, and swapped
+/// in one place — `client_under_test()` in `tests/scenarios.rs`.
+pub trait ClientUnderTest: Send + Sync {
+    /// A name for this client in test output.
+    fn name(&self) -> &str;
+
+    /// What this client offers above the capture floor. Scenarios that need
+    /// something it does not offer are skipped, not failed.
+    fn offers(&self) -> Offers;
+
+    /// Start the client as its own operating system process.
+    ///
+    /// Called more than once per scenario with the same [`ClientEnvironment`]:
+    /// that is what a restart is.
+    fn launch(
+        &self,
+        environment: &ClientEnvironment,
+    ) -> Result<Box<dyn ClientProcess>, ClientError>;
+}
+
+/// A running client under test.
+pub trait ClientProcess: Send {
+    /// Do one thing at the person's surface and read the one answer. Blocks
+    /// until the client answers or the harness runs out of patience, which is
+    /// itself observable: E1 times this.
+    fn act(&mut self, action: &Action) -> Result<Reply, ClientError>;
+
+    /// Kill the process without warning. `SIGKILL`, no cleanup, no chance to
+    /// flush. Idempotent.
+    fn kill(&mut self);
+}

--- a/crates/altair-conformance/src/instance.rs
+++ b/crates/altair-conformance/src/instance.rs
@@ -1,0 +1,740 @@
+//! The fake instance: the second of the two observed boundaries.
+//!
+//! It is not the real instance and must never become one. It exists to be
+//! driven — to accept, refuse, stall, and drop connections on command — and to
+//! record what arrived, in what order, carrying what identities.
+//!
+//! # The control surface, in full
+//!
+//! One setter and one getter, which is the whole point:
+//!
+//! - [`FakeInstance::set_behaviour`] takes one [`Behaviour`], a flat enum. The
+//!   instance answers every subsequent call according to it.
+//! - [`FakeInstance::log`] returns everything that has arrived.
+//!
+//! Everything else on the type is a convenience over those two. A Kotlin
+//! transcription is the same enum, the same two entry points, a gRPC server,
+//! and the same byte copying proxy; there is deliberately no builder, no
+//! generic, and no callback for a transcriber to have to interpret.
+//!
+//! # Why there is a proxy
+//!
+//! Two conditions cannot be expressed inside a gRPC handler. "Unreachable"
+//! (A1, F2) and "the connection drops after the instance committed" (D1) are
+//! both facts about the socket, so the instance listens behind a byte copying
+//! proxy that can refuse a connection outright or tear a live one down.
+
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use altair_proto::v1;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+use tonic::{Request, Response, Status, Streaming};
+
+/// How the fake instance answers. One value at a time; set it, then act.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Behaviour {
+    /// Every intent applies.
+    Accept,
+    /// Nothing connects. Connections are closed the moment they are accepted,
+    /// which a client sees as a transport failure exactly as it would see a
+    /// refused connection.
+    Unreachable,
+    /// The connection works and the token does not. Per DR-005 this is a wait,
+    /// not a fault, and A2 and F3 turn on the client agreeing.
+    Unauthenticated,
+    /// The submission arrives and no answer ever comes. E1.
+    Stall,
+    /// The submission arrives, nothing is committed, and the connection is
+    /// torn down. An ordinary wait; used to make a client retry.
+    DropBeforeCommit,
+    /// The submission arrives, the instance commits and records the
+    /// acknowledgement it would have sent, and then the connection is torn
+    /// down before that acknowledgement can reach the client. D1's condition.
+    DropAfterCommit,
+    /// Refuse any intent whose content carries one of these titles; apply
+    /// everything else. E2, E3, E4, F4, F7.
+    RefuseTitled(Vec<String>),
+    /// Refuse the nth intent to arrive, counting from one across the whole run;
+    /// apply every other. G1.
+    RefuseNth(usize),
+    /// Refuse everything as not available, with this free text detail. G4 runs
+    /// twice with different detail and requires the person to see no
+    /// difference.
+    RefuseNotAvailable { detail: String },
+    /// Apply edits, and say a concurrent change was retained. G2.
+    ApplyWithConflict,
+    /// Answer an edit with a recreation under a new identity. G3.
+    RecreateOnEdit,
+    /// Answer with a status a client has no way to classify as self clearing.
+    /// F6, F8, F9.
+    UnrecognisedCondition,
+}
+
+/// One submission, as it arrived.
+#[derive(Debug, Clone)]
+pub struct Submission {
+    /// Position in the single arrival order shared with body streams.
+    pub seq: u64,
+    /// Whatever was in the `authorization` metadata, if anything.
+    pub token: Option<String>,
+    pub intents: Vec<v1::Intent>,
+    /// What the instance answered, where it answered. One per intent, in the
+    /// order submitted.
+    pub acknowledgements: Vec<v1::Acknowledgement>,
+    /// Whether the client could have received the answer. False for a stall
+    /// and for either drop.
+    pub answered: bool,
+}
+
+/// One completed body stream.
+#[derive(Debug, Clone)]
+pub struct BodyArrival {
+    /// Position in the arrival order, taken when the stream *completed*, which
+    /// is what C3 compares against.
+    pub seq: u64,
+    pub body_id: Vec<u8>,
+    pub bytes: Vec<u8>,
+}
+
+/// One intent, flattened out of its submission into the global arrival order.
+#[derive(Debug, Clone)]
+pub struct IntentArrival {
+    /// Position among intents, counting from zero. Ordering assertions use it.
+    pub order: usize,
+    /// Position of the carrying submission in the shared arrival order.
+    pub seq: u64,
+    pub token: Option<String>,
+    pub intent: v1::Intent,
+    pub acknowledgement: Option<v1::Acknowledgement>,
+    /// Whether the client could have received the answer. False for a stall
+    /// and for either drop, which is exactly the distinction D1 turns on.
+    pub answered: bool,
+}
+
+impl IntentArrival {
+    /// Whether the instance applied this intent.
+    #[must_use]
+    pub fn applied(&self) -> bool {
+        matches!(
+            self.acknowledgement
+                .as_ref()
+                .and_then(|ack| ack.outcome.as_ref()),
+            Some(v1::acknowledgement::Outcome::Applied(_))
+        )
+    }
+
+    /// Whether the instance refused this intent.
+    #[must_use]
+    pub fn refused(&self) -> bool {
+        matches!(
+            self.acknowledgement
+                .as_ref()
+                .and_then(|ack| ack.outcome.as_ref()),
+            Some(v1::acknowledgement::Outcome::Refused(_))
+        )
+    }
+
+    /// The recreation the instance answered with, where it answered with one.
+    #[must_use]
+    pub fn recreated(&self) -> Option<v1::Recreated> {
+        match self
+            .acknowledgement
+            .as_ref()
+            .and_then(|ack| ack.outcome.as_ref())
+        {
+            Some(v1::acknowledgement::Outcome::Recreated(recreated)) => Some(recreated.clone()),
+            _ => None,
+        }
+    }
+
+    /// The retained conflict the acknowledgement carries, where it carries one.
+    #[must_use]
+    pub fn conflict(&self) -> Option<v1::ConflictRetained> {
+        match self
+            .acknowledgement
+            .as_ref()
+            .and_then(|ack| ack.outcome.as_ref())
+        {
+            Some(v1::acknowledgement::Outcome::Applied(applied)) => applied.conflict.clone(),
+            _ => None,
+        }
+    }
+}
+
+/// Everything that reached the instance.
+#[derive(Debug, Clone, Default)]
+pub struct Log {
+    pub submissions: Vec<Submission>,
+    pub bodies: Vec<BodyArrival>,
+}
+
+impl Log {
+    /// Every intent in arrival order.
+    #[must_use]
+    pub fn intents(&self) -> Vec<IntentArrival> {
+        let mut out = Vec::new();
+        for submission in &self.submissions {
+            for (index, intent) in submission.intents.iter().enumerate() {
+                out.push(IntentArrival {
+                    order: out.len(),
+                    seq: submission.seq,
+                    token: submission.token.clone(),
+                    intent: intent.clone(),
+                    acknowledgement: submission.acknowledgements.get(index).cloned(),
+                    answered: submission.answered,
+                });
+            }
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct Inner {
+    behaviour: Option<Behaviour>,
+    log: Log,
+    /// Intent identity to the acknowledgement already issued for it. D3: a
+    /// replay returns the original, unchanged.
+    issued: HashMap<Vec<u8>, v1::Acknowledgement>,
+    /// Entity identities the instance has actually committed. D1 and D4 count
+    /// these to prove one entity rather than two.
+    committed: HashSet<Vec<u8>>,
+    /// How many intents have been decided, ever. `RefuseNth` counts here.
+    decided: usize,
+}
+
+struct State {
+    inner: Mutex<Inner>,
+    seq: AtomicU64,
+    generation: watch::Sender<u64>,
+}
+
+impl State {
+    fn behaviour(&self) -> Behaviour {
+        self.inner
+            .lock()
+            .unwrap()
+            .behaviour
+            .clone()
+            .unwrap_or(Behaviour::Accept)
+    }
+
+    fn next_seq(&self) -> u64 {
+        self.seq.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Tear down every live connection. The generation is what the proxy tasks
+    /// watch.
+    fn drop_connections(&self) {
+        self.generation.send_modify(|value| *value += 1);
+    }
+}
+
+/// A controllable instance, listening on a local port.
+pub struct FakeInstance {
+    state: Arc<State>,
+    address: SocketAddr,
+}
+
+impl FakeInstance {
+    /// Start listening. The returned instance answers [`Behaviour::Accept`]
+    /// until told otherwise.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a local port cannot be bound, which is a broken harness
+    /// rather than a conformance verdict.
+    pub async fn start() -> Self {
+        let (generation, generation_rx) = watch::channel(0_u64);
+        let state = Arc::new(State {
+            inner: Mutex::new(Inner::default()),
+            seq: AtomicU64::new(0),
+            generation,
+        });
+
+        let backend = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind backend");
+        let backend_address = backend.local_addr().expect("backend address");
+        let service = v1::altair_server::AltairServer::new(Service {
+            state: Arc::clone(&state),
+        });
+        tokio::spawn(async move {
+            let incoming = tokio_stream::wrappers::TcpListenerStream::new(backend);
+            let _ = tonic::transport::Server::builder()
+                .add_service(service)
+                .serve_with_incoming(incoming)
+                .await;
+        });
+
+        let front = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind front");
+        let address = front.local_addr().expect("front address");
+        let proxy_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            proxy(front, backend_address, proxy_state, generation_rx).await;
+        });
+
+        Self { state, address }
+    }
+
+    /// Where clients should be pointed.
+    #[must_use]
+    pub fn url(&self) -> String {
+        format!("http://{}", self.address)
+    }
+
+    /// The whole control surface, half one.
+    pub fn set_behaviour(&self, behaviour: Behaviour) {
+        let mut inner = self.state.inner.lock().unwrap();
+        inner.behaviour = Some(behaviour);
+    }
+
+    /// The whole control surface, half two.
+    #[must_use]
+    pub fn log(&self) -> Log {
+        self.state.inner.lock().unwrap().log.clone()
+    }
+
+    /// Every intent that has arrived, in order.
+    #[must_use]
+    pub fn intents(&self) -> Vec<IntentArrival> {
+        self.log().intents()
+    }
+
+    /// Every body stream that completed, in order.
+    #[must_use]
+    pub fn bodies(&self) -> Vec<BodyArrival> {
+        self.log().bodies
+    }
+
+    /// Entity identities the instance actually committed. Counting these is
+    /// how "one entity, not two" is checked.
+    #[must_use]
+    pub fn committed_entities(&self) -> HashSet<Vec<u8>> {
+        self.state.inner.lock().unwrap().committed.clone()
+    }
+
+    /// Tear down every live connection, without changing the behaviour.
+    pub fn drop_connections(&self) {
+        self.state.drop_connections();
+    }
+
+    /// Wait until at least `count` intents have arrived. Answers whether they
+    /// did.
+    pub async fn wait_for_intents(&self, count: usize, patience: Duration) -> bool {
+        self.wait_until(patience, |instance| instance.intents().len() >= count)
+            .await
+    }
+
+    /// Wait until `condition` holds of the instance. Answers whether it did.
+    pub async fn wait_until<F>(&self, patience: Duration, condition: F) -> bool
+    where
+        F: Fn(&Self) -> bool,
+    {
+        let deadline = tokio::time::Instant::now() + patience;
+        loop {
+            if condition(self) {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    /// Let `window` pass, then answer whether `condition` held throughout.
+    /// The shape every "and nothing else happens" assertion needs.
+    pub async fn stayed_true<F>(&self, window: Duration, condition: F) -> bool
+    where
+        F: Fn(&Self) -> bool,
+    {
+        let deadline = tokio::time::Instant::now() + window;
+        loop {
+            if !condition(self) {
+                return false;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reading an intent, at the boundary
+// ---------------------------------------------------------------------------
+
+/// The entity identity an intent names, where it names one.
+#[must_use]
+pub fn entity_id_of(intent: &v1::Intent) -> Option<Vec<u8>> {
+    match intent.action.as_ref()? {
+        v1::intent::Action::Create(create) => match create.subject.as_ref()? {
+            v1::create::Subject::Entity(entity) => Some(entity.entity_id.clone()),
+            v1::create::Subject::Relation(_) => None,
+        },
+        v1::intent::Action::Edit(edit) => match edit.subject.as_ref()? {
+            v1::edit::Subject::Entity(entity) => Some(entity.entity_id.clone()),
+            v1::edit::Subject::Relation(_) => None,
+        },
+        _ => None,
+    }
+}
+
+/// The entity creation an intent carries, where it creates an entity.
+#[must_use]
+pub fn create_entity_of(intent: &v1::Intent) -> Option<&v1::CreateEntity> {
+    match intent.action.as_ref()? {
+        v1::intent::Action::Create(create) => match create.subject.as_ref()? {
+            v1::create::Subject::Entity(entity) => Some(entity),
+            v1::create::Subject::Relation(_) => None,
+        },
+        _ => None,
+    }
+}
+
+/// The content an intent carries, where it carries any.
+#[must_use]
+pub fn content_of(intent: &v1::Intent) -> Option<&v1::EntityContent> {
+    match intent.action.as_ref()? {
+        v1::intent::Action::Create(create) => match create.subject.as_ref()? {
+            v1::create::Subject::Entity(entity) => entity.content.as_ref(),
+            v1::create::Subject::Relation(_) => None,
+        },
+        v1::intent::Action::Edit(edit) => match edit.subject.as_ref()? {
+            v1::edit::Subject::Entity(entity) => entity.content.as_ref(),
+            v1::edit::Subject::Relation(_) => None,
+        },
+        _ => None,
+    }
+}
+
+/// The title an intent carries, where it carries one.
+#[must_use]
+pub fn title_of(intent: &v1::Intent) -> Option<String> {
+    content_of(intent).and_then(|content| content.title.clone())
+}
+
+/// The body identity a file intent names, where it names one.
+#[must_use]
+pub fn body_id_of(intent: &v1::Intent) -> Option<Vec<u8>> {
+    match content_of(intent)?.specific.as_ref()? {
+        v1::entity_content::Specific::File(file) => file.body_id.clone(),
+        _ => None,
+    }
+}
+
+/// Whether the intent creates an entity.
+#[must_use]
+pub fn is_create(intent: &v1::Intent) -> bool {
+    matches!(
+        intent.action.as_ref(),
+        Some(v1::intent::Action::Create(v1::Create {
+            subject: Some(v1::create::Subject::Entity(_))
+        }))
+    )
+}
+
+/// Whether the intent edits an entity.
+#[must_use]
+pub fn is_edit(intent: &v1::Intent) -> bool {
+    matches!(
+        intent.action.as_ref(),
+        Some(v1::intent::Action::Edit(v1::Edit {
+            subject: Some(v1::edit::Subject::Entity(_))
+        }))
+    )
+}
+
+// ---------------------------------------------------------------------------
+// The service
+// ---------------------------------------------------------------------------
+
+struct Service {
+    state: Arc<State>,
+}
+
+impl Service {
+    /// Decide one intent, honouring the idempotence rule first: an intent the
+    /// instance already holds gets its original acknowledgement back,
+    /// unchanged, and is not decided a second time.
+    fn decide(&self, intent: &v1::Intent, behaviour: &Behaviour) -> v1::Acknowledgement {
+        let mut inner = self.state.inner.lock().unwrap();
+        if let Some(held) = inner.issued.get(&intent.intent_id) {
+            return held.clone();
+        }
+        inner.decided += 1;
+        let nth = inner.decided;
+        drop(inner);
+
+        let refused = |reason: v1::RefusalReason, detail: String| v1::Acknowledgement {
+            intent_id: intent.intent_id.clone(),
+            outcome: Some(v1::acknowledgement::Outcome::Refused(v1::Refused {
+                reason: reason as i32,
+                detail,
+            })),
+        };
+        let applied = |conflict: Option<v1::ConflictRetained>| v1::Acknowledgement {
+            intent_id: intent.intent_id.clone(),
+            outcome: Some(v1::acknowledgement::Outcome::Applied(v1::Applied {
+                entity_ids: entity_id_of(intent).into_iter().collect(),
+                relation_ids: Vec::new(),
+                counter: 1,
+                conflict,
+            })),
+        };
+
+        let acknowledgement = match behaviour {
+            Behaviour::RefuseNth(k) if nth == *k => {
+                refused(v1::RefusalReason::NotAvailable, String::new())
+            }
+            Behaviour::RefuseTitled(titles)
+                if title_of(intent).is_some_and(|title| titles.contains(&title)) =>
+            {
+                refused(v1::RefusalReason::NotAvailable, String::new())
+            }
+            Behaviour::RefuseNotAvailable { detail } => {
+                refused(v1::RefusalReason::NotAvailable, detail.clone())
+            }
+            Behaviour::RecreateOnEdit if is_edit(intent) => v1::Acknowledgement {
+                intent_id: intent.intent_id.clone(),
+                outcome: Some(v1::acknowledgement::Outcome::Recreated(v1::Recreated {
+                    original_entity_id: entity_id_of(intent).unwrap_or_default(),
+                    new_entity_id: uuid::Uuid::new_v4().as_bytes().to_vec(),
+                    counter: 1,
+                })),
+            },
+            Behaviour::ApplyWithConflict if is_edit(intent) => {
+                applied(Some(v1::ConflictRetained {
+                    // Field 1 of EntityContent is the title, which is what the
+                    // scenarios edit.
+                    content_fields: vec![1],
+                    specific_fields: Vec::new(),
+                    block_ids: Vec::new(),
+                }))
+            }
+            _ => applied(None),
+        };
+
+        let mut inner = self.state.inner.lock().unwrap();
+        inner
+            .issued
+            .insert(intent.intent_id.clone(), acknowledgement.clone());
+        match acknowledgement.outcome.as_ref() {
+            Some(v1::acknowledgement::Outcome::Applied(applied)) => {
+                for id in &applied.entity_ids {
+                    inner.committed.insert(id.clone());
+                }
+            }
+            Some(v1::acknowledgement::Outcome::Recreated(recreated)) => {
+                inner.committed.insert(recreated.new_entity_id.clone());
+            }
+            _ => {}
+        }
+        acknowledgement
+    }
+
+    fn record(
+        &self,
+        seq: u64,
+        token: Option<String>,
+        intents: Vec<v1::Intent>,
+        acknowledgements: Vec<v1::Acknowledgement>,
+        answered: bool,
+    ) {
+        let mut inner = self.state.inner.lock().unwrap();
+        inner.log.submissions.push(Submission {
+            seq,
+            token,
+            intents,
+            acknowledgements,
+            answered,
+        });
+    }
+}
+
+fn token_of<T>(request: &Request<T>) -> Option<String> {
+    request
+        .metadata()
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .map(std::string::ToString::to_string)
+}
+
+#[tonic::async_trait]
+impl v1::altair_server::Altair for Service {
+    async fn submit(
+        &self,
+        request: Request<v1::SubmitRequest>,
+    ) -> Result<Response<v1::SubmitResponse>, Status> {
+        let seq = self.state.next_seq();
+        let token = token_of(&request);
+        let behaviour = self.state.behaviour();
+        let intents = request.into_inner().intents;
+
+        match behaviour {
+            Behaviour::Unauthenticated => {
+                self.record(seq, token, intents, Vec::new(), false);
+                return Err(Status::unauthenticated(""));
+            }
+            Behaviour::UnrecognisedCondition => {
+                self.record(seq, token, intents, Vec::new(), false);
+                return Err(Status::unknown(""));
+            }
+            Behaviour::Stall => {
+                self.record(seq, token, intents, Vec::new(), false);
+                std::future::pending::<()>().await;
+                unreachable!()
+            }
+            Behaviour::DropBeforeCommit => {
+                self.record(seq, token, intents, Vec::new(), false);
+                self.state.drop_connections();
+                std::future::pending::<()>().await;
+                unreachable!()
+            }
+            _ => {}
+        }
+
+        let acknowledgements: Vec<_> = intents
+            .iter()
+            .map(|intent| self.decide(intent, &behaviour))
+            .collect();
+
+        if behaviour == Behaviour::DropAfterCommit {
+            self.record(seq, token, intents, acknowledgements, false);
+            self.state.drop_connections();
+            std::future::pending::<()>().await;
+            unreachable!()
+        }
+
+        self.record(seq, token, intents, acknowledgements.clone(), true);
+        Ok(Response::new(v1::SubmitResponse { acknowledgements }))
+    }
+
+    async fn put_body(
+        &self,
+        request: Request<Streaming<v1::BodyChunk>>,
+    ) -> Result<Response<v1::PutBodyAck>, Status> {
+        let behaviour = self.state.behaviour();
+        if behaviour == Behaviour::Unauthenticated {
+            return Err(Status::unauthenticated(""));
+        }
+        let mut stream = request.into_inner();
+        let mut body_id = Vec::new();
+        let mut bytes = Vec::new();
+        while let Some(chunk) = stream.message().await? {
+            if !chunk.body_id.is_empty() {
+                body_id = chunk.body_id;
+            }
+            bytes.extend_from_slice(&chunk.data);
+        }
+        // The sequence is taken at completion, because C3 asks whether the
+        // stream *completed* before the intent naming it arrived.
+        let seq = self.state.next_seq();
+        let received = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+        let mut inner = self.state.inner.lock().unwrap();
+        inner.log.bodies.push(BodyArrival {
+            seq,
+            body_id: body_id.clone(),
+            bytes,
+        });
+        drop(inner);
+        Ok(Response::new(v1::PutBodyAck {
+            body_id,
+            bytes_received: received,
+        }))
+    }
+
+    type GetBodyStream =
+        tokio_stream::wrappers::ReceiverStream<Result<v1::BodyChunk, tonic::Status>>;
+
+    async fn get_body(
+        &self,
+        _request: Request<v1::BodyRequest>,
+    ) -> Result<Response<Self::GetBodyStream>, Status> {
+        Err(Status::unimplemented(
+            "the fake instance answers writes only",
+        ))
+    }
+
+    async fn query(
+        &self,
+        _request: Request<v1::QueryRequest>,
+    ) -> Result<Response<v1::QueryResponse>, Status> {
+        Err(Status::unimplemented(
+            "the fake instance answers writes only",
+        ))
+    }
+
+    async fn changes(
+        &self,
+        _request: Request<v1::ChangesRequest>,
+    ) -> Result<Response<v1::ChangesResponse>, Status> {
+        Err(Status::unimplemented(
+            "the fake instance answers writes only",
+        ))
+    }
+
+    async fn get_health(
+        &self,
+        _request: Request<v1::HealthRequest>,
+    ) -> Result<Response<v1::HealthResponse>, Status> {
+        Err(Status::unimplemented(
+            "the fake instance answers writes only",
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The proxy
+// ---------------------------------------------------------------------------
+
+async fn proxy(
+    front: TcpListener,
+    backend: SocketAddr,
+    state: Arc<State>,
+    generation: watch::Receiver<u64>,
+) {
+    loop {
+        let Ok((mut inbound, _)) = front.accept().await else {
+            return;
+        };
+        if state.behaviour() == Behaviour::Unreachable {
+            // Closed the moment it opens: a transport failure, which is the
+            // same class of thing as a refused connection and is what a client
+            // must treat as a wait.
+            drop(inbound);
+            continue;
+        }
+        let mut watcher = generation.clone();
+        let at_open = *watcher.borrow_and_update();
+        tokio::spawn(async move {
+            let Ok(mut outbound) = TcpStream::connect(backend).await else {
+                return;
+            };
+            tokio::select! {
+                _ = tokio::io::copy_bidirectional(&mut inbound, &mut outbound) => {}
+                () = generation_changed(&mut watcher, at_open) => {}
+            }
+        });
+    }
+}
+
+async fn generation_changed(watcher: &mut watch::Receiver<u64>, from: u64) {
+    loop {
+        if *watcher.borrow_and_update() != from {
+            return;
+        }
+        if watcher.changed().await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    }
+}

--- a/crates/altair-conformance/src/lib.rs
+++ b/crates/altair-conformance/src/lib.rs
@@ -1,0 +1,91 @@
+//! The outbox conformance suite: `conformance/scenarios.md`, made executable.
+//!
+//! # This suite is expected to fail. Do not delete it.
+//!
+//! The outbox does not exist yet. Wave 4.1 writes it; Wave 1.5 wrote the
+//! scenarios that judge it, because DR-006's obligation is that they exist
+//! before the *second* implementation and they may as well exist before the
+//! first. Every scenario here runs to completion against a stub client that
+//! implements nothing, and fails on the behaviour it is about. That gradient —
+//! scenarios turning green one at a time as Wave 4.1 lands behaviour — is the
+//! whole value of the suite, and it is destroyed by anything that makes a
+//! scenario pass without an outbox behind it.
+//!
+//! So: the scenarios are gated behind the `run-conformance` feature, off by
+//! default, and `mise run conformance` is how you look at the red. See
+//! `README.md` beside this file.
+//!
+//! # What is observed
+//!
+//! Two boundaries and no others. [`client`] is the person's; [`instance`] is
+//! the instance's. Nothing here reads the client's storage, its queue, or any
+//! internal state, because `conformance/scenarios.md` says in as many words
+//! that those are not conformance concerns.
+
+pub mod client;
+pub mod instance;
+pub mod null;
+pub mod process;
+pub mod world;
+
+/// How a scenario ended, other than by failing. A failure is a panic, so
+/// libtest reports it the way it reports every other failing test.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// The client did what the scenario requires.
+    Passed,
+    /// The scenario does not apply to this client, and says why. The substrate
+    /// puts everything above the capture floor at the client's discretion, so
+    /// a skip is a conforming answer and not a quiet pass.
+    Skipped(String),
+}
+
+/// Record how a scenario ended.
+///
+/// Prints, so `--nocapture` shows skips plainly, and appends to the file named
+/// by `ALTAIR_CONFORMANCE_LEDGER` when that is set, so a skip is mechanically
+/// distinguishable from a pass rather than only visible to a reader.
+pub fn report(id: &str, test_name: &str, outcome: &Outcome) {
+    let line = match outcome {
+        Outcome::Passed => format!("{id}\tPASSED\t{test_name}"),
+        Outcome::Skipped(why) => format!("{id}\tSKIPPED\t{test_name}\t{why}"),
+    };
+    println!("[conformance] {line}");
+    if let Ok(path) = std::env::var("ALTAIR_CONFORMANCE_LEDGER") {
+        use std::io::Write;
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            let _ = writeln!(file, "{line}");
+        }
+    }
+}
+
+/// Declare one scenario.
+///
+/// The literal is the scenario's id in `conformance/scenarios.md`, and
+/// `tests/coverage.rs` reads these literals back out of the source to prove
+/// that every scenario in the document has exactly one test and no test names
+/// a scenario the document does not have.
+#[macro_export]
+macro_rules! scenario {
+    ($id:literal, $name:ident, $body:block) => {
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn $name() {
+            let outcome: $crate::Outcome = async move $body.await;
+            $crate::report($id, stringify!($name), &outcome);
+        }
+    };
+}
+
+/// End a scenario as skipped unless the client offers what it needs.
+#[macro_export]
+macro_rules! skip_unless {
+    ($condition:expr, $why:expr) => {
+        if !$condition {
+            return $crate::Outcome::Skipped(($why).to_string());
+        }
+    };
+}

--- a/crates/altair-conformance/src/null.rs
+++ b/crates/altair-conformance/src/null.rs
@@ -1,0 +1,61 @@
+//! The Wave 1 client under test: one that does nothing.
+//!
+//! This is why the suite is red, and it is red for the right reason. The null
+//! client is a real process, launched the same way the terminal client will be,
+//! speaking the same channel. It answers every action honestly with "nothing
+//! happened", so each scenario runs its steps to completion and then fails on
+//! the behaviour it is actually about.
+//!
+//! It declares [`Offers::everything`] on purpose. It offers nothing at all, but
+//! the client this suite exists for — the Wave 4.1 terminal client — offers
+//! editing and file capture, and a stub that declared otherwise would skip
+//! nineteen scenarios rather than fail them. The skip machinery is exercised
+//! separately, in `tests/skips.rs`.
+
+use std::path::PathBuf;
+
+use crate::client::{ClientEnvironment, ClientError, ClientProcess, ClientUnderTest, Offers};
+use crate::process::ChildClient;
+
+pub struct NullClient {
+    program: PathBuf,
+    offers: Offers,
+}
+
+impl NullClient {
+    /// Point at the built `altair-null-client` binary. Tests pass
+    /// `env!("CARGO_BIN_EXE_altair-null-client")`.
+    #[must_use]
+    pub fn at(program: impl Into<PathBuf>) -> Self {
+        Self {
+            program: program.into(),
+            offers: Offers::everything(),
+        }
+    }
+
+    /// Narrow what this client claims to offer. Used to prove that a
+    /// capture-only client skips rather than fails.
+    #[must_use]
+    pub fn offering(mut self, offers: Offers) -> Self {
+        self.offers = offers;
+        self
+    }
+}
+
+impl ClientUnderTest for NullClient {
+    fn name(&self) -> &str {
+        "null client (Wave 1 placeholder; implements nothing)"
+    }
+
+    fn offers(&self) -> Offers {
+        self.offers
+    }
+
+    fn launch(
+        &self,
+        environment: &ClientEnvironment,
+    ) -> Result<Box<dyn ClientProcess>, ClientError> {
+        let child = ChildClient::spawn(&self.program, &[], environment)?;
+        Ok(Box::new(child))
+    }
+}

--- a/crates/altair-conformance/src/process.rs
+++ b/crates/altair-conformance/src/process.rs
@@ -1,0 +1,135 @@
+//! Driving a client that runs as its own process.
+//!
+//! One channel, newline delimited JSON, lockstep. An [`Action`] goes in on the
+//! child's stdin; one [`Reply`] comes back on its stdout. Anything the child
+//! writes to stderr is left alone so a failing client can still say why.
+//!
+//! A Kotlin transcription of this file is a `ProcessBuilder`, a
+//! `BufferedWriter`, a reader thread, and a `BlockingQueue` with a poll
+//! timeout. There is nothing else in it on purpose.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::time::Duration;
+
+use crate::client::{Action, ClientEnvironment, ClientError, ClientProcess, Reply};
+
+/// How long the harness waits for one answer before calling the client silent.
+///
+/// Generous, because a silent client is a harness fault rather than a verdict.
+/// E1 measures latency itself and does not lean on this.
+pub const PATIENCE: Duration = Duration::from_secs(10);
+
+/// Environment variable names handed to a launched client.
+///
+/// Named here rather than inline so the Kotlin harness and the Rust one cannot
+/// drift, and so a client author has one list to read.
+pub mod env_var {
+    /// Where the instance answers, as a URL.
+    pub const INSTANCE: &str = "ALTAIR_CONFORMANCE_INSTANCE";
+    /// Durable storage. Survives a kill and a device restart.
+    pub const STATE_DIR: &str = "ALTAIR_CONFORMANCE_STATE_DIR";
+    /// Ephemeral storage. Wiped by a device restart.
+    pub const RUNTIME_DIR: &str = "ALTAIR_CONFORMANCE_RUNTIME_DIR";
+    /// The token to present.
+    pub const TOKEN: &str = "ALTAIR_CONFORMANCE_TOKEN";
+}
+
+/// A client under test running as a child process.
+pub struct ChildClient {
+    child: Child,
+    stdin: Option<std::process::ChildStdin>,
+    replies: Receiver<Result<String, String>>,
+    dead: bool,
+}
+
+impl ChildClient {
+    /// Spawn `program` with `arguments`, handing it the environment.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the process cannot be started or its pipes cannot be taken.
+    pub fn spawn(
+        program: &std::path::Path,
+        arguments: &[String],
+        environment: &ClientEnvironment,
+    ) -> Result<Self, ClientError> {
+        let mut child = Command::new(program)
+            .args(arguments)
+            .env(env_var::INSTANCE, &environment.instance_url)
+            .env(env_var::STATE_DIR, &environment.state_dir)
+            .env(env_var::RUNTIME_DIR, &environment.runtime_dir)
+            .env(env_var::TOKEN, &environment.token)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(ClientError::Io)?;
+
+        let stdin = child.stdin.take().ok_or(ClientError::Gone)?;
+        let stdout = child.stdout.take().ok_or(ClientError::Gone)?;
+
+        // A reader thread rather than a blocking read, so a client that never
+        // answers costs the harness a timeout instead of the whole suite.
+        let (sender, replies) = mpsc::channel();
+        std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                let message = match line {
+                    Ok(text) => Ok(text),
+                    Err(error) => Err(error.to_string()),
+                };
+                if sender.send(message).is_err() {
+                    return;
+                }
+            }
+        });
+
+        Ok(Self {
+            child,
+            stdin: Some(stdin),
+            replies,
+            dead: false,
+        })
+    }
+}
+
+impl ClientProcess for ChildClient {
+    fn act(&mut self, action: &Action) -> Result<Reply, ClientError> {
+        if self.dead {
+            return Err(ClientError::Gone);
+        }
+        let stdin = self.stdin.as_mut().ok_or(ClientError::Gone)?;
+        let mut line = serde_json::to_string(action)
+            .map_err(|error| ClientError::Unreadable(error.to_string()))?;
+        line.push('\n');
+        stdin.write_all(line.as_bytes()).map_err(ClientError::Io)?;
+        stdin.flush().map_err(ClientError::Io)?;
+
+        match self.replies.recv_timeout(PATIENCE) {
+            Ok(Ok(text)) => serde_json::from_str(&text)
+                .map_err(|error| ClientError::Unreadable(format!("{error}: {text}"))),
+            Ok(Err(error)) => Err(ClientError::Unreadable(error)),
+            Err(RecvTimeoutError::Timeout) => Err(ClientError::Silent),
+            Err(RecvTimeoutError::Disconnected) => Err(ClientError::Gone),
+        }
+    }
+
+    fn kill(&mut self) {
+        if self.dead {
+            return;
+        }
+        self.dead = true;
+        // Drop stdin first so the child cannot mistake the kill for an orderly
+        // end of input and flush on the way out.
+        self.stdin = None;
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for ChildClient {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}

--- a/crates/altair-conformance/src/world.rs
+++ b/crates/altair-conformance/src/world.rs
@@ -1,0 +1,298 @@
+//! One scenario's world: a fake instance, a client under test, and the two
+//! directories that make a process kill and a device restart different things.
+//!
+//! Everything a scenario is allowed to do goes through here, which is how the
+//! two-boundary rule is kept: there is no method on [`World`] that reads the
+//! client's storage or its queue.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::client::{
+    Action, CaptureContent, ClientEnvironment, ClientProcess, ClientUnderTest, Event, Label,
+    Offers, Reply, Signal,
+};
+use crate::instance::FakeInstance;
+
+/// How long the harness waits for something that should happen.
+pub const SETTLE: Duration = Duration::from_secs(3);
+
+/// How long the harness watches to prove something does not happen. Long
+/// enough to cover several retry cycles of any sane client.
+pub const QUIET: Duration = Duration::from_millis(1500);
+
+pub struct World {
+    pub instance: FakeInstance,
+    under_test: Arc<dyn ClientUnderTest>,
+    root: PathBuf,
+    environment: ClientEnvironment,
+    client: Option<Box<dyn ClientProcess>>,
+}
+
+impl World {
+    /// Start a fake instance and prepare a client's environment. Nothing is
+    /// launched until [`World::launch`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the temporary directories cannot be made.
+    pub async fn new(under_test: Arc<dyn ClientUnderTest>) -> Self {
+        let instance = FakeInstance::start().await;
+        let root =
+            std::env::temp_dir().join(format!("altair-conformance-{}", uuid::Uuid::new_v4()));
+        let state_dir = root.join("state");
+        let runtime_dir = root.join("runtime");
+        std::fs::create_dir_all(&state_dir).expect("make state dir");
+        std::fs::create_dir_all(&runtime_dir).expect("make runtime dir");
+        let environment = ClientEnvironment {
+            instance_url: instance.url(),
+            state_dir,
+            runtime_dir,
+            token: format!("conformance-{}", uuid::Uuid::new_v4()),
+        };
+        Self {
+            instance,
+            under_test,
+            root,
+            environment,
+            client: None,
+        }
+    }
+
+    #[must_use]
+    pub fn offers(&self) -> Offers {
+        self.under_test.offers()
+    }
+
+    #[must_use]
+    pub fn client_name(&self) -> &str {
+        self.under_test.name()
+    }
+
+    /// Start the client. Panics if it cannot be started, which is a harness
+    /// fault rather than a verdict.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the client process cannot be launched.
+    pub fn launch(&mut self) {
+        assert!(
+            self.client.is_none(),
+            "the client under test is already running"
+        );
+        let client = self
+            .under_test
+            .launch(&self.environment)
+            .unwrap_or_else(|error| panic!("could not launch the client under test: {error}"));
+        self.client = Some(client);
+    }
+
+    /// Kill the client without warning. `SIGKILL`; no flush, no cleanup.
+    pub fn kill(&mut self) {
+        if let Some(mut client) = self.client.take() {
+            client.kill();
+        }
+    }
+
+    /// B1: the process dies and comes back. Both directories survive.
+    pub fn restart_process(&mut self) {
+        self.kill();
+        self.launch();
+    }
+
+    /// B2: the device restarts. Durable storage survives; everything
+    /// ephemeral does not, so the runtime directory is wiped.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the runtime directory cannot be recreated.
+    pub fn restart_device(&mut self) {
+        self.kill();
+        let runtime = self.environment.runtime_dir.clone();
+        let _ = std::fs::remove_dir_all(&runtime);
+        std::fs::create_dir_all(&runtime).expect("recreate runtime dir");
+        self.launch();
+    }
+
+    /// A4: local storage the client cannot write to.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the permissions cannot be changed.
+    #[cfg(unix)]
+    pub fn make_state_unwritable(&self) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(
+            &self.environment.state_dir,
+            std::fs::Permissions::from_mode(0o500),
+        )
+        .expect("make the state dir unwritable");
+    }
+
+    #[cfg(unix)]
+    fn make_state_writable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
+    }
+
+    /// Do one thing at the person's surface.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the client cannot be reached at all.
+    pub fn act(&mut self, action: &Action) -> Reply {
+        let client = self
+            .client
+            .as_mut()
+            .expect("the client under test is not running");
+        client
+            .act(action)
+            .unwrap_or_else(|error| panic!("could not reach the client under test: {error}"))
+    }
+
+    /// Do one thing, and say how long the person waited for the answer.
+    pub fn act_timed(&mut self, action: &Action) -> (Reply, Duration) {
+        let started = Instant::now();
+        let reply = self.act(action);
+        (reply, started.elapsed())
+    }
+
+    /// Capture a note whose title is the label, which is how the harness
+    /// recognises it again at the instance boundary.
+    pub fn capture(&mut self, label: &str) -> Reply {
+        self.act(&Action::Capture {
+            label: label.to_string(),
+            content: CaptureContent::Note {
+                title: label.to_string(),
+                body: String::new(),
+            },
+        })
+    }
+
+    pub fn capture_content(&mut self, label: &str, content: CaptureContent) -> Reply {
+        self.act(&Action::Capture {
+            label: label.to_string(),
+            content,
+        })
+    }
+
+    pub fn edit(&mut self, label: &str, title: &str) -> Reply {
+        self.act(&Action::Edit {
+            label: label.to_string(),
+            title: title.to_string(),
+        })
+    }
+
+    pub fn open(&mut self, label: &str) -> Reply {
+        self.act(&Action::Open {
+            label: label.to_string(),
+        })
+    }
+
+    pub fn bind(&mut self, member_id: &[u8]) -> Reply {
+        self.act(&Action::Bind {
+            member_id: member_id.to_vec(),
+        })
+    }
+
+    /// Everything standing in front of the person right now.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the client answers something other than a showing.
+    pub fn showing(&mut self) -> Vec<Signal> {
+        match self.act(&Action::Showing) {
+            Reply::Showing { signals } => signals,
+            other => panic!("asked what the client is showing and it said {other:?}"),
+        }
+    }
+
+    /// Person facing events since the last drain.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the client answers something other than events.
+    pub fn drain_events(&mut self) -> Vec<Event> {
+        match self.act(&Action::DrainEvents) {
+            Reply::Events { events } => events,
+            other => panic!("asked the client for events and it said {other:?}"),
+        }
+    }
+
+    /// Assert the client accepted `label`, and say so in the failure when it
+    /// did not. Almost every scenario opens with this, which is why the stub
+    /// client fails all of them for the same honest reason.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the client did not show acceptance.
+    pub fn accept(&mut self, label: &str) {
+        let reply = self.capture(label);
+        assert_accepted(&reply, label);
+    }
+}
+
+/// Assert one reply is acceptance of `label`.
+///
+/// # Panics
+///
+/// Panics when it is not.
+pub fn assert_accepted(reply: &Reply, label: &str) {
+    match reply {
+        Reply::Accepted { label: shown } => assert_eq!(
+            shown, label,
+            "the client accepted something, but named it {shown} rather than {label}"
+        ),
+        other => panic!(
+            "the client was expected to show {label} as accepted and showed {other:?} instead"
+        ),
+    }
+}
+
+/// Pull an entity reply apart, or fail saying what came instead.
+///
+/// # Panics
+///
+/// Panics when the reply is not an entity.
+#[must_use]
+pub fn expect_entity(reply: &Reply) -> Seen {
+    match reply {
+        Reply::Entity {
+            label,
+            present,
+            entity_id,
+            title,
+            body,
+            bytes,
+        } => Seen {
+            label: label.clone(),
+            present: *present,
+            entity_id: entity_id.clone(),
+            title: title.clone(),
+            body: body.clone(),
+            bytes: bytes.clone(),
+        },
+        other => panic!("the client was asked to show an entity and answered {other:?}"),
+    }
+}
+
+/// What the person sees when they return to something.
+#[derive(Debug, Clone)]
+pub struct Seen {
+    pub label: Label,
+    pub present: bool,
+    pub entity_id: Vec<u8>,
+    pub title: Option<String>,
+    pub body: Option<String>,
+    pub bytes: Option<Vec<u8>>,
+}
+
+impl Drop for World {
+    fn drop(&mut self) {
+        self.kill();
+        #[cfg(unix)]
+        Self::make_state_writable(&self.environment.state_dir);
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}

--- a/crates/altair-conformance/tests/coverage.rs
+++ b/crates/altair-conformance/tests/coverage.rs
@@ -1,0 +1,116 @@
+//! The document and the suite name the same scenarios.
+//!
+//! Ungated on purpose: this runs in the default `cargo test --workspace` and
+//! stays green. It is how "all of them run" is checkable without running the
+//! red suite, and it is what fails if someone adds a scenario to
+//! `conformance/scenarios.md` without adding a test, or deletes a test.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+/// `conformance/scenarios.md` states thirty four scenarios across sections A
+/// to G: A1–A5, B1–B5, C1–C3, D1–D4, E1–E4, F1–F9, G1–G4. If that number
+/// changes, the document changed, and this constant is where it is noticed.
+const EXPECTED: usize = 34;
+
+fn repository_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+fn suite_source() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("scenarios.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()))
+}
+
+/// Scenario ids as the document states them: a line opening `**A1. `.
+fn ids_in_the_document() -> BTreeSet<String> {
+    let path = repository_root().join("conformance").join("scenarios.md");
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+    let mut ids = BTreeSet::new();
+    for line in text.lines() {
+        let Some(rest) = line.strip_prefix("**") else {
+            continue;
+        };
+        let Some((head, _)) = rest.split_once(". ") else {
+            continue;
+        };
+        if is_scenario_id(head) {
+            ids.insert(head.to_string());
+        }
+    }
+    ids
+}
+
+/// Every `scenario!(id, test_name, …)` declaration in the suite.
+///
+/// Parsed whitespace-insensitively, because rustfmt decides for itself whether
+/// an invocation fits on one line and the mapping must not depend on that.
+fn declarations(source: &str) -> Vec<(String, String)> {
+    let mut found = Vec::new();
+    for chunk in source.split("scenario!(").skip(1) {
+        let rest = chunk.trim_start();
+        let rest = rest
+            .strip_prefix('"')
+            .expect("a scenario id, quoted, comes first");
+        let (id, rest) = rest.split_once('"').expect("the id is closed");
+        let rest = rest.trim_start().strip_prefix(',').expect("then a comma");
+        let name: String = rest
+            .trim_start()
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        found.push((id.to_string(), name));
+    }
+    found
+}
+
+fn is_scenario_id(candidate: &str) -> bool {
+    let mut characters = candidate.chars();
+    let Some(section) = characters.next() else {
+        return false;
+    };
+    matches!(section, 'A'..='G')
+        && characters.clone().count() > 0
+        && characters.all(|character| character.is_ascii_digit())
+}
+
+#[test]
+fn every_scenario_in_the_document_has_a_test_and_every_test_has_a_scenario() {
+    let document = ids_in_the_document();
+    let mut suite = BTreeSet::new();
+    for (id, _) in declarations(&suite_source()) {
+        assert!(is_scenario_id(&id), "{id} is not a scenario id");
+        assert!(suite.insert(id.clone()), "{id} is declared twice");
+    }
+
+    let missing: Vec<_> = document.difference(&suite).collect();
+    assert!(missing.is_empty(), "scenarios with no test: {missing:?}");
+
+    let invented: Vec<_> = suite.difference(&document).collect();
+    assert!(
+        invented.is_empty(),
+        "tests naming scenarios the document does not have: {invented:?}"
+    );
+
+    assert_eq!(
+        document.len(),
+        EXPECTED,
+        "the document states {EXPECTED} scenarios"
+    );
+}
+
+#[test]
+fn every_test_is_named_for_its_scenario() {
+    for (id, name) in declarations(&suite_source()) {
+        assert!(
+            name.starts_with(&format!("{}_", id.to_lowercase())),
+            "the test for {id} is called {name}, so the mapping is not mechanical"
+        );
+    }
+}

--- a/crates/altair-conformance/tests/harness.rs
+++ b/crates/altair-conformance/tests/harness.rs
@@ -1,0 +1,363 @@
+//! The harness itself works.
+//!
+//! Ungated on purpose: these run in the default `cargo test --workspace` and
+//! stay green. A red conformance suite is only worth anything if the red is
+//! about the client and not about the harness, so the pieces the scenarios
+//! lean on are exercised here — the fake instance's four behaviours, the
+//! process channel, and the difference between a skip and a pass.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use altair_conformance::client::{
+    Action, CaptureContent, ClientEnvironment, ClientUnderTest, Offers, Reply,
+};
+use altair_conformance::instance::{Behaviour, FakeInstance};
+use altair_conformance::null::NullClient;
+use altair_conformance::world::World;
+use altair_conformance::{Outcome, report};
+use altair_proto::v1;
+
+fn null_client() -> Arc<dyn ClientUnderTest> {
+    Arc::new(NullClient::at(env!("CARGO_BIN_EXE_altair-null-client")))
+}
+
+fn an_intent() -> v1::Intent {
+    v1::Intent {
+        intent_id: uuid::Uuid::new_v4().as_bytes().to_vec(),
+        action: Some(v1::intent::Action::Create(v1::Create {
+            subject: Some(v1::create::Subject::Entity(v1::CreateEntity {
+                entity_id: uuid::Uuid::new_v4().as_bytes().to_vec(),
+                created_at: Some(prost_types::Timestamp {
+                    seconds: 0,
+                    nanos: 0,
+                }),
+                capture_method: "conformance-harness".to_string(),
+                content: Some(v1::EntityContent {
+                    title: Some("harness".to_string()),
+                    specific: Some(v1::entity_content::Specific::Note(
+                        v1::NoteContent::default(),
+                    )),
+                    ..v1::EntityContent::default()
+                }),
+            })),
+        })),
+    }
+}
+
+async fn submit(url: &str, intent: v1::Intent) -> Result<v1::SubmitResponse, tonic::Status> {
+    let mut client = v1::altair_client::AltairClient::connect(url.to_string())
+        .await
+        .map_err(|error| tonic::Status::unavailable(error.to_string()))?;
+    let response = client
+        .submit(v1::SubmitRequest {
+            intents: vec![intent],
+        })
+        .await?;
+    Ok(response.into_inner())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_fake_instance_accepts_and_records_what_arrived() {
+    let instance = FakeInstance::start().await;
+    instance.set_behaviour(Behaviour::Accept);
+    let response = submit(&instance.url(), an_intent())
+        .await
+        .expect("accepted");
+    assert_eq!(response.acknowledgements.len(), 1);
+    let arrivals = instance.intents();
+    assert_eq!(arrivals.len(), 1);
+    assert!(arrivals[0].applied());
+    assert!(arrivals[0].answered);
+    assert_eq!(instance.committed_entities().len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_fake_instance_refuses_on_command() {
+    let instance = FakeInstance::start().await;
+    instance.set_behaviour(Behaviour::RefuseTitled(vec!["harness".to_string()]));
+    let response = submit(&instance.url(), an_intent())
+        .await
+        .expect("answered");
+    assert!(matches!(
+        response.acknowledgements[0].outcome,
+        Some(v1::acknowledgement::Outcome::Refused(_))
+    ));
+    assert!(instance.committed_entities().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_fake_instance_can_be_unreachable() {
+    let instance = FakeInstance::start().await;
+    instance.set_behaviour(Behaviour::Unreachable);
+    let outcome = submit(&instance.url(), an_intent()).await;
+    assert!(
+        outcome.is_err(),
+        "nothing connects while the instance is unreachable"
+    );
+    assert!(instance.intents().is_empty(), "and nothing reaches it");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_fake_instance_can_stall() {
+    let instance = FakeInstance::start().await;
+    instance.set_behaviour(Behaviour::Stall);
+    let waited = tokio::time::timeout(
+        Duration::from_millis(750),
+        submit(&instance.url(), an_intent()),
+    )
+    .await;
+    assert!(waited.is_err(), "the instance never responds");
+    assert_eq!(
+        instance.intents().len(),
+        1,
+        "though the submission did arrive"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_fake_instance_can_drop_after_committing() {
+    let instance = FakeInstance::start().await;
+    instance.set_behaviour(Behaviour::DropAfterCommit);
+    let outcome =
+        tokio::time::timeout(Duration::from_secs(5), submit(&instance.url(), an_intent())).await;
+    assert!(
+        matches!(outcome, Ok(Err(_))),
+        "the connection drops before the acknowledgement"
+    );
+    assert_eq!(
+        instance.committed_entities().len(),
+        1,
+        "after the instance committed"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_fake_instance_returns_a_held_acknowledgement_unchanged() {
+    let instance = FakeInstance::start().await;
+    instance.set_behaviour(Behaviour::Accept);
+    let intent = an_intent();
+    let first = submit(&instance.url(), intent.clone())
+        .await
+        .expect("accepted");
+    let second = submit(&instance.url(), intent)
+        .await
+        .expect("accepted again");
+    assert_eq!(first.acknowledgements, second.acknowledgements);
+    assert_eq!(
+        instance.committed_entities().len(),
+        1,
+        "one entity, not two"
+    );
+}
+
+/// C1 and C2 read ordering out of a flat list, so that list has to be flat
+/// across submissions and not only within one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_arrival_order_is_flat_across_submissions() {
+    let instance = FakeInstance::start().await;
+    instance.set_behaviour(Behaviour::Accept);
+    let mut client = v1::altair_client::AltairClient::connect(instance.url())
+        .await
+        .expect("connect");
+    for _ in 0..2 {
+        client
+            .submit(v1::SubmitRequest {
+                intents: vec![an_intent(), an_intent()],
+            })
+            .await
+            .expect("accepted");
+    }
+    let orders: Vec<usize> = instance
+        .intents()
+        .iter()
+        .map(|arrival| arrival.order)
+        .collect();
+    assert_eq!(orders, vec![0, 1, 2, 3]);
+}
+
+/// G1 leans on the nth intent being counted across the whole run.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn refuse_nth_refuses_exactly_the_nth_intent_to_arrive() {
+    let instance = FakeInstance::start().await;
+    instance.set_behaviour(Behaviour::RefuseNth(3));
+    let mut client = v1::altair_client::AltairClient::connect(instance.url())
+        .await
+        .expect("connect");
+    for _ in 0..4 {
+        client
+            .submit(v1::SubmitRequest {
+                intents: vec![an_intent()],
+            })
+            .await
+            .expect("answered");
+    }
+    let refused: Vec<usize> = instance
+        .intents()
+        .iter()
+        .filter(|arrival| arrival.refused())
+        .map(|a| a.order)
+        .collect();
+    assert_eq!(refused, vec![2], "the third to arrive, counting from one");
+}
+
+/// C3 compares a body's position in the arrival order with an intent's, so the
+/// body has to take its position when the stream completes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_body_takes_its_place_in_the_arrival_order_when_its_stream_completes() {
+    let instance = FakeInstance::start().await;
+    instance.set_behaviour(Behaviour::Accept);
+    let mut client = v1::altair_client::AltairClient::connect(instance.url())
+        .await
+        .expect("connect");
+    let body_id = uuid::Uuid::new_v4().as_bytes().to_vec();
+    let chunks = vec![
+        v1::BodyChunk {
+            body_id: body_id.clone(),
+            data: b"one".to_vec(),
+        },
+        v1::BodyChunk {
+            body_id: Vec::new(),
+            data: b"two".to_vec(),
+        },
+    ];
+    let ack = client
+        .put_body(tokio_stream::iter(chunks))
+        .await
+        .expect("the body is accepted")
+        .into_inner();
+    assert_eq!(ack.bytes_received, 6);
+    client
+        .submit(v1::SubmitRequest {
+            intents: vec![an_intent()],
+        })
+        .await
+        .expect("accepted");
+
+    let body = &instance.bodies()[0];
+    assert_eq!(body.body_id, body_id);
+    assert_eq!(body.bytes, b"onetwo");
+    assert!(
+        body.seq < instance.intents()[0].seq,
+        "the completed body precedes the later intent"
+    );
+}
+
+/// G2 and G3 read their verdicts off the acknowledgement, so those readers have
+/// to see what the behaviours put there.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn conflict_and_recreation_acknowledgements_are_readable() {
+    let entity_id = uuid::Uuid::new_v4().as_bytes().to_vec();
+    let edit = |title: &str| v1::Intent {
+        intent_id: uuid::Uuid::new_v4().as_bytes().to_vec(),
+        action: Some(v1::intent::Action::Edit(v1::Edit {
+            subject: Some(v1::edit::Subject::Entity(v1::EditEntity {
+                entity_id: entity_id.clone(),
+                base_counter: 1,
+                content: Some(v1::EntityContent {
+                    title: Some(title.to_string()),
+                    ..v1::EntityContent::default()
+                }),
+            })),
+        })),
+    };
+
+    let conflicting = FakeInstance::start().await;
+    conflicting.set_behaviour(Behaviour::ApplyWithConflict);
+    submit(&conflicting.url(), edit("one"))
+        .await
+        .expect("applied");
+    assert!(conflicting.intents()[0].conflict().is_some());
+    assert!(conflicting.intents()[0].applied());
+
+    let recreating = FakeInstance::start().await;
+    recreating.set_behaviour(Behaviour::RecreateOnEdit);
+    submit(&recreating.url(), edit("one"))
+        .await
+        .expect("recreated");
+    let recreated = recreating.intents()[0].recreated().expect("a recreation");
+    assert_eq!(recreated.original_entity_id, entity_id);
+    assert_ne!(recreated.new_entity_id, entity_id);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_client_process_answers_on_the_channel() {
+    let instance = FakeInstance::start().await;
+    let root = std::env::temp_dir().join(format!("altair-harness-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(root.join("state")).expect("state dir");
+    std::fs::create_dir_all(root.join("runtime")).expect("runtime dir");
+    let environment = ClientEnvironment {
+        instance_url: instance.url(),
+        state_dir: root.join("state"),
+        runtime_dir: root.join("runtime"),
+        token: "harness".to_string(),
+    };
+
+    let mut client = null_client().launch(&environment).expect("launch");
+    let reply = client
+        .act(&Action::Capture {
+            label: "A".to_string(),
+            content: CaptureContent::Bare,
+        })
+        .expect("an answer");
+    assert_eq!(
+        reply,
+        Reply::Nothing,
+        "the Wave 1 client under test implements nothing"
+    );
+    assert_eq!(
+        client.act(&Action::Showing).expect("an answer"),
+        Reply::Showing {
+            signals: Vec::new()
+        }
+    );
+    client.kill();
+    assert!(
+        client.act(&Action::Showing).is_err(),
+        "a killed client is gone"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_kill_and_a_device_restart_differ_in_what_survives() {
+    let mut world = World::new(null_client()).await;
+    world.launch();
+    world.restart_process();
+    world.restart_device();
+    // Reaching here means both restart paths launch a fresh process against
+    // the same durable state. What the two do differently to the ephemeral
+    // directory is B2's whole subject.
+    assert_eq!(world.offers(), Offers::everything());
+}
+
+#[test]
+fn a_capture_only_client_offers_less_and_therefore_skips_more() {
+    let narrow = NullClient::at("unused").offering(Offers::capture_only());
+    assert!(
+        !narrow.offers().offline_edit,
+        "A3, B5, C1, C3, E3, G2 and G3 skip against this client"
+    );
+    assert!(!narrow.offers().unbound_capture);
+    assert!(!narrow.offers().file_capture);
+}
+
+#[test]
+fn a_skip_is_reported_differently_from_a_pass() {
+    let ledger = std::env::temp_dir().join(format!("altair-ledger-{}", uuid::Uuid::new_v4()));
+    // SAFETY: single-threaded test, and the variable is removed before it ends.
+    unsafe { std::env::set_var("ALTAIR_CONFORMANCE_LEDGER", &ledger) };
+    report("A3", "a3_example", &Outcome::Passed);
+    report(
+        "B5",
+        "b5_example",
+        &Outcome::Skipped("this client does not capture files".to_string()),
+    );
+    unsafe { std::env::remove_var("ALTAIR_CONFORMANCE_LEDGER") };
+
+    let written = std::fs::read_to_string(&ledger).expect("the ledger was written");
+    let _ = std::fs::remove_file(&ledger);
+    assert!(written.contains("A3\tPASSED\ta3_example"));
+    assert!(written.contains("B5\tSKIPPED\tb5_example\tthis client does not capture files"));
+}

--- a/crates/altair-conformance/tests/scenarios.rs
+++ b/crates/altair-conformance/tests/scenarios.rs
@@ -1,0 +1,1470 @@
+//! `conformance/scenarios.md`, executed.
+//!
+//! One test per scenario, named for its id. The id literal in each
+//! `scenario!` invocation is what `tests/coverage.rs` reads back to prove the
+//! document and this file name the same thirty four scenarios.
+//!
+//! **These fail, and that is the deliverable of Wave 1.5.** The outbox is
+//! Wave 4.1's work. Until it exists, [`NullClient`] is what these run against
+//! and it implements nothing, so every scenario drives its steps to completion
+//! and then fails on the behaviour it is about. Read the crate's `README.md`
+//! before deciding one of them is broken.
+
+#![cfg(feature = "run-conformance")]
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use altair_conformance::client::{
+    Action, CaptureContent, ClientUnderTest, Reply, Signal, SignalKind,
+};
+use altair_conformance::instance::{self, Behaviour};
+use altair_conformance::null::NullClient;
+use altair_conformance::world::{QUIET, SETTLE, Seen, World, assert_accepted, expect_entity};
+use altair_conformance::{Outcome, scenario, skip_unless};
+
+/// **The one line Wave 4.1 changes.** Swap the null client for the terminal
+/// client's adapter and the suite starts going green, one scenario at a time.
+fn client_under_test() -> Arc<dyn ClientUnderTest> {
+    Arc::new(NullClient::at(env!("CARGO_BIN_EXE_altair-null-client")))
+}
+
+async fn world() -> World {
+    World::new(client_under_test()).await
+}
+
+/// F9 says three weeks. A suite cannot wait three weeks, so it waits long
+/// enough to cover many retry cycles of any sane client and asserts that the
+/// standing statement did not change and that nothing repeated. What this does
+/// not exercise is anything keyed to a real calendar.
+const LONG_ABSENCE: Duration = Duration::from_millis(2000);
+
+// ---------------------------------------------------------------------------
+// Polling the person's boundary. The instance's own waits live on FakeInstance.
+// ---------------------------------------------------------------------------
+
+async fn until_showing<F>(world: &mut World, patience: Duration, condition: F) -> bool
+where
+    F: Fn(&[Signal]) -> bool,
+{
+    let deadline = Instant::now() + patience;
+    loop {
+        let signals = world.showing();
+        if condition(&signals) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn until_seen<F>(world: &mut World, label: &str, patience: Duration, condition: F) -> bool
+where
+    F: Fn(&Seen) -> bool,
+{
+    let deadline = Instant::now() + patience;
+    loop {
+        let seen = expect_entity(&world.open(label));
+        if condition(&seen) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+fn faults(signals: &[Signal]) -> Vec<&Signal> {
+    signals
+        .iter()
+        .filter(|signal| signal.kind == SignalKind::Fault)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// A. Acceptance
+// ---------------------------------------------------------------------------
+
+scenario!(
+    "A1",
+    a1_capture_with_the_instance_unreachable_is_accepted,
+    {
+        let mut world = world().await;
+        world.instance.set_behaviour(Behaviour::Unreachable);
+        world.launch();
+
+        let reply = world.capture("A");
+        assert_accepted(&reply, "A");
+
+        let seen = expect_entity(&world.open("A"));
+        assert!(
+            seen.present,
+            "an accepted capture is readable on the client immediately"
+        );
+        assert_eq!(
+            seen.title.as_deref(),
+            Some("A"),
+            "and it is the thing the person captured"
+        );
+
+        let signals = world.showing();
+        assert!(
+            signals.is_empty(),
+            "nothing about the unreachability may be shown at the moment of capture, and the client showed {signals:?}"
+        );
+
+        Outcome::Passed
+    }
+);
+
+scenario!("A2", a2_capture_with_an_expired_session_is_accepted, {
+    let mut world = world().await;
+    // Per DR-005 this is a wait, carried by the protocol rather than inferred.
+    world.instance.set_behaviour(Behaviour::Unauthenticated);
+    world.launch();
+
+    let reply = world.capture("A");
+    assert_accepted(&reply, "A");
+
+    let seen = expect_entity(&world.open("A"));
+    assert!(
+        seen.present,
+        "acceptance is identical to A1 in every observable respect"
+    );
+    assert_eq!(seen.title.as_deref(), Some("A"));
+
+    let signals = world.showing();
+    assert!(
+        signals.is_empty(),
+        "an expired session is the same wait as an unreachable instance, and the client showed {signals:?}"
+    );
+
+    Outcome::Passed
+});
+
+scenario!("A3", a3_capture_with_no_household_binding_is_accepted, {
+    let mut world = world().await;
+    skip_unless!(
+        world.offers().unbound_capture,
+        "this client requires binding before capture, which is conforming"
+    );
+    world.instance.set_behaviour(Behaviour::Accept);
+    world.launch();
+
+    let reply = world.capture("A");
+    assert_accepted(&reply, "A");
+    let seen = expect_entity(&world.open("A"));
+    assert!(seen.present, "an unbound capture is accepted and durable");
+
+    // No author, so nothing can be attributed and nothing sends.
+    assert!(
+        world
+            .instance
+            .stayed_true(QUIET, |i| i.intents().is_empty())
+            .await,
+        "an unbound capture has no author, so it cannot have sent before binding"
+    );
+
+    let member = uuid::Uuid::new_v4();
+    world.bind(member.as_bytes());
+    assert!(
+        world.instance.wait_for_intents(1, SETTLE).await,
+        "on binding, the author is set and the intent sends"
+    );
+    let arrivals = world.instance.intents();
+    assert!(
+        arrivals
+            .iter()
+            .any(|arrival| instance::title_of(&arrival.intent).as_deref() == Some("A")),
+        "what sends on binding is the capture that was waiting"
+    );
+
+    Outcome::Passed
+});
+
+scenario!(
+    "A4",
+    a4_acceptance_is_refused_when_local_storage_cannot_hold_the_capture,
+    {
+        let mut world = world().await;
+        world.instance.set_behaviour(Behaviour::Unreachable);
+        world.make_state_unwritable();
+        world.launch();
+
+        let reply = world.capture("A");
+        match &reply {
+            Reply::Refused { condition } => assert!(
+                !condition.trim().is_empty(),
+                "the condition is stated at the moment of the attempt, and this refusal states nothing"
+            ),
+            other => panic!(
+                "local storage cannot hold the capture, so the client must refuse and state why; it answered {other:?}"
+            ),
+        }
+
+        let seen = expect_entity(&world.open("A"));
+        assert!(
+            !seen.present,
+            "the entity must not appear anywhere as though it were held"
+        );
+
+        Outcome::Passed
+    }
+);
+
+scenario!(
+    "A5",
+    a5_an_entity_with_only_an_identity_a_type_and_a_timestamp_is_accepted,
+    {
+        let mut world = world().await;
+        world.instance.set_behaviour(Behaviour::Accept);
+        world.launch();
+
+        let reply = world.capture_content("A", CaptureContent::Bare);
+        assert_accepted(&reply, "A");
+
+        assert!(
+            world.instance.wait_for_intents(1, SETTLE).await,
+            "and it sends"
+        );
+        let arrivals = world.instance.intents();
+        let create = arrivals
+            .iter()
+            .find(|arrival| instance::is_create(&arrival.intent))
+            .expect("a create must arrive");
+        let entity =
+            instance::create_entity_of(&create.intent).expect("the create names an entity");
+
+        assert!(!entity.entity_id.is_empty(), "an identity");
+        assert!(entity.created_at.is_some(), "a timestamp");
+        let content = entity
+            .content
+            .as_ref()
+            .expect("a type is the tag of content.specific");
+        assert!(content.specific.is_some(), "a type");
+        assert!(
+            content.title.is_none(),
+            "no field is required at any point on this path, and the client invented a title"
+        );
+
+        Outcome::Passed
+    }
+);
+
+// ---------------------------------------------------------------------------
+// B. Durability
+// ---------------------------------------------------------------------------
+
+scenario!("B1", b1_an_accepted_capture_survives_a_kill, {
+    let mut world = world().await;
+    world.instance.set_behaviour(Behaviour::Unreachable);
+    world.launch();
+    world.accept("A");
+
+    world.restart_process();
+
+    let seen = expect_entity(&world.open("A"));
+    assert!(
+        seen.present,
+        "the entity is present after a kill without warning"
+    );
+    assert!(
+        world.instance.intents().is_empty(),
+        "the instance was unreachable throughout, so the entity is still unsent"
+    );
+
+    world.instance.set_behaviour(Behaviour::Accept);
+    assert!(
+        world.instance.wait_for_intents(1, SETTLE).await,
+        "and it sends when the instance becomes reachable"
+    );
+
+    Outcome::Passed
+});
+
+scenario!(
+    "B2",
+    b2_an_accepted_capture_survives_a_restart_of_the_device,
+    {
+        let mut world = world().await;
+        world.instance.set_behaviour(Behaviour::Unreachable);
+        world.launch();
+        world.accept("A");
+
+        // A device restart loses everything ephemeral, not only the process. The
+        // runtime directory goes; the state directory stays.
+        world.restart_device();
+
+        let seen = expect_entity(&world.open("A"));
+        assert!(
+            seen.present,
+            "the entity is present after the device restarts"
+        );
+        assert!(world.instance.intents().is_empty(), "and is still unsent");
+
+        world.instance.set_behaviour(Behaviour::Accept);
+        assert!(
+            world.instance.wait_for_intents(1, SETTLE).await,
+            "and it sends when the instance becomes reachable"
+        );
+
+        Outcome::Passed
+    }
+);
+
+scenario!(
+    "B3",
+    b3_the_queue_survives_alongside_the_entities_it_references,
+    {
+        let mut world = world().await;
+        world.instance.set_behaviour(Behaviour::Unreachable);
+        world.launch();
+        for label in ["A", "B", "C"] {
+            world.accept(label);
+        }
+
+        world.restart_process();
+
+        let mut local = Vec::new();
+        for label in ["A", "B", "C"] {
+            let seen = expect_entity(&world.open(label));
+            assert!(
+                seen.present,
+                "every entity an intent refers to is present after restart: {label}"
+            );
+            local.push(seen.entity_id);
+        }
+
+        world.instance.set_behaviour(Behaviour::Accept);
+        assert!(
+            world.instance.wait_for_intents(3, SETTLE).await,
+            "every intent is present after restart and sends"
+        );
+
+        let arrived: HashSet<Vec<u8>> = world
+            .instance
+            .intents()
+            .iter()
+            .filter_map(|arrival| instance::entity_id_of(&arrival.intent))
+            .collect();
+        for (label, id) in ["A", "B", "C"].iter().zip(local) {
+            assert!(
+                arrived.contains(&id),
+                "neither exists without the other: {label} is readable on the client but no intent named it"
+            );
+        }
+
+        Outcome::Passed
+    }
+);
+
+scenario!(
+    "B4",
+    b4_acceptance_is_shown_only_once_the_capture_is_durable,
+    {
+        // Killed at the moment acceptance is shown, on repeated runs: the harness
+        // kills as soon as it reads the acceptance and before doing anything else.
+        for run in 1..=10 {
+            let mut world = world().await;
+            world.instance.set_behaviour(Behaviour::Unreachable);
+            world.launch();
+
+            let reply = world.capture("A");
+            world.kill();
+            assert_accepted(&reply, "A");
+
+            world.launch();
+            let seen = expect_entity(&world.open("A"));
+            assert!(
+                seen.present,
+                "run {run}: acceptance was shown before a kill immediately afterwards would have left the entity present"
+            );
+        }
+
+        Outcome::Passed
+    }
+);
+
+scenario!("B5", b5_a_body_is_durable_before_its_capture_is_accepted, {
+    let mut world = world().await;
+    skip_unless!(
+        world.offers().file_capture,
+        "this client does not capture files"
+    );
+    world.instance.set_behaviour(Behaviour::Unreachable);
+    world.launch();
+
+    let bytes = b"the bytes acceptance has to cover".to_vec();
+    let reply = world.capture_content(
+        "F",
+        CaptureContent::File {
+            media_type: "text/plain".to_string(),
+            bytes: bytes.clone(),
+        },
+    );
+    world.kill();
+    assert_accepted(&reply, "F");
+
+    world.launch();
+    let seen = expect_entity(&world.open("F"));
+    assert!(
+        seen.present,
+        "a kill immediately after acceptance leaves the intent present"
+    );
+    assert_eq!(
+        seen.bytes.as_ref(),
+        Some(&bytes),
+        "and leaves the bytes present"
+    );
+
+    world.instance.set_behaviour(Behaviour::Accept);
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| !i.bodies().is_empty())
+            .await,
+        "and both reach the instance"
+    );
+    assert_eq!(
+        world.instance.bodies()[0].bytes,
+        bytes,
+        "the bytes acceptance covered are the bytes that arrive"
+    );
+
+    Outcome::Passed
+});
+
+// ---------------------------------------------------------------------------
+// C. Ordering
+// ---------------------------------------------------------------------------
+
+scenario!("C1", c1_a_create_precedes_its_own_edits, {
+    let mut world = world().await;
+    skip_unless!(
+        world.offers().offline_edit,
+        "this client does not edit while offline"
+    );
+    world.instance.set_behaviour(Behaviour::Unreachable);
+    world.launch();
+    world.accept("A");
+    world.edit("A", "A/1");
+    world.edit("A", "A/2");
+
+    world.instance.set_behaviour(Behaviour::Accept);
+    assert!(
+        world.instance.wait_for_intents(3, SETTLE).await,
+        "all three intents send"
+    );
+
+    let arrivals = world.instance.intents();
+    let create = arrivals
+        .iter()
+        .find(|arrival| instance::is_create(&arrival.intent))
+        .expect("the create must arrive");
+    let subject = instance::entity_id_of(&create.intent).expect("the create names an entity");
+    let position = |title: &str| -> usize {
+        arrivals
+            .iter()
+            .find(|arrival| {
+                instance::is_edit(&arrival.intent)
+                    && instance::entity_id_of(&arrival.intent).as_ref() == Some(&subject)
+                    && instance::title_of(&arrival.intent).as_deref() == Some(title)
+            })
+            .unwrap_or_else(|| panic!("the edit carrying {title} must arrive"))
+            .order
+    };
+
+    let first = position("A/1");
+    let second = position("A/2");
+    assert!(
+        create.order < first,
+        "the instance receives the create before either edit"
+    );
+    assert!(first < second, "and the first edit before the second");
+
+    Outcome::Passed
+});
+
+scenario!("C2", c2_ordering_is_per_entity_not_global, {
+    let mut world = world().await;
+    skip_unless!(
+        world.offers().offline_edit,
+        "this client does not edit while offline"
+    );
+    world.instance.set_behaviour(Behaviour::Unreachable);
+    world.launch();
+    world.accept("A");
+    world.accept("B");
+    world.edit("A", "A/1");
+
+    world.instance.set_behaviour(Behaviour::Accept);
+    assert!(
+        world.instance.wait_for_intents(3, SETTLE).await,
+        "all three intents send"
+    );
+
+    let arrivals = world.instance.intents();
+    let create = arrivals
+        .iter()
+        .find(|arrival| {
+            instance::is_create(&arrival.intent)
+                && instance::title_of(&arrival.intent).as_deref() == Some("A")
+        })
+        .expect("A's create must arrive");
+    let subject = instance::entity_id_of(&create.intent).expect("A's create names an entity");
+    let edit = arrivals
+        .iter()
+        .find(|arrival| {
+            instance::is_edit(&arrival.intent)
+                && instance::entity_id_of(&arrival.intent).as_ref() == Some(&subject)
+        })
+        .expect("A's edit must arrive");
+
+    assert!(create.order < edit.order, "A's create precedes A's edit");
+    // Nothing is asserted about where B's create falls, deliberately: this
+    // scenario exists to say that nothing is required of it.
+
+    Outcome::Passed
+});
+
+scenario!("C3", c3_a_body_precedes_the_intent_that_refers_to_it, {
+    let mut world = world().await;
+    skip_unless!(
+        world.offers().file_capture,
+        "this client does not capture files"
+    );
+    world.instance.set_behaviour(Behaviour::Accept);
+    world.launch();
+
+    let reply = world.capture_content(
+        "F",
+        CaptureContent::File {
+            media_type: "text/plain".to_string(),
+            bytes: b"body".to_vec(),
+        },
+    );
+    assert_accepted(&reply, "F");
+
+    let arrived = world
+        .instance
+        .wait_until(SETTLE, |i| {
+            !i.bodies().is_empty()
+                && i.intents()
+                    .iter()
+                    .any(|arrival| instance::body_id_of(&arrival.intent).is_some())
+        })
+        .await;
+    assert!(
+        arrived,
+        "both the body and the intent naming it must reach the instance"
+    );
+
+    let body = world.instance.bodies().remove(0);
+    let intents = world.instance.intents();
+    let naming = intents
+        .iter()
+        .find(|arrival| instance::body_id_of(&arrival.intent) == Some(body.body_id.clone()))
+        .expect("an intent must name the body that was uploaded");
+
+    assert!(
+        body.seq < naming.seq,
+        "the body stream completes before the intent naming that body arrives"
+    );
+
+    Outcome::Passed
+});
+
+// ---------------------------------------------------------------------------
+// D. Idempotence
+// ---------------------------------------------------------------------------
+
+scenario!(
+    "D1",
+    d1_a_lost_acknowledgement_produces_one_entity_not_two,
+    {
+        let mut world = world().await;
+        world.instance.set_behaviour(Behaviour::DropAfterCommit);
+        world.launch();
+        world.accept("A");
+
+        assert!(
+            world.instance.wait_for_intents(1, SETTLE).await,
+            "the intent reaches the instance"
+        );
+        let target = world.instance.intents()[0].intent.intent_id.clone();
+
+        world.instance.set_behaviour(Behaviour::Accept);
+        let landed = world
+            .instance
+            .wait_until(SETTLE, |i| {
+                i.intents()
+                    .iter()
+                    .any(|arrival| arrival.intent.intent_id == target && arrival.answered)
+            })
+            .await;
+        assert!(landed, "the client retries after a lost acknowledgement");
+
+        let arrivals = world.instance.intents();
+        let same: Vec<_> = arrivals
+            .iter()
+            .filter(|arrival| arrival.intent.intent_id == target)
+            .collect();
+        assert!(
+            same.len() >= 2,
+            "the retry is a resubmission of the same intent"
+        );
+        assert!(
+            same.iter().all(|arrival| arrival.intent == same[0].intent),
+            "it resubmits the same intent identity, unchanged"
+        );
+        assert_eq!(
+            world.instance.committed_entities().len(),
+            1,
+            "the instance produces one entity"
+        );
+
+        let seen = same.len();
+        assert!(
+            world
+                .instance
+                .stayed_true(QUIET, |i| i
+                    .intents()
+                    .iter()
+                    .filter(|arrival| arrival.intent.intent_id == target)
+                    .count()
+                    <= seen)
+                .await,
+            "the client accepts the returned acknowledgement as final"
+        );
+
+        Outcome::Passed
+    }
+);
+
+scenario!("D2", d2_an_intent_identity_is_generated_once, {
+    let mut world = world().await;
+    world.instance.set_behaviour(Behaviour::DropBeforeCommit);
+    world.launch();
+    world.accept("A");
+
+    assert!(
+        world.instance.wait_for_intents(2, SETTLE).await,
+        "the client retries"
+    );
+    world.restart_process();
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i.intents().len() >= 3)
+            .await,
+        "and keeps retrying across a restart"
+    );
+
+    world.instance.set_behaviour(Behaviour::Accept);
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i.intents().iter().any(|a| a.answered))
+            .await,
+        "and eventually lands"
+    );
+
+    let identities: HashSet<Vec<u8>> = world
+        .instance
+        .intents()
+        .iter()
+        .map(|arrival| arrival.intent.intent_id.clone())
+        .collect();
+    assert_eq!(
+        identities.len(),
+        1,
+        "its identity is the value it was given when it was created, across every retry and restart"
+    );
+
+    Outcome::Passed
+});
+
+scenario!(
+    "D3",
+    d3_replaying_an_intent_the_instance_already_holds_is_not_a_fault,
+    {
+        let mut world = world().await;
+        world.instance.set_behaviour(Behaviour::DropAfterCommit);
+        world.launch();
+        world.accept("A");
+
+        assert!(
+            world.instance.wait_for_intents(1, SETTLE).await,
+            "the instance takes the intent"
+        );
+        let target = world.instance.intents()[0].intent.intent_id.clone();
+        let original = world.instance.intents()[0]
+            .acknowledgement
+            .clone()
+            .expect("the instance committed, so it holds an acknowledgement");
+
+        world.instance.set_behaviour(Behaviour::Accept);
+        let landed = world
+            .instance
+            .wait_until(SETTLE, |i| {
+                i.intents()
+                    .iter()
+                    .any(|arrival| arrival.intent.intent_id == target && arrival.answered)
+            })
+            .await;
+        assert!(landed, "the client submits it again");
+
+        let arrivals = world.instance.intents();
+        let replayed = arrivals
+            .iter()
+            .rev()
+            .find(|arrival| arrival.intent.intent_id == target && arrival.answered)
+            .expect("the replay was answered");
+        assert_eq!(
+            replayed.acknowledgement.as_ref(),
+            Some(&original),
+            "the instance returns the original acknowledgement unchanged"
+        );
+
+        let signals = world.showing();
+        assert!(
+            signals.is_empty(),
+            "the client shows no fault, and it showed {signals:?}"
+        );
+        assert_eq!(
+            world.instance.committed_entities().len(),
+            1,
+            "and no duplicate"
+        );
+
+        Outcome::Passed
+    }
+);
+
+scenario!("D4", d4_replay_after_an_absence_produces_no_duplicates, {
+    let mut world = world().await;
+    world.instance.set_behaviour(Behaviour::DropAfterCommit);
+    world.launch();
+    let labels = ["A", "B", "C", "D", "E"];
+    for label in labels {
+        world.accept(label);
+    }
+
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i.committed_entities().len() == labels.len())
+            .await,
+        "some of its intents arrived, and their acknowledgements did not"
+    );
+
+    // The absence.
+    world.kill();
+    world.instance.set_behaviour(Behaviour::Accept);
+    world.launch();
+
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| {
+                let held: HashSet<_> = i
+                    .intents()
+                    .iter()
+                    .filter(|arrival| arrival.answered)
+                    .map(|arrival| arrival.intent.intent_id.clone())
+                    .collect();
+                held.len() == labels.len()
+            })
+            .await,
+        "it returns and replays its whole outbox"
+    );
+    assert_eq!(
+        world.instance.committed_entities().len(),
+        labels.len(),
+        "the household holds one of each entity"
+    );
+
+    Outcome::Passed
+});
+
+// ---------------------------------------------------------------------------
+// E. Non-blocking
+// ---------------------------------------------------------------------------
+
+scenario!("E1", e1_a_stalled_send_does_not_gate_the_interface, {
+    let mut world = world().await;
+    world.instance.set_behaviour(Behaviour::Unreachable);
+    world.launch();
+
+    let (reply, baseline) = world.act_timed(&Action::Capture {
+        label: "base".to_string(),
+        content: CaptureContent::Note {
+            title: "base".to_string(),
+            body: String::new(),
+        },
+    });
+    assert_accepted(&reply, "base");
+
+    world.instance.set_behaviour(Behaviour::Stall);
+    assert!(
+        world.instance.wait_for_intents(1, SETTLE).await,
+        "a send must be in progress"
+    );
+
+    let (reply, stalled) = world.act_timed(&Action::Capture {
+        label: "during".to_string(),
+        content: CaptureContent::Note {
+            title: "during".to_string(),
+            body: String::new(),
+        },
+    });
+    assert_accepted(&reply, "during");
+    assert!(
+        stalled <= baseline + Duration::from_millis(500),
+        "acceptance happens at the same speed as it would with nothing in flight: {baseline:?} with nothing in flight, {stalled:?} with a send hanging"
+    );
+
+    let (reply, latency) = world.act_timed(&Action::Open {
+        label: "base".to_string(),
+    });
+    let seen = expect_entity(&reply);
+    assert!(
+        seen.present && latency <= Duration::from_millis(500),
+        "nothing in the client is unavailable while the send hangs: reading took {latency:?}"
+    );
+
+    Outcome::Passed
+});
+
+scenario!("E2", e2_a_faulted_item_does_not_stop_unrelated_items, {
+    let mut world = world().await;
+    world
+        .instance
+        .set_behaviour(Behaviour::RefuseTitled(vec!["A".to_string()]));
+    world.launch();
+    world.accept("A");
+    world.accept("B");
+
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i
+                .intents()
+                .iter()
+                .any(|arrival| arrival.refused()))
+            .await,
+        "an intent for entity A must be refused"
+    );
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i
+                .intents()
+                .iter()
+                .any(|arrival| arrival.applied()
+                    && instance::title_of(&arrival.intent).as_deref() == Some("B")))
+            .await,
+        "B's intents send"
+    );
+
+    Outcome::Passed
+});
+
+scenario!(
+    "E3",
+    e3_a_faulted_item_stops_later_intents_for_the_same_entity,
+    {
+        let mut world = world().await;
+        skip_unless!(
+            world.offers().offline_edit,
+            "this client does not edit while offline"
+        );
+        world
+            .instance
+            .set_behaviour(Behaviour::RefuseTitled(vec!["A".to_string()]));
+        world.launch();
+        world.accept("A");
+        world.edit("A", "A/1");
+
+        assert!(
+            world
+                .instance
+                .wait_until(SETTLE, |i| i
+                    .intents()
+                    .iter()
+                    .any(|arrival| arrival.refused()))
+                .await,
+            "a create for entity A must be refused"
+        );
+
+        assert!(
+            world
+                .instance
+                .stayed_true(QUIET, |i| !i.intents().iter().any(
+                    |arrival| instance::title_of(&arrival.intent).as_deref() == Some("A/1")
+                ))
+                .await,
+            "the edit waiting behind the refused create is not sent"
+        );
+
+        // Retention is observed where it can be: the person's edit is still theirs.
+        // What the outbox holds internally is not a conformance concern.
+        let seen = expect_entity(&world.open("A"));
+        assert!(seen.present, "and it is retained rather than discarded");
+        assert_eq!(
+            seen.title.as_deref(),
+            Some("A/1"),
+            "the person's edit is still there"
+        );
+
+        Outcome::Passed
+    }
+);
+
+scenario!("E4", e4_a_refused_intent_is_retained_and_not_retried, {
+    let mut world = world().await;
+    world
+        .instance
+        .set_behaviour(Behaviour::RefuseTitled(vec!["A".to_string()]));
+    world.launch();
+    world.accept("A");
+
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i
+                .intents()
+                .iter()
+                .any(|arrival| arrival.refused()))
+            .await,
+        "the intent must be refused"
+    );
+    let target = world
+        .instance
+        .intents()
+        .into_iter()
+        .find(instance::IntentArrival::refused)
+        .expect("a refused arrival")
+        .intent
+        .intent_id;
+
+    assert!(
+        world
+            .instance
+            .stayed_true(QUIET, |i| i
+                .intents()
+                .iter()
+                .filter(|arrival| arrival.intent.intent_id == target)
+                .count()
+                == 1)
+            .await,
+        "the client does not resubmit a refused intent on its own"
+    );
+
+    let seen = expect_entity(&world.open("A"));
+    assert!(
+        seen.present,
+        "nothing is dropped, and nothing is errored away"
+    );
+
+    Outcome::Passed
+});
+
+// ---------------------------------------------------------------------------
+// F. Silence and signalling
+// ---------------------------------------------------------------------------
+
+scenario!("F1", f1_depth_is_never_reported, {
+    let mut world = world().await;
+    world.instance.set_behaviour(Behaviour::Unreachable);
+    world.launch();
+    for index in 0..40 {
+        world.accept(&format!("N{index}"));
+    }
+
+    let signals = world.showing();
+    assert!(
+        signals.is_empty(),
+        "no badge, count, banner, or other indication of how many is permitted, and the client showed {signals:?}"
+    );
+
+    // Including after an absence.
+    world.restart_process();
+    let signals = world.showing();
+    assert!(
+        signals.is_empty(),
+        "this holds at every depth, including after an absence: {signals:?}"
+    );
+    assert!(
+        !signals
+            .iter()
+            .any(|signal| signal.quantity == Some(40) || signal.text.contains("40")),
+        "and nothing may say forty"
+    );
+
+    Outcome::Passed
+});
+
+scenario!("F2", f2_an_unreachable_instance_is_silent, {
+    let mut world = world().await;
+    world.instance.set_behaviour(Behaviour::Unreachable);
+    world.launch();
+    for label in ["A", "B", "C"] {
+        world.accept(label);
+    }
+
+    assert!(
+        until_showing(&mut world, QUIET, <[Signal]>::is_empty).await,
+        "an unreachable instance is a wait, and nothing is signalled"
+    );
+
+    Outcome::Passed
+});
+
+scenario!("F3", f3_an_expired_session_is_silent, {
+    let mut world = world().await;
+    world.instance.set_behaviour(Behaviour::Unauthenticated);
+    world.launch();
+    for label in ["A", "B", "C"] {
+        world.accept(label);
+    }
+
+    assert!(
+        world.instance.wait_for_intents(1, SETTLE).await,
+        "the client keeps trying rather than waiting to be told"
+    );
+    let signals = world.showing();
+    assert!(
+        signals.is_empty(),
+        "an expired session is a wait, not a fault: {signals:?}"
+    );
+
+    // And it clears by the ordinary path continuing to run, with no person in
+    // it: the harness does nothing between here and the assertion.
+    world.instance.set_behaviour(Behaviour::Accept);
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i.committed_entities().len() == 3)
+            .await,
+        "the client refreshes without a person"
+    );
+    let signals = world.showing();
+    assert!(
+        signals.is_empty(),
+        "and nothing was signalled on the way: {signals:?}"
+    );
+
+    Outcome::Passed
+});
+
+scenario!("F4", f4_a_refusal_is_signalled, {
+    let mut world = world().await;
+    world
+        .instance
+        .set_behaviour(Behaviour::RefuseTitled(vec!["A".to_string()]));
+    world.launch();
+    world.accept("A");
+
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i
+                .intents()
+                .iter()
+                .any(|arrival| arrival.refused()))
+            .await,
+        "the instance must refuse the intent"
+    );
+    assert!(
+        until_showing(&mut world, SETTLE, |signals| !faults(signals).is_empty()).await,
+        "the client signals a fault"
+    );
+
+    Outcome::Passed
+});
+
+scenario!(
+    "F5",
+    f5_a_local_durability_failure_is_signalled_at_the_moment_of_the_attempt,
+    {
+        let mut world = world().await;
+        world.instance.set_behaviour(Behaviour::Accept);
+        world.make_state_unwritable();
+        world.launch();
+
+        // The moment of the attempt: the answer to the capture itself, not
+        // something that turns up later.
+        let reply = world.capture("A");
+        match &reply {
+            Reply::Refused { condition } => {
+                assert!(!condition.trim().is_empty(), "the condition is stated");
+            }
+            other => panic!(
+                "the one condition that reaches the guarantee rather than delaying it must be said plainly at the moment of the attempt; the client answered {other:?}"
+            ),
+        }
+        assert!(
+            world
+                .instance
+                .stayed_true(QUIET, |i| i.intents().is_empty())
+                .await,
+            "nothing was accepted, so nothing may send"
+        );
+
+        Outcome::Passed
+    }
+);
+
+scenario!("F6", f6_an_unrecognised_condition_is_signalled, {
+    let mut world = world().await;
+    world
+        .instance
+        .set_behaviour(Behaviour::UnrecognisedCondition);
+    world.launch();
+    world.accept("A");
+
+    assert!(
+        world.instance.wait_for_intents(1, SETTLE).await,
+        "the client must reach the instance"
+    );
+    assert!(
+        until_showing(&mut world, SETTLE, |signals| !faults(signals).is_empty()).await,
+        "a condition the client cannot classify as self clearing is treated as a fault and signalled"
+    );
+
+    Outcome::Passed
+});
+
+scenario!(
+    "F7",
+    f7_a_signal_may_quantify_the_fault_and_never_the_backlog,
+    {
+        let mut world = world().await;
+        let refused: Vec<String> = (0..3).map(|index| format!("R{index}")).collect();
+        world
+            .instance
+            .set_behaviour(Behaviour::RefuseTitled(refused.clone()));
+        world.launch();
+        for label in &refused {
+            world.accept(label);
+        }
+        assert!(
+            world
+                .instance
+                .wait_until(SETTLE, |i| i
+                    .intents()
+                    .iter()
+                    .filter(|a| a.refused())
+                    .count()
+                    == 3)
+                .await,
+            "three intents were refused"
+        );
+
+        // And forty are waiting.
+        world.instance.set_behaviour(Behaviour::Unreachable);
+        for index in 0..40 {
+            world.accept(&format!("W{index}"));
+        }
+
+        let signals = world.showing();
+        assert!(
+            !signals.is_empty(),
+            "the refusals are still a fault, and a fault is signalled"
+        );
+        for signal in &signals {
+            assert!(
+                matches!(signal.quantity, None | Some(3)),
+                "a signal may say three and no other number, and this one says {:?}",
+                signal.quantity
+            );
+            // Only checkable by convention: a person facing statement is text, so
+            // the harness can look for the forbidden number in it and no more.
+            assert!(
+                !signal.text.contains("40") && !signal.text.contains("43"),
+                "and nothing may say forty: {}",
+                signal.text
+            );
+        }
+
+        Outcome::Passed
+    }
+);
+
+scenario!("F8", f8_a_signal_clears_when_its_condition_clears, {
+    let mut world = world().await;
+    world
+        .instance
+        .set_behaviour(Behaviour::UnrecognisedCondition);
+    world.launch();
+    world.accept("A");
+
+    assert!(
+        until_showing(&mut world, SETTLE, |signals| !faults(signals).is_empty()).await,
+        "a fault must be signalled first"
+    );
+
+    world.instance.set_behaviour(Behaviour::Accept);
+    // Nothing here acknowledges or dismisses anything. There is no action in
+    // the harness's vocabulary that could.
+    assert!(
+        until_showing(&mut world, SETTLE, |signals| faults(signals).is_empty()).await,
+        "the signal goes when its condition ceases, with nothing for the person to dismiss"
+    );
+
+    Outcome::Passed
+});
+
+scenario!("F9", f9_a_signal_does_not_escalate_repeat_or_age, {
+    let mut world = world().await;
+    world
+        .instance
+        .set_behaviour(Behaviour::UnrecognisedCondition);
+    world.launch();
+    world.accept("A");
+
+    assert!(
+        until_showing(&mut world, SETTLE, |signals| faults(signals).len() == 1).await,
+        "a fault must be signalled first"
+    );
+    let first = world.showing();
+    world.drain_events();
+
+    // Three weeks, approximated: long enough for many retry cycles.
+    tokio::time::sleep(LONG_ABSENCE).await;
+
+    let later = world.showing();
+    assert_eq!(
+        later.len(),
+        1,
+        "when the person returns they find one current statement, and found {later:?}"
+    );
+    assert_eq!(
+        later, first,
+        "nothing says how long it has been true, and the statement did not escalate"
+    );
+    let events = world.drain_events();
+    assert!(
+        events.is_empty(),
+        "and nothing has repeated in the interval: {events:?}"
+    );
+
+    Outcome::Passed
+});
+
+// ---------------------------------------------------------------------------
+// G. Outcomes the instance returns
+// ---------------------------------------------------------------------------
+
+scenario!(
+    "G1",
+    g1_partial_success_leaves_the_successful_part_captured,
+    {
+        let mut world = world().await;
+        world.instance.set_behaviour(Behaviour::Unreachable);
+        world.launch();
+        for index in 0..200 {
+            world.accept(&format!("N{index}"));
+        }
+
+        world.instance.set_behaviour(Behaviour::RefuseNth(100));
+        assert!(
+            world
+                .instance
+                .wait_until(SETTLE, |i| i.intents().len() >= 200)
+                .await,
+            "two hundred intents are submitted"
+        );
+
+        let arrivals = world.instance.intents();
+        let applied: Vec<_> = arrivals
+            .iter()
+            .filter(|arrival| arrival.applied())
+            .collect();
+        assert!(
+            applied.len() >= 99,
+            "the hundredth is refused and ninety nine are applied; {} were",
+            applied.len()
+        );
+        assert_eq!(
+            arrivals.iter().filter(|arrival| arrival.refused()).count(),
+            1,
+            "one refusal, and the submission is not treated as one unit"
+        );
+
+        let applied_ids: Vec<Vec<u8>> = applied
+            .iter()
+            .map(|arrival| arrival.intent.intent_id.clone())
+            .collect();
+        let unique: HashSet<Vec<u8>> = applied_ids.iter().cloned().collect();
+        assert_eq!(
+            unique.len(),
+            applied_ids.len(),
+            "the client handles each acknowledgement on its own terms: an applied intent is not sent again"
+        );
+
+        Outcome::Passed
+    }
+);
+
+scenario!("G2", g2_a_retained_conflict_is_not_a_failure, {
+    let mut world = world().await;
+    skip_unless!(
+        world.offers().offline_edit,
+        "this client does not edit while offline"
+    );
+    world.instance.set_behaviour(Behaviour::ApplyWithConflict);
+    world.launch();
+    world.accept("A");
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i
+                .intents()
+                .iter()
+                .any(|a| a.applied() && a.answered))
+            .await,
+        "the create must land before there is anything to edit"
+    );
+
+    world.edit("A", "A/1");
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i
+                .intents()
+                .iter()
+                .any(|arrival| arrival.answered && arrival.conflict().is_some()))
+            .await,
+        "an edit is applied and its acknowledgement carries a retained conflict"
+    );
+
+    let target = world
+        .instance
+        .intents()
+        .into_iter()
+        .find(|arrival| arrival.conflict().is_some())
+        .expect("the conflicted acknowledgement")
+        .intent
+        .intent_id;
+
+    let signals = world.showing();
+    assert!(
+        signals.is_empty(),
+        "nothing is signalled as a fault, and the client showed {signals:?}"
+    );
+    assert!(
+        world
+            .instance
+            .stayed_true(QUIET, |i| i
+                .intents()
+                .iter()
+                .filter(|arrival| arrival.intent.intent_id == target)
+                .count()
+                == 1)
+            .await,
+        "the client treats the intent as done and nothing is retried"
+    );
+
+    Outcome::Passed
+});
+
+scenario!("G3", g3_a_recreation_is_carried_not_lost, {
+    let mut world = world().await;
+    skip_unless!(
+        world.offers().offline_edit,
+        "this client does not edit while offline"
+    );
+    world.instance.set_behaviour(Behaviour::RecreateOnEdit);
+    world.launch();
+    world.accept("A");
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i.intents().iter().any(|a| a.applied()))
+            .await,
+        "the create must land before there is anything to edit"
+    );
+    let original = expect_entity(&world.open("A")).entity_id;
+
+    world.edit("A", "A/1");
+    assert!(
+        world
+            .instance
+            .wait_until(SETTLE, |i| i
+                .intents()
+                .iter()
+                .any(|a| a.recreated().is_some()))
+            .await,
+        "the acknowledgement names a new identity"
+    );
+    let recreated = world
+        .instance
+        .intents()
+        .into_iter()
+        .find_map(|arrival| arrival.recreated())
+        .expect("a recreation");
+    assert_ne!(
+        recreated.new_entity_id, original,
+        "the new identity is a new identity"
+    );
+
+    let adopted = recreated.new_entity_id.clone();
+    assert!(
+        until_seen(&mut world, "A", SETTLE, |seen| seen.entity_id == adopted).await,
+        "the client's local entity adopts the new identity"
+    );
+    let seen = expect_entity(&world.open("A"));
+    assert!(seen.present, "and the person's work is present under it");
+    assert_eq!(seen.title.as_deref(), Some("A/1"), "all of it");
+
+    let signals = world.showing();
+    assert!(
+        signals.is_empty(),
+        "this is not signalled as a fault, because nothing was lost: {signals:?}"
+    );
+
+    Outcome::Passed
+});
+
+scenario!("G4", g4_a_refusal_reveals_nothing_about_existence, {
+    async fn signals_for(detail: &str) -> Vec<Signal> {
+        let mut world = World::new(client_under_test()).await;
+        world.instance.set_behaviour(Behaviour::RefuseNotAvailable {
+            detail: detail.to_string(),
+        });
+        world.launch();
+        world.accept("A");
+        assert!(
+            world
+                .instance
+                .wait_until(SETTLE, |i| i
+                    .intents()
+                    .iter()
+                    .any(instance::IntentArrival::refused))
+                .await,
+            "the intent must be refused as not available"
+        );
+        assert!(
+            until_showing(&mut world, SETTLE, |signals| !signals.is_empty()).await,
+            "the refusal must reach the person"
+        );
+        world.showing()
+    }
+
+    // The detail is free text for a person reading a log and is never parsed
+    // by a client. Nothing anywhere distinguishes absent from invisible.
+    let absent = signals_for("entity does not exist").await;
+    let invisible = signals_for("entity is not visible to this member").await;
+    assert_eq!(
+        absent, invisible,
+        "the client shows the same thing whether the entity is absent or invisible to this member"
+    );
+
+    Outcome::Passed
+});

--- a/mise.toml
+++ b/mise.toml
@@ -7,3 +7,14 @@ rust-analyzer = "latest"
 [tasks.test]
 description = "Bring up Postgres and run the workspace test suite"
 run = "docker compose up -d --wait && cargo test --workspace"
+
+# Expected to fail, on purpose, until Wave 4.1 writes the outbox. The scenarios
+# are gated off in the default suite so `main` stays mergeable; this is how the
+# red is looked at. See crates/altair-conformance/README.md.
+#
+# --nocapture so a skipped scenario is visible rather than silently green, and
+# --test-threads=1 because several scenarios measure how long the client took
+# to answer.
+[tasks.conformance]
+description = "Run the outbox conformance scenarios (red until Wave 4.1)"
+run = "cargo test -p altair-conformance --features run-conformance --test scenarios -- --nocapture --test-threads=1"

--- a/mise.toml
+++ b/mise.toml
@@ -15,6 +15,24 @@ run = "docker compose up -d --wait && cargo test --workspace"
 # --nocapture so a skipped scenario is visible rather than silently green, and
 # --test-threads=1 because several scenarios measure how long the client took
 # to answer.
+#
+# libtest has no third verdict, so a scenario a client legitimately skips is
+# reported "ok" alongside one that passed. The ledger is how the two are told
+# apart: every scenario that did not fail writes a line to it saying which it
+# was, and the summary at the end is printed whatever the exit status.
 [tasks.conformance]
 description = "Run the outbox conformance scenarios (red until Wave 4.1)"
-run = "cargo test -p altair-conformance --features run-conformance --test scenarios -- --nocapture --test-threads=1"
+run = """
+# Absolute: cargo runs an integration test with the package directory as its
+# working directory, not the workspace root.
+ledger="$PWD/target/conformance-outcomes.tsv"
+mkdir -p "$(dirname "$ledger")"
+rm -f "$ledger"
+status=0
+ALTAIR_CONFORMANCE_LEDGER="$ledger" cargo test -p altair-conformance \
+  --features run-conformance --test scenarios -- --nocapture --test-threads=1 || status=$?
+echo
+echo "--- scenarios that did not fail; anything absent here failed ---"
+sort "$ledger" 2>/dev/null || echo "(none)"
+exit $status
+"""


### PR DESCRIPTION
Wave 1, lane 1.5 — `conformance/scenarios.md` made executable. **A red suite is the deliverable.**

## What this is and why it is failing on purpose

DR-006's obligation is that the scenarios exist before the *second* outbox implementation, not after the first two disagree. They may as well exist before the first. So: 34 scenarios, all executing, all failing, against a stub client that implements nothing.

As Wave 4.1 lands behaviour they turn green **one at a time**, and that gradient is the whole value. Anything that makes a scenario pass without an outbox behind it destroys it — which is why the crate README opens with "do not delete it, and do not 'fix' it."

## Resolving the CI tension

A red suite inside `cargo test --workspace` would make `main` un-mergeable, against the repo's own rule that `main` always works. Resolution:

- Scenarios sit behind a **`run-conformance` feature, off by default** — `cargo test --workspace` stays green.
- **`mise run conformance`** runs the red on purpose, one command away.
- A CI job named **`conformance (red until Wave 4.1)`**, `continue-on-error: true`, so the red is visible on every PR without blocking anything. It reuses the shared toolchain cache pattern rather than inventing a third one.

**Beyond the brief, and it closes a real hole:** libtest has two verdicts, so a scenario a client *legitimately skips* reports `ok` beside one that genuinely passed. That is precisely the silently-green failure this suite exists to prevent. Every non-failing scenario now writes `id ⇥ PASSED|SKIPPED ⇥ test ⇥ why` to a ledger, printed after the run whatever the exit status:

```
--- scenarios that did not fail; anything absent here failed ---
A3	SKIPPED	a3_capture_with_no_household_binding_is_accepted	this client requires binding before capture, which is conforming
B5	SKIPPED	b5_a_body_is_durable_before_its_capture_is_accepted	this client does not capture files
```

## 34 scenarios, not 35 — my brief was wrong

I briefed this lane as 35 scenarios. The document has **34**. The lane caught it and pinned it:

```
$ grep -cE '^\*\*[A-G][0-9]+\.' conformance/scenarios.md
34
```

`tests/coverage.rs` asserts the document contains exactly 34 and that the id sets on both sides are **equal**, so an added scenario turns the *default* suite red until it is expressed. That is the right place for this check — it fails loudly rather than drifting.

## The client-under-test trait — the most consequential thing here

This is what Wave 4.1 codes against:

```rust
pub trait ClientUnderTest: Send + Sync {
    fn name(&self) -> &str;
    fn offers(&self) -> Offers;
    fn launch(&self, environment: &ClientEnvironment)
        -> Result<Box<dyn ClientProcess>, ClientError>;
}

pub trait ClientProcess: Send {
    fn act(&mut self, action: &Action) -> Result<Reply, ClientError>;
    fn kill(&mut self);          // SIGKILL. Idempotent.
}
```

**No method reads the client's storage or its queue.** The scenarios are explicit that *"what the outbox holds internally, how it stores it, and what it is called are not conformance concerns"* — so the trait cannot express it. `Reply::Entity` carries `entity_id`, which is public identity (client-assigned, on the wire, the subject of G3), not internal state.

Wave 4.1 supplies an adapter binary and changes **one function** in `tests/scenarios.rs`.

## The fake instance

One setter, one getter, and a flat enum — `Accept`, `Unreachable`, `Unauthenticated`, `Stall`, `DropBeforeCommit`, `DropAfterCommit`, `RefuseTitled`, `RefuseNth`, `RefuseNotAvailable`, `ApplyWithConflict`, `RecreateOnEdit`, `UnrecognisedCondition`. No builder, no generics, no callbacks — the plan asked that the Kotlin mirror be *transcription rather than reinterpretation*, and a flat state machine transcribes.

**Two behaviours are socket facts, not handler results**, so the server sits behind a byte-copying TCP proxy: `Unreachable` closes on accept, and `DropAfterCommit` commits the intent *and* its acknowledgement, then tears the connection down before the answer can leave. D1's entire subject is "the instance committed and the answer never arrived," and a `Status::unavailable` would not have been that.

`tests/harness.rs` — 14 tests, **ungated and green** — proves each control behaviour works, so a red scenario is never ambiguously about the harness.

## Kill and restart, and how B2 differs from B1

Every client gets two directories: `state_dir` (durable) and `runtime_dir` (ephemeral). **B1** kills and relaunches with both intact. **B2** kills, *wipes `runtime_dir`*, and relaunches — so a client keeping its outbox in the ephemeral directory passes B1 and fails B2.

Fidelity cost, stated rather than hidden: a real reboot also empties the page cache, so a client writing without `fsync` would survive a kill and lose data on restart. Dropping caches needs root, so that half is **not** exercised. What is exercised is the loss of everything ephemeral.

**B4** kills *at the moment acceptance is shown* — `capture()` returns the instant the acceptance line is read, and `kill()` is the very next statement, before any assertion. Repeated 10 times on a fresh world, per the scenario's "on repeated runs."

## Verification

Rebased onto `a7033c1`. Both invariants checked by the orchestrator:

```
$ cargo test --workspace                       # GREEN
  tests/coverage.rs  2 passed    tests/harness.rs  14 passed
  tests/scenarios.rs 0 passed    (feature off: nothing compiled in)

$ cargo test -p altair-conformance --features run-conformance --test scenarios
  test result: FAILED. 0 passed; 34 failed
```

I spot-checked that failures are scenario-specific rather than one shared stub:

```
a4_… : local storage cannot hold the capture, so the client must refuse and
       state why; it answered Nothing
f5_… : the one condition that reaches the guarantee rather than delaying it
       must be said plainly at the moment of the attempt
```

Most fail at acceptance, which is correct — acceptance is the first thing every scenario needs, and it is the first thing 4.1 will implement.

## Findings against `conformance/scenarios.md` — reported, not fixed

Documents are gated, and these are amendments for you to make or reject:

1. **G1's arithmetic.** "Two hundred intents… the hundredth is refused. Then ninety nine are applied." With one refusal out of 200, **199** should apply — 99 before and 100 after. The proto carries the same phrasing, so it is at least consistent, but as written it either reads loosely or implies the client stops at the refusal, which contradicts E2. The suite asserts the defensible reading: at least 99 applied, exactly one refused, nothing applied is resubmitted.
2. **A3's "with no author" is not observable at the instance boundary.** `CreateEntity` carries no author field — `author_member_id` lives on `Entity`, set by the instance from the token. So it can only be checked as *nothing sends before binding*. If the intent is that an unbound client may send and be attributed later, the two readings differ observably.
3. **E4 and F8 are in tension for a refusal.** E4 retains and never retries; F8 clears a signal when its condition clears. A refusal's condition never clears without a person, and no affordance for that is named anywhere. F8 is therefore only testable against a non-refusal fault. This will bite Wave 4.2, not 4.1.
4. **F1's "three week absence" and F9's "three weeks" are untestable as literals** — compressed to a 2s window covering many retry cycles. A real duration would need an injectable clock.
5. **G2's "removes it from the outbox" names an internal.** The boundary-visible consequence is "nothing is retried," which is what is asserted.
6. **The `**Xn.` heading convention is now load-bearing** — `tests/coverage.rs` parses it. Reformatting a scenario heading breaks a green test.

## Left undone

- **The outbox.** Deliberately, not a line.
- The Kotlin harness (Android time, per DR-006); the Rust one is shaped for transcription.
- `GetBody`/`Query`/`Changes`/`GetHealth` return `unimplemented` — no scenario reaches them.
- **Non-Unix**: `make_state_unwritable` is `#[cfg(unix)]`, so A4 and F5 will not compile on Windows.
- **A4/F5 under root**: `chmod 0o500` does not stop root, so those two would fail-to-fail if CI ever ran as root. Unguarded; noted.
