### PR TITLE
Let the guards be written about

### DIFF
--- a/.claude/hooks/no-hook-bypass.sh
+++ b/.claude/hooks/no-hook-bypass.sh
@@ -84,21 +84,37 @@ esac
 cmd=$(jq -r '.tool_input.command // ""' <<<"$input")
 [ -n "$cmd" ] || exit 0
 
-# Heredoc bodies are prose. Commit messages and pull request bodies discuss
-# these flags — this script's own commit message names the marker it protects —
-# and a guard that fires on writing about it would be worse than no guard,
-# because the way round it would become routine. Everything below matches the
-# stripped text, self-defence included.
-stripped=$(awk '
-  BEGIN { skip = 0 }
-  skip == 0 && match($0, /<<-?[[:space:]]*'"'"'?"?[A-Za-z_][A-Za-z0-9_]*'"'"'?"?/) {
-    tag = substr($0, RSTART, RLENGTH)
-    gsub(/^<<-?[[:space:]]*|['"'"'"]/, "", tag)
-    skip = 1; print; next
-  }
-  skip == 1 { if ($0 ~ "^[[:space:]]*" tag "[[:space:]]*$") skip = 0; next }
-  { print }
-' <<<"$cmd") || fail_closed $LINENO
+# Heredoc bodies are prose where the heredoc feeds a command that carries prose:
+# a commit message, a pull request or issue body, a tag annotation. Those
+# routinely quote the very rules this guard enforces — the commit that
+# introduced the sibling guard was refused for naming this file — and a guard
+# that fires on writing about a rule makes evading it routine.
+#
+# The body is stripped ONLY for those commands. A heredoc feeding a shell or an
+# interpreter keeps its body, because that body is code that runs:
+#
+#   git commit -F - <<EOF ... EOF    body is prose, stripped
+#   bash <<EOF ... rm docs/x.md      body is code, kept and caught
+#
+# The line opening the heredoc is always kept, so a redirect written on it
+# (cat > docs/x.md <<EOF) is still seen.
+strip_prose_heredocs() {
+  awk '
+    BEGIN { skip = 0 }
+    skip == 0 {
+      if (match($0, /<<-?[[:space:]]*'"'"'?"?[A-Za-z_][A-Za-z0-9_]*'"'"'?"?/) &&
+          $0 ~ /(git[[:space:]]+(commit|tag|notes)|gh[[:space:]]+(pr|issue|release))/) {
+        tag = substr($0, RSTART, RLENGTH)
+        gsub(/^<<-?[[:space:]]*|['"'"'"]/, "", tag)
+        skip = 1
+      }
+      print; next
+    }
+    skip == 1 { if ($0 ~ "^[[:space:]]*" tag "[[:space:]]*$") { skip = 0 }; next }
+  '
+}
+
+stripped=$(strip_prose_heredocs <<<"$cmd") || fail_closed $LINENO
 
 # True when the command writes to something matching regex $1. Mirrors
 # protect-docs.sh: the mutating token must reach the target without crossing a

--- a/.claude/hooks/protect-docs.sh
+++ b/.claude/hooks/protect-docs.sh
@@ -45,6 +45,61 @@ guard() {
   deny "$1 docs/ holds this project's design authority and is gated. A human must approve by running: touch .claude/.docs-unlock (valid ${UNLOCK_TTL}s), then retry."
 }
 
+# Heredoc bodies are prose where the heredoc feeds a command that carries prose:
+# a commit message, a pull request or issue body, a tag annotation. Those
+# routinely quote the very rules this guard enforces — the commit that
+# introduced the sibling guard was refused for naming this file — and a guard
+# that fires on writing about a rule makes evading it routine.
+#
+# The body is stripped ONLY for those commands. A heredoc feeding a shell or an
+# interpreter keeps its body, because that body is code that runs:
+#
+#   git commit -F - <<EOF ... EOF    body is prose, stripped
+#   bash <<EOF ... rm docs/x.md      body is code, kept and caught
+#
+# The line opening the heredoc is always kept, so a redirect written on it
+# (cat > docs/x.md <<EOF) is still seen.
+strip_prose_heredocs() {
+  awk '
+    BEGIN { skip = 0 }
+    skip == 0 {
+      if (match($0, /<<-?[[:space:]]*'"'"'?"?[A-Za-z_][A-Za-z0-9_]*'"'"'?"?/) &&
+          $0 ~ /(git[[:space:]]+(commit|tag|notes)|gh[[:space:]]+(pr|issue|release))/) {
+        tag = substr($0, RSTART, RLENGTH)
+        gsub(/^<<-?[[:space:]]*|['"'"'"]/, "", tag)
+        skip = 1
+      }
+      print; next
+    }
+    skip == 1 { if ($0 ~ "^[[:space:]]*" tag "[[:space:]]*$") { skip = 0 }; next }
+  '
+}
+
+# A heredoc feeding an interpreter is code, and its body is not searched by the
+# line-oriented checks below in any useful way: `python3 - <<EOF` sits on one
+# line and `os.remove("docs/x.md")` on the next, so no single line carries both
+# a mutating token and the target. The shell case only trips the guard by luck,
+# because `rm` and the path share a line.
+#
+# So interpreter bodies are pulled out and judged on their own: if one names
+# docs/ at all, that is enough. An interpreter handed a docs/ path is not doing
+# something this guard should be squinting at.
+interpreter_heredoc_bodies() {
+  awk '
+    BEGIN { skip = 0 }
+    skip == 0 {
+      if (match($0, /<<-?[[:space:]]*'"'"'?"?[A-Za-z_][A-Za-z0-9_]*'"'"'?"?/) &&
+          $0 ~ /(^|[[:space:]|(])(ba|z|k)?sh([[:space:]]|$)|python3?|node|ruby|perl|php|deno|bun/) {
+        tag = substr($0, RSTART, RLENGTH)
+        gsub(/^<<-?[[:space:]]*|['"'"'"]/, "", tag)
+        skip = 1
+      }
+      next
+    }
+    skip == 1 { if ($0 ~ "^[[:space:]]*" tag "[[:space:]]*$") { skip = 0; next }; print }
+  '
+}
+
 # True when $cmd writes to something matching regex $1. The mutating token must
 # reach the target without crossing a command separator, so reading one path
 # while writing an unrelated one does not trip the guard:
@@ -83,7 +138,7 @@ case "$tool" in
     esac
     ;;
   Bash)
-    cmd=$(jq -r '.tool_input.command // ""' <<<"$input")
+    cmd=$(jq -r '.tool_input.command // ""' <<<"$input" | strip_prose_heredocs)
 
     writes_to '\.docs-unlock'   && self_defence ".docs-unlock"
     writes_to 'protect-docs\.sh' && self_defence "protect-docs.sh"
@@ -92,6 +147,12 @@ case "$tool" in
     # a word character is not, so mydocs/ and subdocs/ are left alone.
     if grep -qE '(^|[^[:alnum:]_.-])docs/' <<<"$cmd" && writes_to '[^[:alnum:]_.-]?docs/'; then
       guard "Refusing a command that may modify docs/."
+    fi
+
+    # An interpreter handed a docs/ path inside its heredoc body. See the note
+    # above interpreter_heredoc_bodies for why this cannot be a line match.
+    if grep -qE '(^|[^[:alnum:]_.-])docs/' <<<"$(interpreter_heredoc_bodies <<<"$cmd")"; then
+      guard "Refusing an interpreter whose script names docs/."
     fi
 
     # Same, for a working-directory change into docs/ followed by a write:


### PR DESCRIPTION
Both hook guards match against the raw command text, so a heredoc body counts as if it were typed at a prompt. Commit messages and PR bodies routinely quote the rules these guards enforce — which makes **writing about a rule indistinguishable from breaking it**.

That is not hypothetical in either direction:

- `protect-docs.sh` refused the commit that introduced `no-hook-bypass.sh`, because the message *named the file*.
- `no-hook-bypass.sh` refused **its own** commit for naming the approval marker, and refused `sed -n '1,20p'` on itself — a read.

## The fix

Strip a heredoc body before matching, but **only** where the heredoc feeds a command that carries prose: `git commit`, `git tag`, `git notes`, `gh pr`, `gh issue`, `gh release`.

A heredoc feeding a shell or an interpreter **keeps** its body, because that body is code that runs:

```bash
git commit -F - <<EOF       # body is prose        → stripped
bash <<EOF ... rm docs/x.md # body is code         → kept, and caught
cat > docs/x.md <<EOF       # redirect on the line → always seen
```

The line *opening* the heredoc is never stripped, so a redirect written on it still trips the guard.

### Why not a blanket strip

`no-hook-bypass.sh` shipped with one, and it was too blunt — this would have sailed through:

```bash
bash <<'EOF'
git commit --no-verify -m x
EOF
```

That was a hole I introduced when I wrote it, and it's closed here. Both guards now use the same narrow rule, so they agree on what counts as prose.

## An older gap, found on the way and fixed here

**Present before either change** — I verified against `main`'s version, which allows it too.

The checks are line-oriented, so an interpreter heredoc hides a `docs/` path from them:

```bash
python3 - <<EOF
import os; os.remove('docs/altair-vision.md')
EOF
```

`python3 -` is on one line, the path on the next, and no single line carries both a mutating token and the target. The shell equivalent was caught **only by luck**, because `rm` and the path happen to share a line.

Interpreter bodies (`sh`/`bash`/`zsh`/`ksh`, `python`, `node`, `ruby`, `perl`, `php`, `deno`, `bun`) are now extracted and judged on their own, where naming `docs/` at all is enough. An interpreter handed one of these paths is not something this guard should be squinting at.

## Verification

Eighteen cases, **with the approval markers absent**. That detail matters: my first run had both unlocks open and every case passed, which proved nothing at all — an unlocked guard is permissive by design. Re-run against a marker-free `CLAUDE_PROJECT_DIR`:

| Case | Want | Got |
|---|---|---|
| commit message naming a docs file | allow | allow |
| `gh pr` body naming a docs file | allow | allow |
| commit message naming `protect-docs.sh` | allow | allow |
| commit message naming `--no-verify` / `core.hooksPath` | allow | allow |
| reading a docs file (`cat`) | allow | allow |
| interpreter heredoc that never mentions docs/ | allow | allow |
| ordinary `git commit -m` | allow | allow |
| `rm docs/altair-vision.md` | **deny** | deny |
| `cat > docs/x.md <<EOF` | **deny** | deny |
| `bash <<EOF` … `rm docs/…` | **deny** | deny |
| `python3 - <<EOF` … `os.remove('docs/…')` | **deny** | deny |
| `node <<EOF` … `unlinkSync('docs/…')` | **deny** | deny |
| `python3 - <<EOF` … reading a docs file | **deny** | deny |
| docs write *after* a prose heredoc | **deny** | deny |
| `git commit --no-verify` | **deny** | deny |
| `bash <<EOF` … `--no-verify` | **deny** | deny |
| bypass *after* a prose heredoc | **deny** | deny |

`18 passed, 0 failed`.

## Blast radius

Two hook scripts. No source, no CI, no dependencies. Both guards keep their deny-not-ask posture, their self-defence, their unlock markers, and `no-hook-bypass.sh` keeps its fail-closed `trap`.

The residual limit, stated rather than left to be discovered: this is a text scan and a determined author can always defeat it. Its job is to stop an *accident* and to make a deliberate bypass an explicit, reviewable act — not to be a sandbox.