### PR TITLE
Make a stale lockfile an error in CI, and let the review publish what it finds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,19 @@ jobs:
           cache: false
       - uses: Swatinem/rust-cache@v2
       - run: docker compose up -d --wait
-      - run: cargo test --workspace
+      # --locked, so a lockfile that does not match the manifests is an error
+      # rather than something cargo quietly repairs on the way past. Without it
+      # a stale lockfile passes here and surfaces later somewhere unrelated,
+      # which is exactly how one reached main: the merge resolved Cargo.lock to
+      # one side, every local `cargo test` rewrote it and passed, and the lint
+      # job reported it under the name of the clippy hook.
+      #
+      # This is the copy of that check that does not depend on the committer.
+      # The pre-commit hook runs on a developer's machine and is skippable, and
+      # neither it nor any other local hook runs on a merge commit GitHub builds
+      # itself — where a Cargo.lock conflict can only be resolved by choosing a
+      # side, and both sides are wrong.
+      - run: cargo test --workspace --locked
 
   # The outbox conformance scenarios, which are SUPPOSED to fail.
   #

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,11 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # write, not read: the prompt below posts inline review comments, and
-      # read lets the review run to completion and then silently fail to
-      # deliver it.
+      # Both write, not read. A review that cannot publish is a review that
+      # runs to completion, costs what it costs, and is thrown away — which is
+      # what happened on every run of this workflow before now, while the check
+      # reported success. A pull request comment is an issue comment, so both
+      # scopes are load-bearing.
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
 
     steps:
@@ -50,14 +52,13 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # No `claude_args` allow-list. Restricting it to the single inline
-          # comment tool is what silently discarded every review this workflow
-          # ran: the plugin's own delivery path needs more than that one tool,
-          # so the review completed and every attempt to publish it was denied.
-          # The job holds `contents: read`, so the widest thing it can do here
-          # is comment — which is the entire point of running it.
+          # No --comment. That asks the skill to publish the review itself,
+          # which is the path that kept being denied. track_progress lets the
+          # action own the comment instead, which is the path that works.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          track_progress: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
Two CI fixes. Unrelated causes, both the same shape: **a check that runs, does its work, and reports success while achieving nothing.**

---

## 1 · `--locked`: a stale lockfile becomes an error, not a repair

Cargo treats `Cargo.lock` as advisory. When it doesn't match the manifests, cargo **rewrites it and carries on** — which is why a stale lockfile is invisible when it's created and expensive later.

That's how one reached `main`. A merge resolved the lockfile to one side, so it described neither branch's dependency set. Every local `cargo test` rewrote it and passed. CI failed two pushes later — in the **lint** job, under the name of the **clippy** hook, with the real cause thirty lines into a dependency download log.

### The demonstration, in three runs

```
$ cargo test --workspace --locked --no-run          # healthy lockfile
  Executable tests/store.rs …                                        ← passes

# now delete proptest's entry from Cargo.lock, reproducing the merge mistake

$ cargo test --workspace --locked --no-run
error: cannot update the lock file /…/Cargo.lock because --locked was passed to prevent this

$ cargo test --workspace --no-run                   # same stale lockfile, no flag
     Locking 1 package to latest Rust 1.97.1 compatible version
      Adding proptest v1.11.0                                        ← silently repaired, green
```

The third line is the bug: nothing is wrong, nothing is reported, and the broken lockfile stays committed.

### Three checks, none redundant

| Check | Catches | Limit |
|---|---|---|
| **pre-commit hook** (#12) | while committing, and **repairs** the file | runs on a developer's machine; skippable |
| **lint job** | in CI, because that hook rewrites the file and prek reports the run as modified | names the wrong thing when hook ordering puts something else first |
| **`--locked`** (here) | in CI, depending on neither the committer nor a hook | turns a forgotten lockfile red instead of quietly green — the intent |

The third covers a case **nothing local can see**: a merge commit GitHub builds itself. A `Cargo.lock` conflict there can only be resolved by choosing a side, and both sides are wrong, because the correct lockfile is the union only cargo can compute. No pre-commit hook runs on that merge. **That was reachable on every one of the last four merges.**

**Deliberately unchanged:** the local `mise test` task. Adding a dependency then running tests shouldn't require a separate lockfile step first — locally the pre-commit hook is the right net, and it *fixes* rather than refuses. The `conformance` job is `continue-on-error`, so it would make a poor guard.

---

## 2 · The review has never published anything

Every run of `Claude Code Review` since #4 has done the full review and thrown it away. Zero comments on #6, #7, #8, #9, #10, #14 — verified through the API, not the UI. Each check reported **success**.

That is the worse half. A green check that means nothing trains you to stop reading checks.

### Two earlier attempts, both wrong

- **#5** raised `pull-requests` to `write`. Necessary, not sufficient — a later run had `PullRequests: write` in effect and still published nothing.
- **#11** removed the `--allowedTools` list. Also not it — a run with neither constraint still ended in a denial with nothing posted.

I was guessing, and said so at the time. **Four things were wrong at once**, which is exactly why fixing them one at a time looked like no progress:

| | was | now |
|---|---|---|
| `issues:` | `read` | **`write`** — a PR comment *is* an issue comment |
| `github_token:` | absent | **`${{ github.token }}`** — the action had no token for calls outside the model's tools |
| prompt | `… --comment …` | **no `--comment`** — that asks the *skill* to publish, which is the path that kept being denied |
| `track_progress:` | `false` | **`true`** — lets the *action* own the comment, so the skill only has to produce the review |

Credit where due: this configuration came from a known-working one rather than from more theorising on my part.

**Unchanged:** the trigger set from #5 (`opened`, `ready_for_review`, `reopened` — not `synchronize`), the concurrency group, the draft skip, and the bot-actor loop guard.

---

## Verification

**Part 1 is verified above** — three runs, reproducing the exact merge mistake.

**Part 2 cannot verify itself, and I want to be plain about that.** A `pull_request` workflow runs from the base branch's version of the file, so this PR's checks use the *old* config. The test is the next PR opened after this merges: it either carries a review comment or it doesn't.

CI on this branch: `test` passed in 55s **with `--locked`**, which confirms the committed lockfile is genuinely correct rather than being repaired on the way past. `lint` passed. `conformance` is the intentional red suite.

## Blast radius

Two workflow files. No source, no dependencies, no test changes. One word plus a comment in `ci.yml`; four fields in `claude-code-review.yml`, with every guard from #5 left in place.