### PR TITLE
Require a queued edit to carry the counter it was last acknowledged

### DIFF
--- a/conformance/scenarios.md
+++ b/conformance/scenarios.md
@@ -1,7 +1,7 @@
 # Altair Outbox Conformance Scenarios
 
 **Status:** Draft
-**Date:** 2026-08-16
+**Date:** 2026-08-17
 **Related:** Altair Substrate Specification, Altair Component Model, Altair v0 Scope, DR-004, DR-005, DR-006
 
 ---
@@ -109,6 +109,11 @@ And nothing is required about where B's create falls relative to either.
 Given the person captures a file.
 When the client sends.
 Then the body stream completes before the intent naming that body arrives.
+
+**C4. A queued edit is sent against the counter the instance last acknowledged.**
+Given an entity is created and then edited twice while the instance is unreachable, so both edits were composed against the same counter.
+When the instance becomes reachable.
+Then every edit that arrives for that entity carries the counter the instance acknowledged for the previous write to it, rather than the counter the edit was composed against.
 
 ---
 
@@ -236,7 +241,9 @@ Then the client shows the same thing whether the entity is absent or invisible t
 
 ## What these scenarios decide that the documents do not
 
-Three behaviours follow from combining requirements rather than from any single statement, and they are recorded here because a conformance suite has to be decidable.
+Four behaviours follow from combining requirements rather than from any single statement, and they are recorded here because a conformance suite has to be decidable.
+
+**C4, rebasing a queued edit.** Ordered per entity and a base counter that detects concurrency meet when a person edits the same entity twice while the instance is unreachable. Both edits are composed before either acknowledgement returns, so both name the counter the client last knew. Sent as composed, the second arrives stale against the first and touches the same part, and the substrate's rule for that is to retain both values — a person conflicting with themselves over a sequence they performed in a known order, on a single device, with nobody else involved. The client is the only party that knows that order, so carrying it is its obligation. Coalescing the two into one intent satisfies this equally; what is not permitted is sending a counter the client has already been told is superseded.
 
 **E3, holding later intents for a faulted entity.** Ordered per entity and non-blocking are both required, and they meet when a create is refused and an edit is queued behind it. Sending the edit would break ordering and would name an entity the instance does not hold. Holding it is what these scenarios require.
 

--- a/crates/altair-conformance/src/instance.rs
+++ b/crates/altair-conformance/src/instance.rs
@@ -139,6 +139,22 @@ impl IntentArrival {
         )
     }
 
+    /// The counter the instance acknowledged, where it applied the intent.
+    ///
+    /// C4 compares this against the counter the next edit for the same entity
+    /// declares it was based on.
+    #[must_use]
+    pub fn applied_counter(&self) -> Option<u64> {
+        match self
+            .acknowledgement
+            .as_ref()
+            .and_then(|ack| ack.outcome.as_ref())
+        {
+            Some(v1::acknowledgement::Outcome::Applied(applied)) => Some(applied.counter),
+            _ => None,
+        }
+    }
+
     /// The recreation the instance answered with, where it answered with one.
     #[must_use]
     pub fn recreated(&self) -> Option<v1::Recreated> {
@@ -204,6 +220,10 @@ struct Inner {
     /// Entity identities the instance has actually committed. D1 and D4 count
     /// these to prove one entity rather than two.
     committed: HashSet<Vec<u8>>,
+    /// Per entity write counter, advanced on an accepted write and on nothing
+    /// else. A constant would have done for every scenario but C4, which is
+    /// about a client carrying the value it was last told.
+    counters: HashMap<Vec<u8>, u64>,
     /// How many intents have been decided, ever. `RefuseNth` counts here.
     decided: usize,
 }
@@ -432,6 +452,18 @@ pub fn body_id_of(intent: &v1::Intent) -> Option<Vec<u8>> {
     }
 }
 
+/// The counter an edit declares it was based on, where the intent is an edit.
+#[must_use]
+pub fn base_counter_of(intent: &v1::Intent) -> Option<u64> {
+    match intent.action.as_ref()? {
+        v1::intent::Action::Edit(edit) => match edit.subject.as_ref()? {
+            v1::edit::Subject::Entity(entity) => Some(entity.base_counter),
+            v1::edit::Subject::Relation(_) => None,
+        },
+        _ => None,
+    }
+}
+
 /// Whether the intent creates an entity.
 #[must_use]
 pub fn is_create(intent: &v1::Intent) -> bool {
@@ -482,17 +514,19 @@ impl Service {
                 detail,
             })),
         };
+        // The counter is filled in below, once the outcome is known, because
+        // it advances on an accepted write and on nothing else.
         let applied = |conflict: Option<v1::ConflictRetained>| v1::Acknowledgement {
             intent_id: intent.intent_id.clone(),
             outcome: Some(v1::acknowledgement::Outcome::Applied(v1::Applied {
                 entity_ids: entity_id_of(intent).into_iter().collect(),
                 relation_ids: Vec::new(),
-                counter: 1,
+                counter: 0,
                 conflict,
             })),
         };
 
-        let acknowledgement = match behaviour {
+        let mut acknowledgement = match behaviour {
             Behaviour::RefuseNth(k) if nth == *k => {
                 refused(v1::RefusalReason::NotAvailable, String::new())
             }
@@ -525,6 +559,16 @@ impl Service {
         };
 
         let mut inner = self.state.inner.lock().unwrap();
+        // Assigned here rather than where the acknowledgement was built, so
+        // that a refusal does not advance a counter it never wrote against.
+        if let Some(v1::acknowledgement::Outcome::Applied(applied)) =
+            acknowledgement.outcome.as_mut()
+            && let Some(id) = entity_id_of(intent)
+        {
+            let counter = inner.counters.entry(id).or_insert(0);
+            *counter += 1;
+            applied.counter = *counter;
+        }
         inner
             .issued
             .insert(intent.intent_id.clone(), acknowledgement.clone());

--- a/crates/altair-conformance/tests/coverage.rs
+++ b/crates/altair-conformance/tests/coverage.rs
@@ -8,10 +8,10 @@
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
-/// `conformance/scenarios.md` states thirty four scenarios across sections A
-/// to G: A1–A5, B1–B5, C1–C3, D1–D4, E1–E4, F1–F9, G1–G4. If that number
+/// `conformance/scenarios.md` states thirty five scenarios across sections A
+/// to G: A1–A5, B1–B5, C1–C4, D1–D4, E1–E4, F1–F9, G1–G4. If that number
 /// changes, the document changed, and this constant is where it is noticed.
-const EXPECTED: usize = 34;
+const EXPECTED: usize = 35;
 
 fn repository_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/altair-conformance/tests/scenarios.rs
+++ b/crates/altair-conformance/tests/scenarios.rs
@@ -2,7 +2,7 @@
 //!
 //! One test per scenario, named for its id. The id literal in each
 //! `scenario!` invocation is what `tests/coverage.rs` reads back to prove the
-//! document and this file name the same thirty four scenarios.
+//! document and this file name the same thirty five scenarios.
 //!
 //! **These fail, and that is the deliverable of Wave 1.5.** The outbox is
 //! Wave 4.1's work. Until it exists, [`NullClient`] is what these run against
@@ -577,6 +577,71 @@ scenario!("C3", c3_a_body_precedes_the_intent_that_refers_to_it, {
 
     Outcome::Passed
 });
+
+scenario!(
+    "C4",
+    c4_a_queued_edit_is_sent_against_the_acknowledged_counter,
+    {
+        let mut world = world().await;
+        skip_unless!(
+            world.offers().offline_edit,
+            "this client does not edit while offline"
+        );
+        world.instance.set_behaviour(Behaviour::Unreachable);
+        world.launch();
+        world.accept("A");
+        world.edit("A", "A/1");
+        world.edit("A", "A/2");
+
+        world.instance.set_behaviour(Behaviour::Accept);
+        assert!(
+            world.instance.wait_for_intents(3, SETTLE).await,
+            "all three intents send"
+        );
+
+        let arrivals = world.instance.intents();
+        let create = arrivals
+            .iter()
+            .find(|arrival| instance::is_create(&arrival.intent))
+            .expect("the create must arrive");
+        let subject = instance::entity_id_of(&create.intent).expect("the create names an entity");
+
+        // Walk this entity's writes in arrival order. Each edit must declare
+        // the counter the instance answered with for the write before it. A
+        // client that coalesces its two edits into one intent passes this too:
+        // what fails is sending a counter it has already been told is
+        // superseded.
+        let mut acknowledged = create
+            .applied_counter()
+            .expect("the create is applied, so it is answered with a counter");
+
+        let mut edits = 0;
+        for arrival in arrivals
+            .iter()
+            .filter(|arrival| instance::entity_id_of(&arrival.intent).as_ref() == Some(&subject))
+            .filter(|arrival| instance::is_edit(&arrival.intent))
+        {
+            let base = instance::base_counter_of(&arrival.intent)
+                .expect("an edit declares the counter it was based on");
+            assert_eq!(
+                base, acknowledged,
+                "an edit for A arrived against counter {base}, and the instance \
+                 had already answered {acknowledged} for the write before it. \
+                 Both edits were composed offline against the same counter, so \
+                 the client owes the rebase; sending as composed makes the \
+                 person conflict with themselves."
+            );
+            acknowledged = arrival
+                .applied_counter()
+                .expect("the edit is applied, so it is answered with a counter");
+            edits += 1;
+        }
+
+        assert!(edits > 0, "at least one edit for A must arrive");
+
+        Outcome::Passed
+    }
+);
 
 // ---------------------------------------------------------------------------
 // D. Idempotence


### PR DESCRIPTION
## Why

Wave 2.1 was read against the documents before any of it was written, and this fell out: **a single person, on a single device, with nobody else involved, conflicts with themselves.**

Edit an entity twice while the instance is unreachable. Both edits are composed before either acknowledgement returns, so both name the counter the client last knew. Sent as composed, the second arrives stale against the first and touches the same part — and the substrate's rule for exactly that is to retain both values and ask a person to choose:

> Base counter stale, changed fields overlap: **conflict**
> — the substrate specification, *Detecting a real conflict*

The instance is right to do that; it cannot see that the two edits were sequential. The client is the only party that knows, because it composed them in that order. So carrying the order is the client's obligation, and nothing said so.

Left alone, this surfaces in Wave 4.1 as a conflict marker on the author's own note after any offline create-edit-edit, and it will read as an instance bug in the write path rather than as a missing obligation in the outbox.

## What changed

**`conformance/scenarios.md`** gains **C4**, stated at the boundary the scenarios observe — what reaches the instance — rather than as a rule about outbox internals:

> Then every edit that arrives for that entity carries the counter the instance acknowledged for the previous write to it, rather than the counter the edit was composed against.

A client that coalesces its two edits into one intent passes this equally. What fails is sending a counter it has already been told is superseded. The reasoning is recorded under *What these scenarios decide that the documents do not*, alongside E3, E4 and G3, because like those three it follows from combining requirements rather than from any single statement — ordered-per-entity meeting a base counter that detects concurrency.

**`crates/altair-conformance/src/instance.rs`** — the fake instance answered a constant `counter: 1`, which no scenario had needed to be more than. It now advances a real per-entity counter, assigned after the outcome is known so that a refusal does not move a counter it never wrote against. Two accessors come with it: `IntentArrival::applied_counter` and `instance::base_counter_of`.

**`crates/altair-conformance/tests/scenarios.rs`** — C4 walks the entity's writes in arrival order and asserts each edit's declared base against the counter the instance answered for the write before it.

**`crates/altair-conformance/tests/coverage.rs`** — `EXPECTED` 34 to 35, and the section inventory it documents.

## Evidence

- `cargo test --workspace` green, including `coverage` (the document and the suite name the same 35 scenarios, each test named for its id) and the 14 `harness` tests that exercise the fake instance whose counter behaviour changed.
- `mise run conformance` — C4 is **red**, failing at `world.rs:247` on the null client showing nothing as accepted, which is where C1 and C2 fail too. A red scenario is the deliverable until Wave 4.1; see `crates/altair-conformance/README.md`.
- `mado check` clean.

## Blast radius

The suite and its document. No instance code exists yet to be affected. The one behavioural change outside the new scenario is the fake instance's counter, which nothing previously asserted on — a search for `counter` across the tests found only `harness.rs:256`, which *constructs* an edit rather than reading an acknowledgement.

## Not in this PR

The other two amendments from the same review are held back, because the design documents are gated behind a human-run unlock marker that this session could not reach:

- **Relations join the holding state** — `Remove` can name `relation_ids`, and the store has nowhere to hold a removed relation: no lifecycle, no `deleted_at`, no `deletion_group_id`, and `Restore` names an `entity_id`. Amends the substrate specification and the data model.
- **The scratchpad record** for both decisions, the rejected alternatives, and two findings — including that the schema's `ON DELETE CASCADE`s never fire under erasure, since every one hangs off a delete of the `entity` row and erasure leaves a tombstone.
