### PR TITLE
Give the repository a front door, and tell CLAUDE.md that the code exists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,34 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repository is right now
 
-**Design documents only. There is no source code, no build system, and no tests yet.** Everything in `docs/` specifies a self-hosted personal system ("Altair") that has not been built. The first code lands as Wave 0 of `docs/altair-v0-implementation-plan.md`.
+**Design documents plus the first two waves of the instance.** Everything in `docs/` specifies a self-hosted personal system ("Altair"); `crates/` is the beginning of it. Wave 0 and all five Wave 1 lanes have landed — store bootstrap and the audience predicate, block division, the object store, token validation, and the outbox conformance suite. **Wave 2, the write path, is next and is not started.** There is no running instance and no client.
 
 Consequences for working here:
 
-- There is nothing to build, lint, or run. Do not invent commands or claim to have verified behaviour.
-- Changing a document is the work. Treat prose with the care normally reserved for code: these documents are the authority the implementation will be checked against.
-- When implementation starts, it starts at Wave 0 — see [The codebase that will be built](#the-codebase-that-will-be-built).
+- **Changing a document is the work.** Treat prose with the care normally reserved for code: these documents are the authority the implementation is checked against.
+- **Verify code changes by running the suite** — see [Commands](#commands). Do not claim to have verified behaviour you did not run.
+- `README.md` is the human-facing summary of much of this file. If one changes, check the other.
+
+## Commands
+
+```bash
+mise install                 # toolchain: rust, prek, mado. Docker is the only other prerequisite
+cp .env.example .env         # DATABASE_URL, read by the test harness only
+mise run test                # docker compose up -d --wait, then cargo test --workspace
+mise run conformance         # the outbox scenarios — RED ON PURPOSE, see below
+prek run --all-files         # rustfmt, clippy -D warnings, mado, hygiene. CI runs these same hooks
+```
+
+- **No `protoc` is needed.** Codegen goes through `protox`, which is pure Rust.
+- **Tests need a real PostgreSQL**, never a mock: the audience predicate, both indexes, and `SKIP LOCKED` are Postgres behaviour. Migrations are applied once into a template database and each test branches it with `CREATE DATABASE … TEMPLATE`.
+- **Set `ALTAIR_TEST_PREFIX` per worktree** when lanes run in parallel against one Postgres, or they fight over the template name.
+
+## Two guards that will deny your tool calls
+
+Both are `PreToolUse` hooks in `.claude/settings.json`, both deny rather than ask, and both are unlocked out-of-band by a human for 30 minutes.
+
+- **`docs/` is gated.** Any create, edit, move, or delete under `docs/`, by any means including shell redirection, `sed -i`, or `git restore`, is refused. Reading is always fine. To proceed, ask the user to run `touch .claude/.docs-unlock` — do not attempt a workaround, and do not create the marker yourself; the guard defends it and itself.
+- **Pre-commit hooks may not be skipped.** `--no-verify`, `-n`, `SKIP=`, and `core.hooksPath` are refused. A merge commit made with `--no-verify` once shipped a `Cargo.lock` matching neither branch, and CI failed two pushes later under an unrelated hook's name. The human unlock is `touch .claude/.hooks-unlock`.
 
 ## Document authority
 
@@ -67,11 +88,22 @@ Rules that follow from this and are easy to violate:
 
 `docs/altair-v0-implementation-plan.md` sequences it. **It prescribes no file list and no directory layout** — every item is an outcome with a verification condition ("Done when: …"), and the layout is decided while implementing. Preserve that: do not invent a canonical module tree and treat it as settled.
 
+What has actually been built so far, which is observation rather than a settled tree:
+
+```text
+crates/altaird/            the instance: store/ (audience, tx, entity, ids), body/, objects/, auth/
+crates/altaird/migrations/ 0001_initial.sql, migration one, not re-derived
+crates/altair-proto/       generated contract types (protox + tonic)
+crates/altair-conformance/ the outbox harness and a null client stub
+```
+
+**The conformance suite is red on purpose and must stay that way until Wave 4.1.** It sits behind the `run-conformance` feature so `cargo test --workspace` stays green and `main` stays mergeable, and its CI job is `continue-on-error`. Scenarios turn green one at a time as the outbox lands; anything that makes one pass without an outbox behind it destroys the deliverable. Read `crates/altair-conformance/README.md` before touching it.
+
 Seven waves. Waves 1–3 are planned against reality; Wave 5 onward names outcomes and deliberately leaves shape open. **Re-plan at each wave boundary, and only the next wave.**
 
 | Wave | Produces | Notes |
 |---|---|---|
-| 0 · Plumbing | Cargo workspace, proto codegen in the build, migration runner (`altair-schema.sql` as migration one), integration harness, CI | Harness stands up a **real PostgreSQL**, not a mock — the audience predicate, both indexes and `SKIP LOCKED` are Postgres behaviour. Done when a fresh checkout runs one command and passes an empty suite. |
+| 0 · Plumbing | Cargo workspace, proto codegen in the build, migration runner (`0001_initial.sql` as migration one), integration harness, CI | Harness stands up a **real PostgreSQL**, not a mock — the audience predicate, both indexes and `SKIP LOCKED` are Postgres behaviour. Done when a fresh checkout runs one command and passes an empty suite. |
 | 1 · Foundations | 1.1 store bootstrap · 1.2 block division · 1.3 object store · 1.4 token validation · 1.5 outbox conformance suite | Five genuinely independent lanes, one worktree each. 1.5's deliverable is a **red suite** — every scenario runs and fails. |
 | 2 · Write path | 2.1 intent spine · 2.2 type content, all three domains · 2.3 file bodies · 2.4 reclamation | 2.1 is sequential and load-bearing; do not parallelise the spine, do parallelise what hangs off it. |
 | 3 · Read path | 3.1 literal retrieval arm · 3.2 change stream and horizon · 3.3 health | Literal only. Build the instance half of the change stream even though the TUI need not consume it — omitting the instance side is one-way. |
@@ -87,7 +119,7 @@ Specifics worth knowing before touching the relevant lane:
 - **Block division is a pure function over text**, run only at the instance (DR-004). Atomic constructs never split (fenced code, tables, diagrams); list items do split; identity survives edits to a block and to its neighbours. A long unbroken stretch of prose being one block is correct, not a bug.
 - **The intent spine**: idempotent replay returns the original acknowledgement, the intent row is written in the transaction it acknowledges, a stale base is never a rejection (reject-and-retry is the familiar pattern and it is wrong), both values are retained on a same-part conflict, and refusal on audience is indistinguishable from refusal on nonexistence.
 - **The change sequence allocates from a single position row in the write transaction, so every write serialises on it. That is intended** — a sequence leaves gaps and a poller can read past an uncommitted position and never see it. Record why prominently near the code; this is exactly the shape of thing a future reader removes as an obvious bottleneck.
-- **`altair-schema.sql` already contains Wave 2's test plan**, under *"Checks this file cannot make, which the write path owes."* Turn that list into the suite.
+- **`crates/altaird/migrations/0001_initial.sql` already contains Wave 2's test plan**, under *"Checks this file cannot make, which the write path owes"* (line 886). Turn that list into the suite. The plan document still calls this file `altair-schema.sql`; the name changed when it was adopted as migration one.
 - **Two schema gaps close in Wave 0**: the embedding dimension stays a placeholder in its own late migration, and cycle prevention in nested locations and categories becomes a write-path check rather than a constraint.
 - **Outstanding derivation is computed from provenance in the store, never from the queue.** Losing the queue costs time, not reportability.
 - **The horizon is null, or longer than every other retention window. A middle value is a bug**, not a tuning choice.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ One instance serves one household. Nobody else can raise the price, change the t
 | Wave 0 · plumbing | Landed. Workspace, proto codegen, migration runner, a real-Postgres test harness, CI |
 | Wave 1 · foundations | Landed. Store bootstrap and the audience predicate, block division, the object store, token validation, and the outbox conformance suite |
 | Wave 2 · write path | Next. The intent spine, type content, file bodies, reclamation |
+| Wave 3 · read path | Literal retrieval, the change stream and its horizon, health |
 | Wave 4 · terminal client | The first useful day. Nothing before it is usable software |
+| Waves 5 and 6 | Semantic retrieval, then the message bridge and operations |
 
 The outbox conformance suite is **deliberately red** and will stay red until Wave 4.1 writes the outbox it judges. See [`crates/altair-conformance/README.md`](crates/altair-conformance/README.md) before touching it.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,264 @@
+# Altair
+
+**A self-hosted system where the things you are working toward, the things you know, and the things you own live in one connected place you own permanently, and where a thought can always be captured whatever the network is doing.**
+
+One instance serves one household. Nobody else can raise the price, change the terms, read the contents, or switch it off.
+
+---
+
+## Status
+
+**Early construction.** The design is written and the first code has landed; there is no running instance yet and nothing to install.
+
+| Part | State |
+|---|---|
+| Design documents (`docs/`) | Written. The vision, three domain PRDs, the substrate, the architecture, and seven decision records |
+| Wire contract (`proto/altair/v1/altair.proto`) | Accepted. Field numbers are permanent |
+| Structured store schema (`crates/altaird/migrations/0001_initial.sql`) | Accepted as migration one. Applied and exercised on PostgreSQL 18.6 with pgvector 0.8.6 |
+| Wave 0 · plumbing | Landed. Workspace, proto codegen, migration runner, a real-Postgres test harness, CI |
+| Wave 1 · foundations | Landed. Store bootstrap and the audience predicate, block division, the object store, token validation, and the outbox conformance suite |
+| Wave 2 · write path | Next. The intent spine, type content, file bodies, reclamation |
+| Wave 4 · terminal client | The first useful day. Nothing before it is usable software |
+
+The outbox conformance suite is **deliberately red** and will stay red until Wave 4.1 writes the outbox it judges. See [`crates/altair-conformance/README.md`](crates/altair-conformance/README.md) before touching it.
+
+---
+
+## What Altair is
+
+A life does not divide neatly into projects, notes, and stuff. Rebuilding a kitchen is a plan, a pile of decisions, and a shopping list, all at once. Splitting that across three applications creates three sync boundaries, three search boxes, and three places to forget something.
+
+**The bet:** one place where anything can connect to anything, searchable in a single pass, is worth more than best-in-class depth in any single domain.
+
+### The two principles
+
+Everything else descends from these. When a design decision is contested, it is resolved here first.
+
+**Progress over perfection.** The system must be useful when the data is incomplete, imprecise, and out of date, because it always will be. A campaign with no arcs is valid. Six tracked items out of four hundred is a working inventory. "I don't know how much is left, just mark it lower" is a supported operation.
+
+**No barriers to re-entry.** The cost of returning after three weeks away must be near zero. Nothing accumulates that must be cleared. No streak, score, or counter degrades through absence. Nothing reorganises itself while you are away, so muscle memory still works when you come back.
+
+### Three domains, one entity model
+
+**Guidance** is what you are working toward — campaigns, then arcs, then quests. It answers *what can I actually do right now?*
+
+**Knowledge** is what you are learning and remembering — notes, files, links formed where the writing happens, derived backlinks. It answers *where did I write that down?*
+
+**Tracking** is the resources a household runs on — items across nested locations, amounts at whatever precision you chose. It answers *do we have any left?*
+
+**Anything can be linked to anything, across all three, and one query reaches all three in one pass.** That is the product, more than any individual domain is.
+
+### Capture and retrieval
+
+**Capture never fails.** A thought that cannot be written down when it arrives is gone. Acceptance is local and durable on the device before the person is told; credentials and connectivity never participate. A durable append-only outbox replays to the instance whenever it can.
+
+**Retrieval is the other half.** Loose capture without good retrieval is a landfill. A literal arm and a similarity arm generate candidates together and fuse by rank position, so something is findable when you no longer recall the words you used. Literal matching is a permanent arm, not a fallback, which is why a just-captured entity is findable by its words before anything has been derived from it.
+
+### What it will never be
+
+Settled permanently, not a backlog: no hosted tier or vendor account, no telemetry without opt-in, no team project management (no velocity, estimation, roles, or permission matrices), no activity feeds or comments, no streaks or points or productivity scoring, no ordering that adapts to the person, no user-defined schemas or plugin runtime, no folder tree. The full list is in [the vision](docs/altair-vision.md).
+
+Altair is for ADHD and otherwise neurodivergent adults running their own life and household, who can run a server themselves or live with someone who can. It is explicitly not for teams or organisations.
+
+---
+
+## Architecture in one pass
+
+**One self-hosted instance is the authority for one household.** It owns the public interface, every write, audience enforcement, and retrieval orchestration. Stores sit behind it, clients in front, inference beside it and never authoritative. Process count is packaging, not architecture.
+
+```mermaid
+flowchart TB
+    subgraph FRONT["In front of the instance"]
+        CL["Client<br/>cache and outbox"]
+    end
+
+    PIF{{"The public interface<br/>gRPC, protobuf"}}
+
+    subgraph INST["The instance"]
+        WP["Write path"]
+        RP["Read path"]
+        RD["Reclamation<br/>and delivery"]
+        DW["Derivation worker"]
+    end
+
+    SS[("Structured store<br/>PostgreSQL + pgvector<br/>entities, relations, versions,<br/>both search indexes")]
+    OS[("Object store<br/>file bodies only")]
+    INF["Inference<br/>several independent models"]
+
+    CL --> PIF
+    PIF --> WP
+    PIF --> RP
+    WP --> SS
+    WP --> OS
+    WP -.-> DW
+    RP --> SS
+    RP -.-> OS
+    RP -.-> INF
+    DW --> SS
+    DW -.-> INF
+    RD --> SS
+    RD --> OS
+
+    N["Solid is always present.<br/>Dotted may be absent, and the system<br/>is required to work without it.<br/>Nothing crosses from the read path to the write path."]
+    INF --- N
+
+    style WP fill:#e6f4ff,stroke:#2b7fd9
+    style PIF fill:#fff4e6,stroke:#d9822b
+    style N fill:#f4f4f5,stroke:#a1a1aa
+```
+
+**Structured store** ([DR-002](docs/DR-002-postgresql-structured-store.md)): PostgreSQL holds entities, relations, categories, membership, versions, derived text, embeddings, and *both* search indexes. The indexes live there because the audience predicate must sit inside the candidate query — filtering afterwards leaks and gets limits wrong.
+
+**Object store** ([DR-003](docs/DR-003-object-store.md)): the filesystem behind put, get, delete, and enumerate. File bodies and nothing else. `enumerate` is load-bearing, because erasure removes the record before the bytes and the sweep is what closes that window.
+
+**Derivation worker**: embeddings and their provenance. Its queue is a table claimed with `SELECT … FOR UPDATE SKIP LOCKED`, and it is an optimisation over work that is computable from the store. Losing it costs time, not reportability.
+
+**Inference**: several independently-absent models. An instance without a cross-encoder is conforming, not degraded.
+
+**Write path**: writes are field-scoped and carry a base counter. Overlapping concurrent changes retain both sides. A stale base counter is never a rejection — reject-and-retry is the familiar pattern here and it is wrong, because a device returning after three weeks cannot win a retry race against a household that has been using the system meanwhile.
+
+**Change stream**: polled with a client-held position, and assembled **per member**. Audience broadening and narrowing must arrive as creation and deletion to the affected member; one shared stream filtered late is where a leak happens.
+
+---
+
+## Repository layout
+
+```text
+docs/                      Design documents. The authority the implementation is checked against
+proto/altair/v1/           The public interface. Field numbers are permanent
+conformance/scenarios.md   The outbox specification, made executable, run against every implementation
+crates/
+  altaird/                 The instance: store, block division, object store, token validation
+    migrations/            0001_initial.sql is migration one, and is not re-derived
+  altair-proto/            Generated contract types (protox + tonic, no protoc needed)
+  altair-conformance/      The conformance harness. Red on purpose until Wave 4.1
+compose.yaml               PostgreSQL 18 with pgvector, for tests
+mise.toml                  Toolchain and task definitions
+```
+
+---
+
+## Building and testing
+
+**Prerequisites:** [mise](https://mise.jdx.dev) and a Docker daemon. Everything else — the Rust toolchain, the markdown linter, the pre-commit runner — is installed by mise from `mise.toml`. No `protoc` is required; codegen goes through `protox`, which is pure Rust.
+
+```bash
+mise install                 # toolchain
+cp .env.example .env         # DATABASE_URL for the test harness
+mise run test                # brings up Postgres, then cargo test --workspace
+```
+
+`mise run test` is the whole loop: it runs `docker compose up -d --wait` and then the workspace suite. The harness stands up a **real PostgreSQL**, not a mock, because the audience predicate, both indexes, and `SKIP LOCKED` are Postgres behaviour. Migrations are applied once into a template database and each test branches it with `CREATE DATABASE … TEMPLATE`, so per-test isolation costs about a connection.
+
+Where several worktrees run lanes in parallel against one Postgres, set `ALTAIR_TEST_PREFIX` per worktree so they do not fight over the template name.
+
+To look at the red conformance suite:
+
+```bash
+mise run conformance         # expected to fail until Wave 4.1
+```
+
+It needs no database, no Authentik, and no real instance: the suite stands up its own fake instance on a local port. It prints a ledger at the end, because libtest has no third verdict and a scenario a client legitimately skips would otherwise read as a pass.
+
+Before committing:
+
+```bash
+prek install                 # once, to wire the hooks
+prek run --all-files         # rustfmt, clippy with -D warnings, mado, hygiene
+```
+
+CI runs the same hooks, so the local path and CI cannot drift apart.
+
+---
+
+## The documents
+
+**Changing a document is the work.** These documents are the authority the implementation is checked against, and they form a strict hierarchy — every one names its own position in its header.
+
+```text
+altair-vision.md                          normative, permanent product identity
+  ├── altair-substrate-spec.md            cross-cutting behaviour, under all three domains
+  ├── altair-guidance-prd.md              \
+  ├── altair-knowledge-prd.md              }  domain behaviour
+  ├── altair-tracking-prd.md              /
+  ├── altair-relation-types-spec.md       relation types, which belong to no single domain
+  ├── altair-architecture-foundations.md  what kind of system, before any component
+  │     └── altair-architecture.md        components and what they owe each other
+  │           └── altair-component-model.md  every boundary, and what each side owes on absence
+  ├── altair-data-model.md                every persistent thing, and it decides nothing
+  ├── altair-v0-scope.md                  sequencing; defers, never amends
+  │     └── altair-v0-implementation-plan.md
+  └── DR-001 … DR-007                     product and technology choices made against the above
+```
+
+Three rules follow from that shape and are easy to violate:
+
+**Assembled documents decide nothing.** [`altair-data-model.md`](docs/altair-data-model.md) and [`altair-component-model.md`](docs/altair-component-model.md) restate what their authorities require. Where one disagrees with the substrate spec, a domain PRD, or the architecture, the assembled document is what gets corrected.
+
+**Design before architecture before tools.** Specs say what must be true, the architecture says what structure delivers it, and decision records choose products. A spec that names a product has escaped its layer.
+
+**The scratchpad has no authority.** [`altair-scratchpad.md`](docs/altair-scratchpad.md) holds entries that are `open`, `leaning`, or `parked`. Writing something there is not deciding it.
+
+### Decision records
+
+| Record | Decision |
+|---|---|
+| [DR-001](docs/DR-001-markdown-body-not-storage.md) | Markdown is a note's body, not the storage layer |
+| [DR-002](docs/DR-002-postgresql-structured-store.md) | PostgreSQL with pgvector is the structured store |
+| [DR-003](docs/DR-003-object-store.md) | The object store is the filesystem behind four operations |
+| [DR-004](docs/DR-004-wire-contract.md) | Protocol buffers over gRPC are the wire contract |
+| [DR-005](docs/DR-005-token-validation.md) | The instance validates tokens rather than trusting a gateway |
+| [DR-006](docs/DR-006-runtime-and-clients.md) | Rust for the instance, a terminal client first, Android in Kotlin later |
+| [DR-007](docs/DR-007-identifier-scheme.md) | Every identifier is a random UUIDv4, and nothing reads one |
+
+---
+
+## The plan
+
+[`docs/altair-v0-implementation-plan.md`](docs/altair-v0-implementation-plan.md) sequences the work. It prescribes no file list and no directory layout — every item is an outcome with a verification condition, and the layout is decided while implementing. Early waves are specific; later ones name outcomes and deliberately leave the shape open, and each is re-planned at its boundary.
+
+| Wave | Produces |
+|---|---|
+| 0 · Plumbing | Workspace, proto codegen, migration runner, integration harness, CI |
+| 1 · Foundations | Store bootstrap, block division, object store, token validation, outbox conformance suite |
+| 2 · Write path | Intent spine, type content across all three domains, file bodies, reclamation |
+| 3 · Read path | Literal retrieval arm, change stream and horizon, health |
+| 4 · Terminal client | The Rust outbox, then a ratatui client. **The first useful day** |
+| 5 · Semantic | Derivation worker, inference boundary and bi-encoder, semantic arm and fusion |
+| 6 · Second client and ops | Message bridge, packaging, backup, restore, upgrade |
+
+Deferred decisions have **triggers, not dates**. The embedding model is chosen at Wave 5 against a real corpus, the bridge transport at 6.1, retention constants at 2.4. None is taken early.
+
+### Standing constraints
+
+The ones cheapest to violate and most expensive to repair. They apply to prose changes as much as to code.
+
+- The audience predicate lives **inside** the query that produces candidates, on every path including similarity — never a filter afterwards. One implementation, called by both paths.
+- Nothing crosses from the read path to the write path. The read path writes nothing, including no record of what was asked.
+- A stale base counter is never a rejection.
+- Acceptance is shown only after local durability.
+- Bytes before the record on creation. Record before the bytes on erasure.
+- Relation types are declarations the system interprets, not branches.
+- Derived data is never canonical; a person's edit to it outranks recomputation.
+- Nothing may foreclose export.
+- Field numbers are permanent; removed fields are reserved, never reused.
+- Waiting is silent, faults signal. An unreachable instance and an expired session are the same wait. No counter rises while the person is away, and queue depth is never reported.
+- No client habit becomes load-bearing. What crosses the boundary is the component model's list, not what the first client happened to need.
+
+---
+
+## Contributing
+
+`main` is the single trunk and is always in a working state. Every change reaches it through a pull request from a short-lived branch, including a documents-only edit.
+
+- Branch off `main`, and name the branch for what it contains.
+- Open the pull request early, even in draft — the PR is where discussion happens, not just a final gate.
+- `main` is protected: no direct pushes, no force-pushes, enforced for everyone.
+- **Squash merges only.** The PR title and body become the permanent commit message, so keep them accurate. Branches are deleted on merge.
+- A PR that changes `docs/` owes the review the document hierarchy implies, independent of the GitHub review count.
+
+---
+
+## Licence
+
+[AGPL v3 or later](LICENSE), permanently. That is a Must in the vision document rather than a default, and it is not negotiable.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Altair
 
+[![CI](https://github.com/getaltair/altair/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/getaltair/altair/actions/workflows/ci.yml)
+[![Conformance: red until Wave 4.1](https://img.shields.io/badge/conformance-red%20until%20wave%204.1-red)](crates/altair-conformance/README.md)
+[![Licence: AGPL-3.0-or-later](https://img.shields.io/badge/licence-AGPL--3.0--or--later-blue)](LICENSE)
+
+[![Status: pre-alpha](https://img.shields.io/badge/status-pre--alpha-orange)](#status)
+[![Waves 0 and 1 complete](https://img.shields.io/badge/waves-0%20and%201%20complete-yellowgreen)](docs/altair-v0-implementation-plan.md)
+[![Rust edition 2024](https://img.shields.io/badge/rust-edition%202024-dea584)](Cargo.toml)
+[![PostgreSQL 18 with pgvector](https://img.shields.io/badge/postgresql-18%20with%20pgvector-336791)](docs/DR-002-postgresql-structured-store.md)
+
 **A self-hosted system where the things you are working toward, the things you know, and the things you own live in one connected place you own permanently, and where a thought can always be captured whatever the network is doing.**
 
 One instance serves one household. Nobody else can raise the price, change the terms, read the contents, or switch it off.


### PR DESCRIPTION
> Documentation only. No Rust changes, no schema changes, nothing under `docs/`. Branched from `main` at `fab2975`.

## 💡 What this is

The repository had no README, so a visitor arrived at twenty design documents, three crates, and no statement of what any of it was for or how to run it. This adds one, and repairs `CLAUDE.md`, which still opened by declaring the repository design documents only with no source, no build system, and no tests.

The obvious worry about a README here is that summarising the vision creates a second place where product identity is stated, which is the drift the document hierarchy exists to prevent. It does not, because the README asserts no requirement of its own. Every claim it makes links to the document that owns it, and `CLAUDE.md` now names the README as its human-facing summary so the two are checked together when either moves.

## 🤔 Why we need it, and what it replaces

`CLAUDE.md` was not merely incomplete, it was giving instructions against the current repository. The line under the status section read "There is nothing to build, lint, or run. Do not invent commands or claim to have verified behaviour." The first half stopped being true when Wave 0 closed at `9117129`, and all five Wave 1 lanes have landed since (`#6` store bootstrap, `#9` block division, `#7` object store, `#8` token validation, `#10` conformance suite). A session reading that sentence changes Rust and then declines to run `mise run test`, which is the opposite of what the second half of the sentence wants.

Three more gaps were doing real damage:

- **The migration file has a name nothing can find.** `CLAUDE.md` pointed twice at `altair-schema.sql`, including in the pointer to Wave 2's test plan. The file is `crates/altaird/migrations/0001_initial.sql`, and the owed-checks list is at line 886. A session grepping the old name finds nothing and concludes the test plan does not exist.
- **Neither repository guard was documented.** `.claude/hooks/protect-docs.sh` denies every write under `docs/` until a human runs `touch .claude/.docs-unlock`, and `.claude/hooks/no-hook-bypass.sh` refuses `--no-verify` and friends. Both deny rather than ask. The docs guard's own header comment says "see CLAUDE.md", and `CLAUDE.md` never mentioned it, so a session hitting the refusal had nothing to act on.
- **The red conformance suite looked like a defect.** `CLAUDE.md` said Wave 1.5's deliverable was a red suite, but not that it sits behind the `run-conformance` feature, is excluded from `cargo test --workspace`, and runs `continue-on-error` in CI. Without those mechanics, making it pass reads as a reasonable thing to do, and doing so destroys the deliverable.

What this deliberately does not do is edit anything under `docs/`. The stale filename also appears in `docs/altair-v0-implementation-plan.md:138`, and correcting it there is a normative document change behind a human unlock. `CLAUDE.md` now explains the discrepancy in place instead.

## 🎯 The anchor

**Every factual claim in both files was read out of the repository at this head, never paraphrased from the design documents.** That is the property worth checking, because both files are the kind of prose that ages into confident fiction, and this PR exists because that already happened once.

Concretely, that means the wave status came from `git log`, the commands came from `mise.toml` and `.github/workflows/ci.yml`, the crate layout came from `find crates -type f`, the harness behaviour and `ALTAIR_TEST_PREFIX` came from `crates/altaird/src/testing.rs`, the feature gating came from `crates/altair-conformance/Cargo.toml`, and the migration line number came from grepping the file. Anywhere the prose sounds like the vision document but states a mechanism, that is the thing to check.

## 🛠️ How it works

### 1. `README.md`, new, 275 lines

Ordered so a stranger can stop reading at any point and still have gained something:

1. **Seven badges**, each carrying a fact a visitor would otherwise have to go and find, and each linking to whatever settles it: CI status on `main`, the conformance suite's deliberate red (linking to the crate README that explains why), the licence, pre-alpha status, which waves are complete, the Rust edition, and the PostgreSQL baseline (linking to DR-002). Only the CI badge is live; the rest are static, which means they are claims this repository has to keep true rather than readings taken automatically. The waves badge is the one that will need moving first.
2. **A status table**, because the headline is that there is nothing to install yet. It names what has landed per wave and flags that the conformance suite is red on purpose.
3. **What Altair is**: the two principles, the three domains over one entity model, capture and retrieval, and the permanent exclusions, each pointing at `docs/altair-vision.md`.
4. **Architecture in one pass**, with the component map as a mermaid diagram carrying the solid and dotted absence convention from `docs/altair-component-model.md`, including the missing read-path-to-write-path arrow.
5. **Repository layout and the build commands**, which is the section that did not exist anywhere before.
6. **The document hierarchy**, the three rules easiest to violate, and a table of all seven decision records.
7. **The wave plan and the standing constraints**, then GitHub Flow and the licence.

### 2. `CLAUDE.md`, five targeted edits

| Edit | What it fixes |
| --- | --- |
| Status section rewritten | Removes the false "design documents only" claim and the instruction not to run anything |
| `## Commands` added | `mise install`, `.env`, `mise run test`, `mise run conformance`, `prek run --all-files`, plus no `protoc`, the real-Postgres requirement, and `ALTAIR_TEST_PREFIX` |
| `## Two guards that will deny your tool calls` added | Both hooks, each with the human unlock command and why they deny rather than ask |
| `altair-schema.sql` replaced twice | Real path, real line number, and a note that the plan document still uses the old name |
| As-built layout and conformance gating added | Four-line crate tree plus the `run-conformance` and `continue-on-error` mechanics |

The standing instruction not to invent a canonical module tree is untouched, and the new layout block sits directly beneath it framed as observation rather than a settled shape.

## 🔁 What changed since the last review round

The automated review ran against `58d3b31`, before the badges landed. One of its three observations was actionable and is taken.

- **Taken.** The status table ran `0, 1, 2, 4`, so a reader skimming it had to work out whether Wave 3 had been forgotten. Wave 3 now has its own row and Waves 5 and 6 share one, in `bfa6781`.
- **No action, and the reviewer agreed.** The wire contract's `Draft` header against the permanent field numbers claimed elsewhere predates this PR, is untouched by the diff, and stays a disclosed follow-up below.
- **Not a finding.** The review environment had no Docker, so it could not reproduce the test and conformance numbers. Those receipts stand as re-run below.

Landed since that review: the seven badges (`a52bfe5`) and the status table row (`bfa6781`).

## 🧪 Validation

All at `bfa6781`, the current head.

- `prek run --all-files`: 13 hooks green, covering `mado`, `cargo fmt`, `cargo clippy -D warnings`, and the hygiene set. This is the same command CI's lint job runs.
- `cargo test --workspace --locked`: **132 passed, 0 failed** across 20 test binaries. Run with `ALTAIR_TEST_PREFIX=altair_test_readme` because port 5432 was already bound by the main checkout's compose stack, which is exactly the situation the new `ALTAIR_TEST_PREFIX` note in `CLAUDE.md` describes. The note was written before the collision happened and then confirmed by it.
- `mise run conformance`: **0 passed, 35 failed**, and the ledger printed `(none)`. That is the expected red, and it is the receipt for the claim that the suite is red on purpose rather than broken.
- `mado check README.md CLAUDE.md`: passed. Worth stating separately because `.pre-commit-config.yaml` excludes `docs/` from the hygiene hooks but not the repository root, so both files are linted under the same rules as the design documents.
- All 15 relative links in `README.md` resolve to files that exist, and the `#status` anchor the pre-alpha badge points at matches a real heading.
- All 7 badge URLs return HTTP 200 with `image/svg+xml`, and the escaped ones render as intended, so `AGPL--3.0--or--later` comes back with the title `licence: AGPL-3.0-or-later`. A badge that 404s is worse than no badge, so these were fetched rather than assumed.
- The mermaid component map validates and renders as a `flowchart`, checked before posting rather than assumed.

⚠️ Not covered: nothing here is executable, so the only failure mode is prose that is wrong, and no test catches that. The backstop is a human reading it against the repository.

## 🔍 What reviewers should focus on

- **The README's claim boundary.** It should read as a summary that defers, never as a document that decides. If any sentence in it could be read as stating a requirement the design documents do not already state, that sentence is a bug.
- **The status table and the wave status in `CLAUDE.md`.** These are the lines most likely to be wrong now and certain to rot later. Wave 2 is described as next and not started, which matches `crates/altaird/src` having no write path.
- **The two guard descriptions.** They are instructions a future session will follow under refusal, so the unlock commands and the "do not create the marker yourself" instruction need to be exactly right.
- **The six static badges.** Each one is a hand-maintained claim rather than a live reading, so each is a thing that can rot. The waves badge moves at every wave boundary, and the conformance badge has to come down when Wave 4.1 lands. If you would rather carry fewer of them for that reason, cutting the Rust and PostgreSQL ones costs nothing.
- **The register of the README.** It borrows the design documents' voice, bolded claims followed by reasoning. If it reads as marketing rather than as the project's own prose, say so, because that is a judgement call I made rather than a rule I followed.
- **The strongest objection I can think of, and the one worth pressing:** the README and `CLAUDE.md` now overlap on the architecture summary, the wave table, and the standing constraints, which is three places for the same facts to drift. The alternative is a thin README that only links, and it was rejected because a front door that says "read these twenty documents" is not a front door. If you would rather have the thin version, that is a reasonable call and cheap to make now.

Out of scope: anything under `docs/`, the wire contract's status, and any change to what the documents say.

## 📌 Follow-ups

- **`docs/altair-v0-implementation-plan.md:138` still names `altair-schema.sql`.** Behind the docs guard, so it needs `touch .claude/.docs-unlock` from you before it can be corrected. `CLAUDE.md` explains the discrepancy in the meantime.
- **The wire contract's header still reads "Draft. Field numbers are not permanent until this file is accepted."** `CLAUDE.md`, the implementation plan, and now the README all treat the numbers as permanent and the contract as accepted. Flipping that status is a normative decision rather than a documentation fix, so it waits for you to take it.


