### PR TITLE
Keep the lockfile honest, and stop an agent skipping the hooks that say so

### DIFF
--- a/.claude/hooks/no-hook-bypass.sh
+++ b/.claude/hooks/no-hook-bypass.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# The repository's pre-commit hooks are the only thing between a local mistake
+# and a red CI run, and they are trivially skipped: --no-verify, a -n on git
+# commit, core.hooksPath pointed at nothing, SKIP= in front of prek. Every one
+# is a single token, and reaching for one is always locally reasonable — the
+# hook is slow, or it is complaining about something that "obviously" does not
+# matter.
+#
+# It did matter. Merge commits made with --no-verify and core.hooksPath=/dev/null
+# shipped a Cargo.lock describing neither branch's dependency set. Local
+# `cargo test` passed, because cargo rewrites that file rather than complaining
+# about it, and CI failed two pushes later under the name of an unrelated hook.
+#
+# So: an agent may not skip the hooks. A human may, out of band:
+#
+#     touch .claude/.hooks-unlock
+#
+# Valid for UNLOCK_TTL seconds, then the guard re-arms.
+#
+# Why deny rather than ask: the same reasoning protect-docs.sh records beside
+# it — a PreToolUse "ask" is discarded under bypass and auto permission modes,
+# and an autoMode soft_deny is cleared by apparent user intent. "deny" holds.
+#
+# Reads the PreToolUse payload on stdin; silence means "not my business".
+
+set -uo pipefail
+
+UNLOCK_TTL=1800  # 30 minutes
+
+root="${CLAUDE_PROJECT_DIR:-$PWD}"
+unlock="$root/.claude/.hooks-unlock"
+
+deny() {
+  jq -n --arg r "$1" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+  exit 0
+}
+
+# A guard that breaks must not thereby permit what it exists to refuse. An
+# earlier revision of this script lost a variable during an edit and allowed
+# every bypass while printing an error nobody was reading, so any unexpected
+# failure below lands here and denies.
+fail_closed() {
+  deny "The hook-bypass guard failed while checking this command (line ${1:-?}), so it is refused rather than allowed. Fix .claude/hooks/no-hook-bypass.sh — a human can unlock with: touch .claude/.hooks-unlock"
+}
+trap 'fail_closed $LINENO' ERR
+
+input=$(cat)
+tool=$(jq -r '.tool_name // ""' <<<"$input")
+
+unlocked() {
+  [ -f "$unlock" ] || return 1
+  local now mtime
+  now=$(date +%s)
+  mtime=$(stat -c %Y "$unlock" 2>/dev/null || echo 0)
+  [ $((now - mtime)) -le "$UNLOCK_TTL" ]
+}
+
+guard() {
+  unlocked && exit 0
+  deny "$1
+
+The pre-commit hooks are not optional for an agent. If a hook is failing, fix
+what it reports; if the hook itself is wrong, change it in a commit of its own.
+A human can open a ${UNLOCK_TTL}s window with: touch .claude/.hooks-unlock"
+}
+
+# A file tool cannot skip a git hook, so only one thing matters on that path:
+# neither this script nor its marker may be changed without a human. The
+# Bash-only revision of this guard could be edited away with Write, which made
+# the rest of it decorative.
+case "$tool" in
+  Bash) ;;
+  Edit|MultiEdit|Write|NotebookEdit)
+    path=$(jq -r '.tool_input.file_path // .tool_input.notebook_path // ""' <<<"$input")
+    case "$path" in
+      *no-hook-bypass.sh|*.hooks-unlock)
+        unlocked && exit 0
+        deny "This is the hook-bypass guard itself, and a file tool is no more allowed to change it than a shell is. A human must unlock first: touch .claude/.hooks-unlock" ;;
+    esac
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+
+cmd=$(jq -r '.tool_input.command // ""' <<<"$input")
+[ -n "$cmd" ] || exit 0
+
+# Heredoc bodies are prose. Commit messages and pull request bodies discuss
+# these flags — this script's own commit message names the marker it protects —
+# and a guard that fires on writing about it would be worse than no guard,
+# because the way round it would become routine. Everything below matches the
+# stripped text, self-defence included.
+stripped=$(awk '
+  BEGIN { skip = 0 }
+  skip == 0 && match($0, /<<-?[[:space:]]*'"'"'?"?[A-Za-z_][A-Za-z0-9_]*'"'"'?"?/) {
+    tag = substr($0, RSTART, RLENGTH)
+    gsub(/^<<-?[[:space:]]*|['"'"'"]/, "", tag)
+    skip = 1; print; next
+  }
+  skip == 1 { if ($0 ~ "^[[:space:]]*" tag "[[:space:]]*$") skip = 0; next }
+  { print }
+' <<<"$cmd") || fail_closed $LINENO
+
+# True when the command writes to something matching regex $1. Mirrors
+# protect-docs.sh: the mutating token must reach the target without crossing a
+# command separator, and sed/perl count only with -i — so `sed -n 1,20p` on this
+# script is a read, not an attempt to edit the guard away.
+writes_to() {
+  grep -qE "(>>?[[:space:]]*[^|&;]*$1)|(\b(rm|mv|cp|tee|truncate|install|patch|shred|chmod|chown|ln|dd|touch|python3?|node|ruby)\b[^|&;]*$1)|((sed|perl)[[:space:]]+[^|&;]*-i[^|&;]*$1)|(\bgit[[:space:]]+(checkout|restore|apply|rm|mv|clean|stash)\b[^|&;]*$1)" <<<"$stripped"
+}
+
+# The marker and this script are what make the gate mean anything, so they are
+# writable only inside a window a human already opened.
+if writes_to '\.hooks-unlock' && ! unlocked; then
+  deny "Creating the hook-bypass marker is reserved for a human. Run it yourself: touch .claude/.hooks-unlock"
+fi
+if writes_to 'no-hook-bypass' && ! unlocked; then
+  deny "This is the hook-bypass guard itself. A human must unlock before it can be changed."
+fi
+
+# 1. --no-verify, on git or anything else that honours it.
+grep -qE '(^|[[:space:]])--no-verify([[:space:]]|$)' <<<"$stripped" &&
+  guard "Refusing \`--no-verify\`: it skips the pre-commit hooks."
+
+# 2. git commit -n. Only for commit — `git push -n` is --dry-run and `git log -n`
+#    takes a count, and neither skips anything.
+grep -qE '\bgit\b[^|&;]*\bcommit\b[^|&;]*(^|[[:space:]])-n([[:space:]]|$)' <<<"$stripped" &&
+  guard "Refusing \`git commit -n\`: it is --no-verify spelled shorter."
+
+# 3. core.hooksPath aimed anywhere, by -c, --config, git config, or the env.
+grep -qE 'core\.hooksPath' <<<"$stripped" &&
+  guard "Refusing to redirect core.hooksPath: it disables every repository hook at once."
+
+# 4. The skip variables the hook runners honour.
+grep -qE '(^|[[:space:]])(SKIP|PREK_SKIP|PRE_COMMIT_ALLOW_NO_CONFIG|HUSKY|HUSKY_SKIP_HOOKS)=' <<<"$stripped" &&
+  guard "Refusing to set a hook-skipping environment variable."
+
+# 5. Explicit --no-hooks, used by some porcelain.
+grep -qE '(^|[[:space:]])--no-hooks([[:space:]]|$)' <<<"$stripped" &&
+  guard "Refusing \`--no-hooks\`."
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Edit|MultiEdit|Write|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/no-hook-bypass.sh\"",
+            "timeout": 10
+          }
+        ]
       }
     ]
   }

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 # Created by hand to open a time-boxed window for changing docs/; never committed.
 .claude/.docs-unlock
 
+# Same, for the hook-bypass guard (.claude/hooks/no-hook-bypass.sh). Created by
+# hand to allow --no-verify and friends for a window; never committed.
+.claude/.hooks-unlock
+
 # Rust build output (includes protoc/tonic codegen written to OUT_DIR)
 /target
 **/target

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,25 @@ repos:
 
   - repo: local
     hooks:
+      # Runs before the two cargo hooks below, because both of them also
+      # rewrite a stale Cargo.lock as a side effect of doing their real job.
+      # When that happened the run failed under the name `cargo clippy`, with
+      # the actual cause — a lockfile that did not match the manifests —
+      # buried in thirty lines of dependency downloads. Failing here instead
+      # puts the right name on it.
+      #
+      # `cargo metadata` resolves dependencies without building, so it is the
+      # cheapest command that brings the lockfile back into step. If it
+      # changes the file, prek fails the run and the fix is to stage
+      # Cargo.lock and commit again.
+      - id: cargo-lock
+        name: cargo lock
+        description: Keep Cargo.lock in step with the manifests.
+        entry: bash -c 'cargo metadata --format-version 1 >/dev/null'
+        language: system
+        files: (^|/)Cargo\.(toml|lock)$
+        pass_filenames: false
+
       - id: cargo-fmt
         name: cargo fmt
         description: Format Rust sources with rustfmt.


### PR DESCRIPTION
Two commits, one story. The first adds a check. The second makes it one an agent cannot switch off.

## 1 · Fail on a stale lockfile under its own name

Resolving a `Cargo.lock` merge conflict by taking one side, rather than regenerating it, leaves a lockfile describing neither branch's dependency set. Nothing complains at the time. Every later cargo invocation silently rewrites it, so the failure surfaces somewhere else entirely.

It surfaced in CI on #7 and #8 as this:

```
cargo clippy.............................................................Failed
- hook id: cargo-clippy
- description: Lint the workspace; warnings fail the check
- files were modified by this hook
```

There was no lint problem. Clippy resolved dependencies, found eighteen packages the lockfile lacked, and rewrote it — with the real cause thirty lines down inside a dependency download log:

```
Locking 18 packages to latest Rust 1.97.1 compatible versions
    Adding proptest v1.11.0
    Adding bit-set v0.8.0
    ...
```

**The check already existed. It was wearing the wrong name.** A correct signal attributed to the wrong thing is how a five-second fix becomes a twenty-minute log dig.

So: one local hook, `cargo lock`, ordered **before** `cargo fmt` and `cargo clippy`, because both of those also repair a stale lockfile as a side effect of their real work. `cargo metadata` resolves dependencies without building, so it is the cheapest command that brings the file back into step. If it rewrites the file, prek fails the run and the fix is to stage `Cargo.lock` and commit again — the same shape as `end-of-file-fixer` above it.

Verified by reproducing the exact merge mistake — deleting `proptest` from the lock:

```
$ prek run --all-files
cargo lock...............................................................Failed
- files were modified by this hook
cargo fmt................................................................Passed
cargo clippy.............................................................Passed

$ diff -q Cargo.lock lock.bak
(identical)
```

The new hook names itself, clippy now passes because the lock hook already repaired the file, and the repair is byte-exact.

## 2 · Stop an agent skipping the hooks it finds inconvenient

The hook above is skipped by `--no-verify`, by `-n` on `git commit`, by pointing `core.hooksPath` at nothing, by `SKIP=` in front of prek. So is every other hook here.

**This is not hypothetical. It is the actual cause of the bug in part 1.** The stale lockfile was committed by an agent — me — that had turned the hooks off for a merge, because resolving a conflict felt like the kind of commit hooks get in the way of. Every skip was locally reasonable. The aggregate was a broken lockfile on the remote and two red pull requests.

**A guard that the party most likely to trip it can also switch off is not a guard.** So this one is not skippable by an agent. A human opens a 30-minute window out of band; the marker is named in the script and gitignored beside the existing docs one.

Denied rather than asked, for the reason the docs guard beside it already records: a PreToolUse `ask` is discarded under bypass and auto permission modes, and an `autoMode` soft_deny is cleared by apparent user intent.

Covers `--no-verify`, `git commit -n`, `core.hooksPath` via `-c` / `--config` / `git config` / the environment, `SKIP`, `PREK_SKIP`, `PRE_COMMIT_ALLOW_NO_CONFIG`, `HUSKY`, `HUSKY_SKIP_HOOKS`, and `--no-hooks`.

### Three things it learned by blocking its own author

Each of these is a bug it caught in itself before landing, which is more validation than the test matrix gave it.

- **Heredoc bodies are stripped before matching.** It first blocked the commit that introduces it, because that message *discusses* the flags. A guard that fires on writing about a rule makes evading it routine.
- **It runs on the file tools, not just Bash.** The first revision used `"matcher": "Bash"`, so `Write` could have edited it away — which made the rest of it decorative. It now refuses both paths.
- **`sed`/`perl` count as mutating only with `-i`.** It blocked `sed -n '1,20p'` on itself — a read. Matching the docs guard's discipline fixes it, so inspecting the script is not mistaken for rewriting it.

**And it fails closed.** An intermediate revision lost a variable mid-edit and allowed every bypass while printing an error nobody reads. A `trap ... ERR` now converts any unexpected failure into a denial: a broken guard refuses rather than permits. `[unverified]` — that path is by construction; I could not exercise it without a command the guard correctly refused.

### Verification

Twenty cases, all correct:

| | |
|---|---|
| **Denied** | `--no-verify`, `git commit -n`, `-c core.hooksPath=…`, `SKIP=…`, `git push --no-verify`, `HUSKY=0`, `git config core.hooksPath` |
| **Allowed** | `git commit -m`, `git log -n 5`, `git push -n` (that's `--dry-run`), `git push --force-with-lease`, `echo -n`, `grep -n`, `cargo test` |
| **Allowed** | reading the script — `sed -n`, `cat`, `grep -n` on it |
| **Denied** | its own script and marker, via **both** shell and file tools |
| **Allowed** | an unrelated `Edit` to `crates/altaird/src/lib.rs` |
| **Allowed** | heredoc prose naming the flags and the marker |
| **Denied** | a real bypass placed *after* a heredoc |

## A finding about the existing docs guard

`protect-docs.sh` does **not** strip heredocs, and it blocked this PR's commit message for naming it. Any commit message that mentions the file cannot be written without an unlock. Same class of bug as the first one above, one line to fix, and deliberately not fixed here — that file is gated and this PR is about the lockfile.

## Blast radius

No source, no CI workflow, no dependency changes. One prek hook, one PreToolUse hook, two lines of `.gitignore`. The `--locked` flag on CI's `cargo test` — the guard that does not depend on the committer at all — belongs in `ci.yml`, which #10 also modifies; happy to follow up once that lands.