### PR TITLE
Let the review publish what it produces

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,6 +53,11 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          # No `claude_args` allow-list. Restricting it to the single inline
+          # comment tool is what silently discarded every review this workflow
+          # ran: the plugin's own delivery path needs more than that one tool,
+          # so the review completed and every attempt to publish it was denied.
+          # The job holds `contents: read`, so the widest thing it can do here
+          # is comment — which is the entire point of running it.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
Follow-up to #5. That PR fixed a real bug and did not fix the symptom.

## What #5 got right, and what it missed

#5 raised the job to `pull-requests: write`, reasoning that a review told to post inline comments cannot do so with a read-only token. That was correct.

It was also not sufficient, and I can now prove both halves. From the review run on #9:

```
GITHUB_TOKEN Permissions
  Contents: read
  Issues: read
  Metadata: read
  PullRequests: write        ← #5's fix, in effect
...
"permission_denials_count": 1,  "num_turns": 4,  "is_error": false
```

Comments on #9: **zero.**

## The actual cause

`permission_denials_count` is **Claude Code's own permission gate**, not a GitHub 403. So the token was never the binding constraint. This line was:

```yaml
claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
```

It permits exactly one tool. The `/code-review` plugin's delivery path needs more than that one, gets denied, and stops.

The earlier runs show the same shape at full size. On #6, before #5 landed:

```
"duration_ms": 175629,  "num_turns": 15,  "total_cost_usd": 1.608
"permission_denials_count": 11,  "is_error": false
```

Fifteen turns, $1.61, **eleven** denied attempts to publish, and a green check. After #5 it fails faster — 4 turns, $0.17, 1 denial — because it gives up earlier, but it still publishes nothing.

**The green check is the worse half of this bug.** A review that does the work, throws it away, and reports success is a check that trains you to stop reading it.

## The fix

Remove the allow-list rather than guessing at tool names. I do not know what the plugin reaches for — the run log names the configured tool but not the denied ones — and enumerating a guess would likely reproduce this bug one tool further along.

The safety argument for removing it is that the restriction was never the thing keeping this job safe:

- `contents: read` — it cannot push code, amend a branch, or alter the workflow.
- `pull-requests: write` — the widest thing available to it is commenting on the PR, which is the job's entire purpose.
- #5's actor guards still prevent the review from re-triggering `claude.yml`.

## Verification

Config-only; the workflow parses. **Whether reviews actually appear is observable on the next pull request and not before** — same as #5, and stated for the same reason: I would rather flag an unverified claim than imply I tested something I could not.

If the next PR still shows `permission_denials_count > 0` and no comments, the cause is inside the plugin rather than this workflow, and that is a different investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoSpfLpxPCxkYVeP2Q8M4z