### PR TITLE
Wave 2.1: the intent spine, and migration two beneath it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,3 +173,13 @@ Match the existing register — these documents have a deliberate and consistent
 - Decisions are marked **one-way** (reversing it means rewriting dependants) or **reversible** (changeable behind a boundary). Where something is common industry practice rather than a judgement call, it says so.
 - Documents end with "Deliberately not decided" and "Open questions". Move something out of "Open questions" only when it has actually been decided somewhere normative.
 - Decision records are `DR-NNN-kebab-title.md` with Context / Decision / Alternatives considered / Consequences / Deliberately not decided here.
+
+## What Wave 2.1 settled, for the lanes that follow
+
+Observations from building the intent spine that 2.2, 2.3, and 2.4 would otherwise re-derive.
+
+- **A part is named in one place.** `crates/altaird/src/write/parts.rs` holds the wire field number, the store's text name, and the conflict row's spelling, and `tests/write_parts.rs` keeps them in step. Adding a type-specific part in 2.2 means adding it there, not beside the code that writes it.
+- **Type content is not applied yet, deliberately.** 2.1 creates each type's side-table row with defaults; the fields inside `content.specific` are read for the type tag and nothing else. That is the plan's division, and it is invisible in v0 because no client exists before Wave 4.
+- **Three refusals expire.** A file create, an anchor on a relation, and an explicit `category_position` are all refused as malformed with a detail saying why. Each waits on a lane that is named: 2.3, 2.2, and whatever first reorders.
+- **Erasure's dependent-table list is a constant**, `DEPENDENT_TABLES` in `write/entity.rs`. A new table holding entity content is one line there and one line in `tests/write_lifecycle.rs`, and forgetting is silent because the schema's cascades never fire.
+- **The guards are blunt on purpose and were sharpened twice here.** `WritePath::new` tripped the object-store boundary on `Path::`, and the wire's audience field tripped the one-predicate column check. Both now match at a word boundary, and the two whole-tree checks that reason about the instance skip test sources — a test asserting that both paths call one predicate has to be able to read past it. Watch a guard fail on a deliberate violation before and after touching one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repository is right now
 
-**Design documents plus the first two waves of the instance.** Everything in `docs/` specifies a self-hosted personal system ("Altair"); `crates/` is the beginning of it. Wave 0 and all five Wave 1 lanes have landed — store bootstrap and the audience predicate, block division, the object store, token validation, and the outbox conformance suite. **Wave 2, the write path, is next and is not started.** There is no running instance and no client.
+**Design documents plus the first two waves of the instance.** Everything in `docs/` specifies a self-hosted personal system ("Altair"); `crates/` is the beginning of it. Wave 0, all five Wave 1 lanes, and Wave 2.1 have landed — store bootstrap and the audience predicate, block division, the object store, token validation, the outbox conformance suite, and the intent spine. **Wave 2.2 onward — type content, file bodies, reclamation — is next and is not started.** There is no client, and the instance serves `Submit` and nothing else.
 
 Consequences for working here:
 
@@ -64,6 +64,7 @@ Rules that follow from this and are easy to violate:
 ## Documents that are already accepted as artefacts
 
 - `crates/altaird/migrations/0001_initial.sql` — the structured store, adopted as **migration one**. Applied and exercised on PostgreSQL 18.6 with pgvector 0.8.6. Do not re-derive it.
+- `crates/altaird/migrations/0002_write_provenance.sql` — **migration two**, taken at the start of 2.1. `entity_part_counter` holds, per part, the counter it last moved at and the member who moved it, because conflict detection asks which parts moved between two counter values and nothing else could answer it. A relation gains a lifecycle, the time it was removed, and the act that removed it. Both shapes rejected for the first are recorded in the file.
 - `proto/altair/v1/altair.proto` — the public interface (`package altair.v1`). **Field numbers are permanent; removed fields are reserved, never reused.** Closing one of its recorded gaps means adding a field, not editing one.
 - `conformance/scenarios.md` — the outbox specification made executable, written once and run against every implementation (Rust and Kotlin). Scenarios observe behaviour at two boundaries only: what the person sees, and what reaches the instance.
 
@@ -91,8 +92,10 @@ Rules that follow from this and are easy to violate:
 What has actually been built so far, which is observation rather than a settled tree:
 
 ```text
-crates/altaird/            the instance: store/ (audience, tx, entity, ids), body/, objects/, auth/
-crates/altaird/migrations/ 0001_initial.sql, migration one, not re-derived
+crates/altaird/            the instance: store/ (audience, tx, entity, ids), body/, objects/,
+                           auth/, write/ (parts, provenance, changes, intent, entity, relation),
+                           service.rs (Submit served, the other five unimplemented)
+crates/altaird/migrations/ 0001_initial.sql and 0002_write_provenance.sql, not re-derived
 crates/altair-proto/       generated contract types (protox + tonic)
 crates/altair-conformance/ the outbox harness and a null client stub
 ```
@@ -105,7 +108,7 @@ Seven waves. Waves 1–3 are planned against reality; Wave 5 onward names outcom
 |---|---|---|
 | 0 · Plumbing | Cargo workspace, proto codegen in the build, migration runner (`0001_initial.sql` as migration one), integration harness, CI | Harness stands up a **real PostgreSQL**, not a mock — the audience predicate, both indexes and `SKIP LOCKED` are Postgres behaviour. Done when a fresh checkout runs one command and passes an empty suite. |
 | 1 · Foundations | 1.1 store bootstrap · 1.2 block division · 1.3 object store · 1.4 token validation · 1.5 outbox conformance suite | Five genuinely independent lanes, one worktree each. 1.5's deliverable is a **red suite** — every scenario runs and fails. |
-| 2 · Write path | 2.1 intent spine, **including relations and the served submission call** · 2.2 type content, all three domains · 2.3 file bodies · 2.4 reclamation | 2.1 is sequential and load-bearing; do not parallelise the spine, do parallelise what hangs off it. Re-planned at the Wave 1 boundary: **migration two** opens 2.1, adding per-part write provenance and a lifecycle on a relation. |
+| 2 · Write path | 2.1 intent spine, **including relations and the served submission call** — landed · 2.2 type content, all three domains · 2.3 file bodies · 2.4 reclamation | 2.1 is sequential and load-bearing; do not parallelise the spine, do parallelise what hangs off it. Re-planned at the Wave 1 boundary: **migration two** opens 2.1, adding per-part write provenance and a lifecycle on a relation. |
 | 3 · Read path | 3.1 literal retrieval arm · 3.2 change stream and horizon · 3.3 health | Literal only. Build the instance half of the change stream even though the TUI need not consume it — omitting the instance side is one-way. |
 | 4 · Terminal client | 4.1 Rust outbox (turns 1.5 green) · 4.2 ratatui client | **First useful day.** The TUI carries the whole editing surface; there is no browser and no second client. |
 | 5 · Semantic | derivation worker · inference boundary and bi-encoder · semantic arm and fusion | The embedding model is chosen **here**, against a real corpus, and fixes the schema dimension. |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "hyper-util",
  "jsonwebtoken",
  "proptest",
+ "prost-types",
  "pulldown-cmark",
  "ring",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,6 @@ dependencies = [
  "hyper-util",
  "jsonwebtoken",
  "proptest",
- "prost-types",
  "pulldown-cmark",
  "ring",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,10 +49,12 @@ dependencies = [
 name = "altaird"
 version = "0.0.0"
 dependencies = [
+ "altair-proto",
  "altaird",
  "anyhow",
  "async-trait",
  "base64",
+ "chrono",
  "dotenvy",
  "futures",
  "http-body-util",
@@ -69,6 +71,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
+ "tonic",
  "uuid",
 ]
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ One instance serves one household. Nobody else can raise the price, change the t
 |---|---|
 | Design documents (`docs/`) | Written. The vision, three domain PRDs, the substrate, the architecture, and seven decision records |
 | Wire contract (`proto/altair/v1/altair.proto`) | Accepted. Field numbers are permanent |
-| Structured store schema (`crates/altaird/migrations/0001_initial.sql`) | Accepted as migration one. Applied and exercised on PostgreSQL 18.6 with pgvector 0.8.6 |
+| Structured store schema (`crates/altaird/migrations/`) | `0001_initial.sql` is migration one, applied and exercised on PostgreSQL 18.6 with pgvector 0.8.6. `0002_write_provenance.sql` adds per-part write provenance and a lifecycle on a relation |
 | Wave 0 · plumbing | Landed. Workspace, proto codegen, migration runner, a real-Postgres test harness, CI |
 | Wave 1 · foundations | Landed. Store bootstrap and the audience predicate, block division, the object store, token validation, and the outbox conformance suite |
-| Wave 2 · write path | Next. The intent spine, type content, file bodies, reclamation |
+| Wave 2 · write path | 2.1, the intent spine, has landed: identity and idempotent replay, the counter and conflict detection, the change sequence, relations, lifecycle, and the served submission call. Type content, file bodies, and reclamation are next |
 | Wave 3 · read path | Literal retrieval, the change stream and its horizon, health |
 | Wave 4 · terminal client | The first useful day. Nothing before it is usable software |
 | Waves 5 and 6 | Semantic retrieval, then the message bridge and operations |
@@ -139,7 +139,7 @@ docs/                      Design documents. The authority the implementation is
 proto/altair/v1/           The public interface. Field numbers are permanent
 conformance/scenarios.md   The outbox specification, made executable, run against every implementation
 crates/
-  altaird/                 The instance: store, block division, object store, token validation
+  altaird/                 The instance: store, block division, object store, token validation, write path
     migrations/            0001_initial.sql is migration one, and is not re-derived
   altair-proto/            Generated contract types (protox + tonic, no protoc needed)
   altair-conformance/      The conformance harness. Red on purpose until Wave 4.1

--- a/crates/altair-proto/src/lib.rs
+++ b/crates/altair-proto/src/lib.rs
@@ -4,6 +4,11 @@
 //! this crate generates and re-exports; it never adapts. Everything a client
 //! or the instance needs from the wire lives under [`v1`].
 
+/// The well-known types the contract uses, re-exported so nothing downstream
+/// takes its own dependency on them. A timestamp on the wire is the wire's,
+/// and it should come from the same place the messages holding it do.
+pub use prost_types;
+
 // Nothing here is written by hand, so lints that ask for a different shape have
 // no one to address. Boxing a large oneof variant, for one, is prost's call and
 // not ours.

--- a/crates/altaird/Cargo.toml
+++ b/crates/altaird/Cargo.toml
@@ -34,7 +34,6 @@ uuid = { version = "1.24.1", features = ["v4"] }
 [dev-dependencies]
 altaird = { path = ".", features = ["testing"] }
 proptest = "1.11.0"
-prost-types = "0.14.4"
 chrono = { version = "0.4.42", default-features = false, features = ["std", "clock"] }
 base64 = "0.22.1"
 ring = "0.17.14"

--- a/crates/altaird/Cargo.toml
+++ b/crates/altaird/Cargo.toml
@@ -34,6 +34,8 @@ uuid = { version = "1.24.1", features = ["v4"] }
 [dev-dependencies]
 altaird = { path = ".", features = ["testing"] }
 proptest = "1.11.0"
+prost-types = "0.14.4"
+chrono = { version = "0.4.42", default-features = false, features = ["std", "clock"] }
 base64 = "0.22.1"
 ring = "0.17.14"
 tokio = { version = "1.53.1", features = ["io-util", "net"] }

--- a/crates/altaird/Cargo.toml
+++ b/crates/altaird/Cargo.toml
@@ -9,8 +9,10 @@ publish.workspace = true
 testing = ["dep:dotenvy"]
 
 [dependencies]
+altair-proto = { path = "../altair-proto" }
 anyhow = "1.0.104"
 async-trait = "0.1.89"
+chrono = { version = "0.4.42", default-features = false, features = ["std", "clock"] }
 dotenvy = { version = "0.15.7", optional = true }
 pulldown-cmark = { version = "0.13.4", default-features = false }
 http-body-util = "0.1.3"
@@ -24,6 +26,8 @@ sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio
 tokio = { version = "1.53.1", features = ["fs", "io-util", "macros", "rt-multi-thread", "time"] }
 futures = "0.3.31"
 thiserror = "2.0.19"
+tokio-stream = "0.1.18"
+tonic = "0.14.6"
 uuid = { version = "1.24.1", features = ["v4"] }
 
 
@@ -33,4 +37,5 @@ proptest = "1.11.0"
 base64 = "0.22.1"
 ring = "0.17.14"
 tokio = { version = "1.53.1", features = ["io-util", "net"] }
+tokio-stream = { version = "0.1.18", features = ["net"] }
 tempfile = "3.24.0"

--- a/crates/altaird/migrations/0002_write_provenance.sql
+++ b/crates/altaird/migrations/0002_write_provenance.sql
@@ -1,0 +1,132 @@
+-- Altair structured store, migration two: per-part write provenance, and a
+-- lifecycle on a relation.
+--
+-- Status: Draft.
+-- Governed by: DR-002, Altair Substrate Specification, Altair Component Model,
+--              Altair v0 Implementation Plan (Wave 2.1).
+--
+-- Taken once, at the start of the intent spine, because everything in that
+-- item reads one or the other. The two changes are unrelated to each other and
+-- are here together only because they were both found by reading Wave 2.1
+-- against the documents before writing any of it.
+--
+-- The rules migration one states about what is a constraint and what is a
+-- write-path check are unchanged and are not restated.
+
+-- ---------------------------------------------------------------------------
+-- Per-part write provenance
+-- ---------------------------------------------------------------------------
+--
+-- Conflict detection asks a question nothing in migration one could answer.
+-- The rule from the substrate is that a stale base touching parts disjoint
+-- from what moved since applies without conflict, and evaluating it needs to
+-- know *which parts moved between two counter values*.
+--
+-- Nothing held that. The change sequence carries block identities but no field
+-- list and no counter; an intent row carries the counter after a write but not
+-- what it wrote; and versions are Knowledge-only and a household may decline
+-- them entirely.
+--
+-- So: one row per part of an entity that has ever been written, holding the
+-- counter the part last moved at and the member who moved it. The member is
+-- here because a conflict names whose the other value was, and an entity's
+-- author is its creator and never changes, so the author cannot answer it.
+--
+-- A part is a field, except in a body, where it is the block. That is the same
+-- shape the conflict table already uses, and the two are deliberately spelled
+-- the same way so a reader meeting one recognises the other.
+--
+-- Rejected: a map of parts to counters as a document column on the entity row.
+-- Fewer moving parts, and it would die with the row rather than needing its own
+-- removal on erasure. Against it: the shape would be unenforced by the store,
+-- and a document column in a schema that rejected one for content invites the
+-- argument every time somebody reads it.
+--
+-- Rejected: the changed parts and the counter on the change row. It reuses a
+-- write the transaction already makes and adds no table. Against it: the change
+-- sequence is trimmed below the horizon, so conflict correctness would decay as
+-- history is trimmed, and making the write path depend on a trimmer having not
+-- yet run is the wrong direction.
+
+CREATE TABLE entity_part_counter (
+  entity_id  uuid NOT NULL REFERENCES entity (id) ON DELETE CASCADE,
+
+  -- The part is the field, except in a body, where it is the block. Exactly
+  -- one of these is set, as on the conflict table.
+  --
+  -- The name is text here and a field number on the wire. Something has to
+  -- hold that mapping; migration one recorded that as gap (d) and it is still
+  -- true. What is new is that there are now two tables keyed by it, so the
+  -- mapping has to be written once rather than once per table.
+  field_name text,
+  block_id   uuid REFERENCES block (id) ON DELETE CASCADE,
+
+  -- The entity counter this part last moved at. Compared against an edit's
+  -- base counter, and never shown to anyone.
+  counter    bigint NOT NULL,
+
+  -- Who moved it. A conflict names whose the other value was, and this is
+  -- where that comes from.
+  member_id  uuid NOT NULL REFERENCES membership (id),
+
+  CHECK (num_nonnulls(field_name, block_id) = 1),
+
+  -- NULLS NOT DISTINCT because exactly one of the two key columns is set, so
+  -- the default null-is-distinct behaviour would let the same part be recorded
+  -- any number of times.
+  UNIQUE NULLS NOT DISTINCT (entity_id, field_name, block_id)
+);
+
+-- ---------------------------------------------------------------------------
+-- A relation joins the holding state
+-- ---------------------------------------------------------------------------
+--
+-- The wire can name a relation in a removal and migration one had nowhere to
+-- hold the result. The substrate is explicit that removing a relation is
+-- reversible on the same terms as removing an entity: it leaves traversal, it
+-- comes back with the act that removed it, and there is no restoring one on
+-- its own.
+--
+-- This needs no change to the wire. A removal is already the relation-gone
+-- signal, a restoration is an ordinary relation write, and restoring an entity
+-- with its group reaches the relations in that group.
+--
+-- Rejected: a hard delete, documented as such. It is what migration one and
+-- the wire already implied and it would have cost one sentence. Against it: it
+-- would be the only permanent destructive act in the design with no holding
+-- state and no announcement, in a document that says anything becoming
+-- permanent does so visibly and never as a side effect.
+
+ALTER TABLE relation
+  ADD COLUMN lifecycle         lifecycle_state NOT NULL DEFAULT 'active',
+  ADD COLUMN deleted_at        timestamptz,
+  ADD COLUMN deletion_group_id uuid;
+
+-- The same two invariants the entity row carries, spelled the same way.
+ALTER TABLE relation
+  ADD CONSTRAINT relation_holding_state
+    CHECK ((lifecycle = 'deleted') = (deleted_at IS NOT NULL)),
+  ADD CONSTRAINT relation_group_only_when_deleted
+    CHECK (deletion_group_id IS NULL OR lifecycle = 'deleted');
+
+-- A relation is never a tombstone. Erasing either endpoint removes the
+-- relation outright, which is what erasure means everywhere, and there is
+-- nothing for a tombstone to carry: no edit can arrive for a relation that
+-- needs recognising as a recreation, because a relation has no content a
+-- person would retype.
+--
+-- The enum is shared with the entity row rather than a second one being
+-- declared, because the two states a relation does have mean exactly what they
+-- mean there.
+ALTER TABLE relation
+  ADD CONSTRAINT relation_is_never_a_tombstone
+    CHECK (lifecycle <> 'erased');
+
+-- Restoring an act reaches the relations it removed, which is a read by group.
+CREATE INDEX relation_group_idx ON relation (deletion_group_id)
+  WHERE deletion_group_id IS NOT NULL;
+
+-- The holding window expires by comparison against deleted_at, and it now
+-- reaches relations as well as entities.
+CREATE INDEX relation_holding_idx ON relation (deleted_at)
+  WHERE lifecycle = 'deleted';

--- a/crates/altaird/src/lib.rs
+++ b/crates/altaird/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod auth;
 pub mod body;
 pub mod objects;
+pub mod service;
 pub mod store;
+pub mod write;
 
 #[cfg(feature = "testing")]
 pub mod testing;

--- a/crates/altaird/src/service.rs
+++ b/crates/altaird/src/service.rs
@@ -1,0 +1,138 @@
+//! The public interface, served.
+//!
+//! # One call is served and five are not, on purpose
+//!
+//! Wave 2.1 stands up `Submit` end to end and answers the other five
+//! `unimplemented`. Two of the write path's requirements are observable only
+//! here and are not testable from an internal function:
+//!
+//! - **A submission is never all or nothing.** The answer carries one
+//!   acknowledgement per intent, in the order submitted, and an intent that was
+//!   refused does not affect the one after it.
+//! - **A refusal reveals nothing, and DR-004 extends that to the status code.**
+//!   A submission whose every intent was refused answers `Ok`, with the
+//!   refusals inside it. Any other status would say, at the transport, the
+//!   thing the single refusal reason exists to avoid saying.
+//!
+//! `tests/submission_call.rs` asserts both, and asserts that the five are
+//! deliberately absent rather than forgotten.
+//!
+//! # What a status means here
+//!
+//! The substrate divides conditions into a **wait**, which the ordinary path
+//! clears by continuing to run, and a **fault**, which it does not.
+//!
+//! - `Unauthenticated` — a wait. An absent, expired, forged, or unknown
+//!   credential all produce it, indistinguishably, and DR-005 says the client
+//!   holds silently. It is not a fault and must not be signalled as one.
+//! - `Unavailable` — a wait. The store could not be reached, nothing was
+//!   acknowledged, and the outbox holds. To the person this is the same as the
+//!   instance being unreachable, which is why it is the same outcome.
+//! - `Unimplemented` — a fault. Waiting will not clear it. That is the honest
+//!   answer for the five calls this item does not serve.
+//!
+//! **An intent being refused is none of these.** It is `Ok`, inside the
+//! response, which is what makes a batch partial.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tonic::{Request, Response, Status};
+
+use altair_proto::v1;
+
+use crate::auth::{Authentication, Authenticator, Member, bearer_token};
+use crate::write::WritePath;
+
+/// The instance, as callers reach it.
+pub struct Instance {
+    auth: Arc<Authenticator>,
+    write: WritePath,
+}
+
+impl Instance {
+    #[must_use]
+    pub fn new(auth: Arc<Authenticator>, write: WritePath) -> Self {
+        Self { auth, write }
+    }
+
+    /// Resolve the credential on a request, or say nothing about why not.
+    ///
+    /// Unauthenticated reaches no query surface: a caller of this has a
+    /// `Member` or has a `Status`, and there is no third thing to hold.
+    async fn member<T>(&self, request: &Request<T>) -> Result<Member, Status> {
+        let header = request
+            .metadata()
+            .get("authorization")
+            .and_then(|v| v.to_str().ok());
+        match self.auth.authenticate(bearer_token(header)).await {
+            // The store was unavailable while resolving a membership. A wait.
+            Err(_) => Err(Status::unavailable("")),
+            Ok(Authentication::Unauthenticated) => Err(Status::unauthenticated("")),
+            Ok(Authentication::Member(m)) => Ok(m),
+        }
+    }
+}
+
+/// The five calls Wave 2.1 does not serve.
+///
+/// One message rather than five, because a caller has nothing to do differently
+/// for any of them and the difference would only invite one to try.
+const NOT_YET: &str = "this call is not served by this build";
+
+#[tonic::async_trait]
+impl v1::altair_server::Altair for Instance {
+    async fn submit(
+        &self,
+        request: Request<v1::SubmitRequest>,
+    ) -> Result<Response<v1::SubmitResponse>, Status> {
+        let member = self.member(&request).await?;
+        let intents = request.into_inner().intents;
+
+        match self.write.submit(&member, &intents).await {
+            Ok(acknowledgements) => Ok(Response::new(v1::SubmitResponse { acknowledgements })),
+            // The instance failed, so nothing was acknowledged and the caller's
+            // outbox holds. Silent: the detail would describe the store to
+            // somebody who cannot act on it.
+            Err(_) => Err(Status::unavailable("")),
+        }
+    }
+
+    async fn query(
+        &self,
+        _request: Request<v1::QueryRequest>,
+    ) -> Result<Response<v1::QueryResponse>, Status> {
+        Err(Status::unimplemented(NOT_YET))
+    }
+
+    async fn changes(
+        &self,
+        _request: Request<v1::ChangesRequest>,
+    ) -> Result<Response<v1::ChangesResponse>, Status> {
+        Err(Status::unimplemented(NOT_YET))
+    }
+
+    async fn get_health(
+        &self,
+        _request: Request<v1::HealthRequest>,
+    ) -> Result<Response<v1::HealthResponse>, Status> {
+        Err(Status::unimplemented(NOT_YET))
+    }
+
+    async fn put_body(
+        &self,
+        _request: Request<tonic::Streaming<v1::BodyChunk>>,
+    ) -> Result<Response<v1::PutBodyAck>, Status> {
+        Err(Status::unimplemented(NOT_YET))
+    }
+
+    type GetBodyStream =
+        Pin<Box<dyn tokio_stream::Stream<Item = Result<v1::BodyChunk, Status>> + Send>>;
+
+    async fn get_body(
+        &self,
+        _request: Request<v1::BodyRequest>,
+    ) -> Result<Response<Self::GetBodyStream>, Status> {
+        Err(Status::unimplemented(NOT_YET))
+    }
+}

--- a/crates/altaird/src/store/entity.rs
+++ b/crates/altaird/src/store/entity.rs
@@ -3,6 +3,7 @@
 //! Both go through [`CandidateQuery`], so both carry the same audience
 //! predicate, and there is no third shape that does not.
 
+use chrono::{DateTime, Utc};
 use sqlx::Row;
 use sqlx::postgres::PgRow;
 
@@ -27,8 +28,26 @@ pub struct EntityRow {
     /// departure, so these too are references and not requesters.
     pub audience: Vec<MemberRef>,
     pub lifecycle: LifecycleState,
+    /// When the entity entered the holding state. Null unless deleted, which
+    /// the store checks.
+    pub deleted_at: Option<DateTime<Utc>>,
+    /// The act a removal of several entities was, retained so that restoring
+    /// any of them can bring back the rest.
+    pub deletion_group_id: Option<uuid::Uuid>,
     /// Advances on every accepted write. Never shown to anyone.
     pub counter: i64,
+    /// Set once by the creating client. Settles the order of nothing.
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    /// An open set: clients add ways to create things.
+    pub capture_method: String,
+    /// Whether the entity is still filterable as bulk captured.
+    pub bulk: bool,
+    /// The category it is in, if any. Containment, not a relation.
+    pub category_id: Option<EntityId>,
+    /// Its position within that category. Assigned by the write path, which
+    /// appends on entry.
+    pub category_position: Option<i32>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type)]
@@ -61,7 +80,9 @@ pub enum LifecycleState {
 fn columns() -> String {
     format!(
         "e.id, e.type AS entity_type, e.title, e.author_member_id, \
-         e.{AUDIENCE_COLUMN} AS audience, e.lifecycle, e.counter"
+         e.{AUDIENCE_COLUMN} AS audience, e.lifecycle, e.deleted_at, \
+         e.deletion_group_id, e.counter, e.created_at, e.updated_at, \
+         e.capture_method, e.bulk, e.category_id, e.category_position"
     )
 }
 
@@ -79,7 +100,17 @@ fn row(r: &PgRow) -> sqlx::Result<EntityRow> {
             .map(MemberRef::from_uuid)
             .collect(),
         lifecycle: r.try_get("lifecycle")?,
+        deleted_at: r.try_get("deleted_at")?,
+        deletion_group_id: r.try_get("deletion_group_id")?,
         counter: r.try_get("counter")?,
+        created_at: r.try_get("created_at")?,
+        updated_at: r.try_get("updated_at")?,
+        capture_method: r.try_get("capture_method")?,
+        bulk: r.try_get("bulk")?,
+        category_id: r
+            .try_get::<Option<uuid::Uuid>, _>("category_id")?
+            .map(EntityId::from_uuid),
+        category_position: r.try_get("category_position")?,
     })
 }
 
@@ -127,6 +158,118 @@ pub async fn candidates(
         "ORDER BY e.created_at DESC, e.id LIMIT $?",
         [Bind::Int(limit)],
     );
+    let rows = q.build().fetch_all(tx.conn()).await?;
+    rows.iter().map(row).collect()
+}
+
+/// The next position in a category's order, which is one past the last.
+///
+/// **Deliberately unscoped, and this is the one read here that is.** Every
+/// other query in this module carries the audience predicate because it
+/// produces candidates — rows a member is entitled to see. This produces an
+/// integer and no content at all.
+///
+/// Scoping it would be actively wrong. Position is unique within a container,
+/// and the substrate requires the order to be total and stable. A maximum taken
+/// over only the entities the writing member can see would hand out a position
+/// already held by one they cannot, so two entities would share a position and
+/// the order would stop being total — a correctness failure produced by
+/// applying an access rule to something that is not an access question.
+///
+/// Nothing about the answer discloses anything: the count of things in a
+/// container is not reachable from an integer that is one larger than a number
+/// the caller never learns the provenance of, and the caller already knows the
+/// container exists because it had to be visible to name it.
+///
+/// The substrate's rule is *entering a container places the entity at the end*,
+/// and it holds whether the entity is newly created, moved from another
+/// container, or restored.
+pub async fn next_category_position(tx: &mut WriteTx, category: EntityId) -> sqlx::Result<i32> {
+    let row = sqlx::query(
+        "SELECT coalesce(max(category_position), -1) + 1 AS next \
+         FROM entity WHERE category_id = $1",
+    )
+    .bind(category.as_uuid())
+    .fetch_one(tx.conn())
+    .await?;
+    row.try_get("next")
+}
+
+/// One entity that has just left a container, as the change sequence needs it.
+pub struct Uncategorised {
+    pub id: EntityId,
+    pub audience: Vec<MemberRef>,
+    pub author: Option<MemberRef>,
+    pub counter: i64,
+}
+
+/// Take every entity out of a category, because the category is gone.
+///
+/// The substrate's rule is that *an entity whose category is deleted becomes
+/// uncategorised, which is a valid state requiring no repair*, and erasure is
+/// the stronger form of the same thing. Leaving the reference would point every
+/// member of the category at a tombstone.
+///
+/// **Deliberately unscoped**, for the same reason as
+/// [`next_category_position`] and a sharper one: the container is gone for
+/// everybody, so leaving the entities a writing member cannot see still in it
+/// would keep a dangling reference alive precisely where nobody can find it.
+/// Nothing leaves this function that a caller can show anyone — the identities
+/// go into change entries, and those are assembled per member by the read path,
+/// which applies the predicate then.
+///
+/// The counter advances on each, because it is an accepted write to those
+/// entities and a client that holds one has to learn its category went away.
+pub async fn uncategorise_all(
+    tx: &mut WriteTx,
+    category: EntityId,
+    at: DateTime<Utc>,
+) -> sqlx::Result<Vec<Uncategorised>> {
+    let sql = format!(
+        "UPDATE entity SET category_id = NULL, category_position = NULL, \
+         counter = counter + 1, updated_at = $2 \
+         WHERE category_id = $1 \
+         RETURNING id, {AUDIENCE_COLUMN} AS audience, author_member_id, counter"
+    );
+    let rows = sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(category.as_uuid())
+        .bind(at)
+        .fetch_all(tx.conn())
+        .await?;
+
+    rows.iter()
+        .map(|r| {
+            Ok(Uncategorised {
+                id: r.try_get("id")?,
+                audience: r
+                    .try_get::<Vec<uuid::Uuid>, _>("audience")?
+                    .into_iter()
+                    .map(MemberRef::from_uuid)
+                    .collect(),
+                author: r
+                    .try_get::<Option<uuid::Uuid>, _>("author_member_id")?
+                    .map(MemberRef::from_uuid),
+                counter: r.try_get("counter")?,
+            })
+        })
+        .collect()
+}
+
+/// The entities a single removal act put into holding, as this member can see
+/// them.
+///
+/// Scoped, and through [`CandidateQuery`] like every other candidate set: a
+/// group is a set of entities, so producing one is producing candidates. That
+/// it cannot leak anything in practice — a member could not have removed what
+/// they could not see — is not a reason to build the one query that would if
+/// the assumption ever stopped holding.
+pub async fn holding_group(
+    tx: &mut WriteTx,
+    group: uuid::Uuid,
+    member: MemberId,
+) -> sqlx::Result<Vec<EntityRow>> {
+    let q = CandidateQuery::new(member, WriteScope::Holding.into(), &columns())
+        .and_where("e.deletion_group_id = $?", [Bind::Uuid(group)]);
     let rows = q.build().fetch_all(tx.conn()).await?;
     rows.iter().map(row).collect()
 }

--- a/crates/altaird/src/write/changes.rs
+++ b/crates/altaird/src/write/changes.rs
@@ -1,0 +1,202 @@
+//! The change sequence: one entry per write, in commit order.
+//!
+//! # Read this before you make writes stop serialising on one row
+//!
+//! **Every write in the instance takes an exclusive lock on a single row, and
+//! that is the design rather than an oversight.** It is the thing in this
+//! codebase most likely to be identified by a future reader — including the
+//! person who wrote it — as an obvious bottleneck and removed, so the reasoning
+//! is here, next to the code, and not only in a document.
+//!
+//! A position is allocated by incrementing `change_position.next_position`
+//! inside the writing transaction. The obvious replacement is a Postgres
+//! sequence, which is faster, lock-free, and wrong:
+//!
+//! - A sequence is not transactional. Two writers take positions 7 and 8, the
+//!   holder of 8 commits first, and the holder of 7 is still open.
+//! - A client polling `Changes` sees 8, records its position as 8, and returns
+//!   later asking for everything after 8.
+//! - 7 commits in between and is never delivered to that client. Nothing
+//!   detects it, because the client's position is a number and 7 is behind it.
+//!
+//! That is a partial answer presented as a complete one, which is the single
+//! failure the change stream exists to prevent. A sequence also leaves gaps on
+//! rollback, so a client cannot tell a hole it must wait for from a hole that
+//! will never be filled.
+//!
+//! Allocating from a row inside the transaction makes commit order and position
+//! order the same by construction, and a rolled-back write leaves no gap
+//! because its increment rolls back with it. The cost is that writes serialise.
+//! For one household that is not a cost worth paying anything to avoid.
+//!
+//! **The lock is taken deliberately early**, by [`hold_the_sequence`], before
+//! anything an intent writes. Two things depend on that:
+//!
+//! - Position within a container is `max + 1`, which is only safe against a
+//!   concurrent writer if the two are already serialised. Holding the sequence
+//!   row is what makes the read-then-write safe without a second lock over
+//!   the container.
+//! - Taking it last would mean two transactions could do all their work
+//!   concurrently and then collide at the end, which turns a contended write
+//!   into wasted work rather than into a wait.
+//!
+//! # What an entry says
+//!
+//! An entry carries the audience *before* and *after* the write, because
+//! broadening makes something appear to a member for the first time and
+//! narrowing makes it vanish, and to that member those are creation and
+//! disappearance. Assembling one member's stream from the current audience
+//! alone would produce nothing at all for the member who lost sight of an
+//! entity, which is the leak this column pair exists to prevent. Assembly
+//! itself is the read path's, in Wave 3.2.
+
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+use uuid::Uuid;
+
+use crate::store::WriteTx;
+use crate::store::ids::{EntityId, MemberRef};
+
+/// Take the sequence row's lock for the rest of this transaction.
+///
+/// Called once, before an intent writes anything. See the module docs for why
+/// it is first rather than last.
+pub async fn hold_the_sequence(tx: &mut WriteTx) -> sqlx::Result<()> {
+    sqlx::query("SELECT next_position FROM change_position WHERE singleton FOR UPDATE")
+        .fetch_one(tx.conn())
+        .await?;
+    Ok(())
+}
+
+/// Allocate the next position. Serialises; see the module docs.
+async fn allocate(tx: &mut WriteTx) -> sqlx::Result<i64> {
+    let row = sqlx::query(
+        "UPDATE change_position SET next_position = next_position + 1 \
+         WHERE singleton RETURNING next_position - 1 AS position",
+    )
+    .fetch_one(tx.conn())
+    .await?;
+    row.try_get("position")
+}
+
+/// What an entity write moved, from the change stream's point of view.
+///
+/// The audience pair is the whole reason this struct exists rather than the
+/// call taking an entity id: a narrowing has to reach the member who lost sight
+/// of the entity, and by the time the row is written the current audience no
+/// longer names them.
+pub struct EntityChange {
+    pub entity: EntityId,
+    pub audience_before: Option<Vec<MemberRef>>,
+    pub audience_after: Option<Vec<MemberRef>>,
+    pub author_before: Option<MemberRef>,
+    pub author_after: Option<MemberRef>,
+    /// Where a body moved, which blocks moved. Bodies are Wave 2.2, so this is
+    /// empty here, and it is a parameter rather than an omission so that adding
+    /// bodies does not mean revisiting the shape of an entry.
+    pub changed_blocks: Vec<Uuid>,
+}
+
+fn ids(members: &Option<Vec<MemberRef>>) -> Option<Vec<Uuid>> {
+    members
+        .as_ref()
+        .map(|m| m.iter().copied().map(MemberRef::as_uuid).collect())
+}
+
+/// Created, edited, removed, or restored. **Removal is a change carrying a
+/// lifecycle state, not an absence**, which is why it is this and not
+/// [`entity_gone`].
+pub async fn entity_written(
+    tx: &mut WriteTx,
+    at: DateTime<Utc>,
+    change: &EntityChange,
+) -> sqlx::Result<i64> {
+    write_entity_row(tx, at, "entity_written", change).await
+}
+
+/// Erased. The entity is gone and the sequence has to be able to say so, which
+/// is why the change table carries no foreign key.
+pub async fn entity_gone(
+    tx: &mut WriteTx,
+    at: DateTime<Utc>,
+    change: &EntityChange,
+) -> sqlx::Result<i64> {
+    write_entity_row(tx, at, "entity_gone", change).await
+}
+
+async fn write_entity_row(
+    tx: &mut WriteTx,
+    at: DateTime<Utc>,
+    kind: &str,
+    change: &EntityChange,
+) -> sqlx::Result<i64> {
+    let position = allocate(tx).await?;
+    sqlx::query(
+        "INSERT INTO change (position, occurred_at, kind, entity_id, \
+         audience_before, audience_after, author_before, author_after, \
+         changed_block_ids) \
+         VALUES ($1, $2, $3::change_kind, $4, $5, $6, $7, $8, $9)",
+    )
+    .bind(position)
+    .bind(at)
+    .bind(kind)
+    .bind(change.entity.as_uuid())
+    .bind(ids(&change.audience_before))
+    .bind(ids(&change.audience_after))
+    .bind(change.author_before.map(MemberRef::as_uuid))
+    .bind(change.author_after.map(MemberRef::as_uuid))
+    .bind(&change.changed_blocks)
+    .execute(tx.conn())
+    .await?;
+    Ok(position)
+}
+
+/// Created, edited, or restored.
+///
+/// **A removed relation is [`relation_gone`], not this.** The wire carries a
+/// relation with no lifecycle field, so there is no shape in which a change
+/// says "this relation is now in holding". A member's stream is told the
+/// connection is no longer there, and a restoration says it is there again.
+/// That is the same rule as an entity a member can no longer see: nothing
+/// distinguishes gone from no-longer-visible, deliberately.
+pub async fn relation_written(
+    tx: &mut WriteTx,
+    at: DateTime<Utc>,
+    relation: Uuid,
+) -> sqlx::Result<i64> {
+    write_relation_row(tx, at, "relation_written", relation).await
+}
+
+/// Removed, or removed outright because an endpoint was erased.
+pub async fn relation_gone(
+    tx: &mut WriteTx,
+    at: DateTime<Utc>,
+    relation: Uuid,
+) -> sqlx::Result<i64> {
+    write_relation_row(tx, at, "relation_gone", relation).await
+}
+
+async fn write_relation_row(
+    tx: &mut WriteTx,
+    at: DateTime<Utc>,
+    kind: &str,
+    relation: Uuid,
+) -> sqlx::Result<i64> {
+    // A relation entry carries no audience pair. A relation's visibility
+    // follows its endpoints', which the change row cannot restate without
+    // holding a copy that can go stale, so assembling a member's relation
+    // changes is a question about the endpoints and belongs to the read path
+    // in Wave 3.2.
+    let position = allocate(tx).await?;
+    sqlx::query(
+        "INSERT INTO change (position, occurred_at, kind, relation_id) \
+         VALUES ($1, $2, $3::change_kind, $4)",
+    )
+    .bind(position)
+    .bind(at)
+    .bind(kind)
+    .bind(relation)
+    .execute(tx.conn())
+    .await?;
+    Ok(position)
+}

--- a/crates/altaird/src/write/content.rs
+++ b/crates/altaird/src/write/content.rs
@@ -1,0 +1,289 @@
+//! Reading `EntityContent` off the wire, and saying what a write touched.
+//!
+//! # Set, cleared, untouched
+//!
+//! The wire's rule is the same in every message that holds parts:
+//!
+//! ```text
+//! present            set to this value
+//! listed in cleared  cleared, or emptied where the field is repeated
+//! neither            untouched
+//! ```
+//!
+//! Two of the schema's owed checks live here and nowhere else, because this is
+//! the only place that can see them: **a field both present and cleared**, and
+//! **a cleared number naming no field**. Both are malformed — the message
+//! cannot be read as a well-formed intent — and neither is something a later
+//! layer can recover, because by then the ambiguity has been resolved one way
+//! or the other by whoever wrote the code.
+//!
+//! # Why a part carries its own text
+//!
+//! Both retained sides of a conflict cross as text whatever the part's kind is
+//! (the proto's gap (g), the schema's gap (c)). So conflict detection compares
+//! text, which means the rendering has to be stable and has to be produced the
+//! same way for an arriving value and for a stored one. Producing it here, from
+//! one function per part, is what makes *writes producing the same value are
+//! not divergent* a comparison rather than a hope.
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use altair_proto::v1;
+
+use crate::store::entity::EntityType;
+use crate::store::ids::EntityId;
+
+use super::parts::{ContentPart, Part};
+
+/// A labelled date, as the store holds one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Date {
+    pub label: String,
+    pub occurs_at: DateTime<Utc>,
+    pub bring_forward: bool,
+}
+
+/// One part of `EntityContent`, with the value a write is setting it to.
+///
+/// Clearing is `None` at the inner level for a singular field and an empty
+/// vector for a repeated one, which is the wire's own rule rather than a
+/// convention invented here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PartWrite {
+    Title(Option<String>),
+    Dates(Vec<Date>),
+    Category(Option<EntityId>),
+    CategoryPosition(Option<i32>),
+    Assignments(Vec<Uuid>),
+    Audience(Vec<Uuid>),
+    Bulk(Option<bool>),
+}
+
+impl PartWrite {
+    #[must_use]
+    pub fn part(&self) -> Part {
+        Part::Content(match self {
+            Self::Title(_) => ContentPart::Title,
+            Self::Dates(_) => ContentPart::Dates,
+            Self::Category(_) => ContentPart::Category,
+            Self::CategoryPosition(_) => ContentPart::CategoryPosition,
+            Self::Assignments(_) => ContentPart::Assignments,
+            Self::Audience(_) => ContentPart::Audience,
+            Self::Bulk(_) => ContentPart::Bulk,
+        })
+    }
+
+    /// The text this value is retained as when it is one side of a conflict.
+    ///
+    /// `None` means the part holds nothing — cleared, or never set — which is
+    /// distinct from holding the empty string.
+    #[must_use]
+    pub fn text(&self) -> Option<String> {
+        match self {
+            Self::Title(v) => v.clone(),
+            Self::Dates(v) => (!v.is_empty()).then(|| {
+                v.iter()
+                    .map(|d| {
+                        format!(
+                            "{}\u{1f}{}\u{1f}{}",
+                            d.label,
+                            d.occurs_at.to_rfc3339(),
+                            d.bring_forward
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\u{1e}")
+            }),
+            Self::Category(v) => v.map(|c| c.as_uuid().to_string()),
+            Self::CategoryPosition(v) => v.map(|p| p.to_string()),
+            // Sorted, so that two clients listing the same members in different
+            // orders are not read as disagreeing. A set has no order and the
+            // wire carries it as a list.
+            Self::Assignments(v) | Self::Audience(v) => (!v.is_empty()).then(|| {
+                let mut ids: Vec<String> = v.iter().map(ToString::to_string).collect();
+                ids.sort_unstable();
+                ids.join(",")
+            }),
+            Self::Bulk(v) => v.map(|b| b.to_string()),
+        }
+    }
+}
+
+/// Why a piece of content could not be read.
+#[derive(Debug, Clone)]
+pub struct Malformed(pub String);
+
+fn malformed(what: impl Into<String>) -> Malformed {
+    Malformed(what.into())
+}
+
+/// A sixteen-byte identifier, or nothing.
+///
+/// Length is one of the checks the schema names as *everything the wire shape
+/// implies*. An identifier of the wrong length is not a short identifier; it is
+/// a message that cannot be read.
+pub fn identifier(bytes: &[u8]) -> Result<Uuid, Malformed> {
+    let sized: [u8; 16] = bytes.try_into().map_err(|_| {
+        malformed(format!(
+            "an identifier is 16 bytes, this one is {}",
+            bytes.len()
+        ))
+    })?;
+    Ok(Uuid::from_bytes(sized))
+}
+
+/// The type an entity is, which is the tag of `content.specific`.
+///
+/// There is no parallel type field for it to disagree with, so an absent tag is
+/// an entity of no type, which nothing can store.
+pub fn entity_type(content: &v1::EntityContent) -> Result<EntityType, Malformed> {
+    use v1::entity_content::Specific;
+    match content.specific.as_ref() {
+        Some(Specific::Campaign(_)) => Ok(EntityType::Campaign),
+        Some(Specific::Arc(_)) => Ok(EntityType::Arc),
+        Some(Specific::Quest(_)) => Ok(EntityType::Quest),
+        Some(Specific::Routine(_)) => Ok(EntityType::Routine),
+        Some(Specific::FocusSession(_)) => Ok(EntityType::FocusSession),
+        Some(Specific::CheckIn(_)) => Ok(EntityType::CheckIn),
+        Some(Specific::Note(_)) => Ok(EntityType::Note),
+        Some(Specific::File(_)) => Ok(EntityType::File),
+        Some(Specific::Item(_)) => Ok(EntityType::Item),
+        Some(Specific::Location(_)) => Ok(EntityType::Location),
+        Some(Specific::ShoppingList(_)) => Ok(EntityType::ShoppingList),
+        Some(Specific::Category(_)) => Ok(EntityType::Category),
+        None => Err(malformed(
+            "the type is the tag of content.specific, and this content carries none",
+        )),
+    }
+}
+
+/// Every part this content addresses, in the order the message declares them.
+///
+/// # What it refuses
+///
+/// - A field both present and cleared. The two instructions contradict each
+///   other and there is no reading that honours both.
+/// - A cleared number naming no addressable part. A reserved number, an unknown
+///   one, or `cleared` itself. Silently ignoring it would let a client believe
+///   it had cleared something.
+///
+/// # What it does not do
+///
+/// It does not reach `content.specific`. Type content is Wave 2.2's, and 2.1
+/// creates each type's row with defaults so nothing is ever half-formed. A
+/// create carrying type content therefore lands as an entity of that type whose
+/// type-specific fields hold their defaults, and the fields themselves are not
+/// applied. That is the plan's division rather than an omission here, and it is
+/// invisible in v0 because no client exists before Wave 4.
+pub fn parts_written(content: &v1::EntityContent) -> Result<Vec<PartWrite>, Malformed> {
+    let mut cleared = Vec::new();
+    for number in &content.cleared {
+        let part = ContentPart::from_field_number(*number).ok_or_else(|| {
+            malformed(format!("cleared names field {number}, which is not a part"))
+        })?;
+        cleared.push(part);
+    }
+    let is_cleared = |p: ContentPart| cleared.contains(&p);
+
+    let both = |p: ContentPart| {
+        malformed(format!(
+            "field {} is both present and listed as cleared",
+            p.field_number()
+        ))
+    };
+
+    let mut written = Vec::new();
+
+    if let Some(title) = &content.title {
+        if is_cleared(ContentPart::Title) {
+            return Err(both(ContentPart::Title));
+        }
+        written.push(PartWrite::Title(Some(title.clone())));
+    } else if is_cleared(ContentPart::Title) {
+        written.push(PartWrite::Title(None));
+    }
+
+    if !content.dates.is_empty() {
+        if is_cleared(ContentPart::Dates) {
+            return Err(both(ContentPart::Dates));
+        }
+        let mut dates = Vec::with_capacity(content.dates.len());
+        for d in &content.dates {
+            let when = d
+                .when
+                .as_ref()
+                .and_then(|t| {
+                    DateTime::from_timestamp(t.seconds, u32::try_from(t.nanos).unwrap_or(0))
+                })
+                .ok_or_else(|| malformed("a labelled date carries no usable instant"))?;
+            dates.push(Date {
+                label: d.label.clone(),
+                occurs_at: when,
+                bring_forward: d.bring_forward,
+            });
+        }
+        written.push(PartWrite::Dates(dates));
+    } else if is_cleared(ContentPart::Dates) {
+        written.push(PartWrite::Dates(Vec::new()));
+    }
+
+    if let Some(id) = &content.category_id {
+        if is_cleared(ContentPart::Category) {
+            return Err(both(ContentPart::Category));
+        }
+        written.push(PartWrite::Category(Some(EntityId::from_uuid(identifier(
+            id,
+        )?))));
+    } else if is_cleared(ContentPart::Category) {
+        written.push(PartWrite::Category(None));
+    }
+
+    if let Some(p) = content.category_position {
+        if is_cleared(ContentPart::CategoryPosition) {
+            return Err(both(ContentPart::CategoryPosition));
+        }
+        written.push(PartWrite::CategoryPosition(Some(
+            i32::try_from(p).map_err(|_| malformed("a position that large is not one"))?,
+        )));
+    } else if is_cleared(ContentPart::CategoryPosition) {
+        written.push(PartWrite::CategoryPosition(None));
+    }
+
+    if !content.assigned_member_ids.is_empty() {
+        if is_cleared(ContentPart::Assignments) {
+            return Err(both(ContentPart::Assignments));
+        }
+        let mut ids = Vec::new();
+        for m in &content.assigned_member_ids {
+            ids.push(identifier(m)?);
+        }
+        written.push(PartWrite::Assignments(ids));
+    } else if is_cleared(ContentPart::Assignments) {
+        written.push(PartWrite::Assignments(Vec::new()));
+    }
+
+    if !content.audience_member_ids.is_empty() {
+        if is_cleared(ContentPart::Audience) {
+            return Err(both(ContentPart::Audience));
+        }
+        let mut ids = Vec::new();
+        for m in &content.audience_member_ids {
+            ids.push(identifier(m)?);
+        }
+        written.push(PartWrite::Audience(ids));
+    } else if is_cleared(ContentPart::Audience) {
+        written.push(PartWrite::Audience(Vec::new()));
+    }
+
+    if let Some(b) = content.bulk {
+        if is_cleared(ContentPart::Bulk) {
+            return Err(both(ContentPart::Bulk));
+        }
+        written.push(PartWrite::Bulk(Some(b)));
+    } else if is_cleared(ContentPart::Bulk) {
+        written.push(PartWrite::Bulk(None));
+    }
+
+    Ok(written)
+}

--- a/crates/altaird/src/write/content.rs
+++ b/crates/altaird/src/write/content.rs
@@ -118,6 +118,27 @@ fn malformed(what: impl Into<String>) -> Malformed {
     Malformed(what.into())
 }
 
+/// An instant, as the wire carries one.
+///
+/// **Refused rather than absorbed.** A timestamp whose nanos do not fit, or
+/// whose seconds name no representable instant, is a message that cannot be
+/// read — the same class as an identifier of the wrong length, and one of the
+/// schema's owed checks for the same reason: *everything the wire shape
+/// implies*.
+///
+/// This exists as one function because two callers parse the same shape and
+/// they were not agreeing. A labelled date refused a garbled instant; a
+/// create's `created_at` silently substituted the instance's own clock, so a
+/// client with a broken clock conversion was told its capture had been
+/// accepted with a time it never sent. Whichever of those is right, they
+/// cannot both be, and refusing is the one that tells the client something.
+pub fn instant(t: &altair_proto::prost_types::Timestamp) -> Result<DateTime<Utc>, Malformed> {
+    let nanos = u32::try_from(t.nanos)
+        .map_err(|_| malformed("a timestamp's nanos are not a fraction of a second"))?;
+    DateTime::from_timestamp(t.seconds, nanos)
+        .ok_or_else(|| malformed("a timestamp naming no representable instant"))
+}
+
 /// A sixteen-byte identifier, or nothing.
 ///
 /// Length is one of the checks the schema names as *everything the wire shape
@@ -213,10 +234,8 @@ pub fn parts_written(content: &v1::EntityContent) -> Result<Vec<PartWrite>, Malf
             let when = d
                 .when
                 .as_ref()
-                .and_then(|t| {
-                    DateTime::from_timestamp(t.seconds, u32::try_from(t.nanos).unwrap_or(0))
-                })
-                .ok_or_else(|| malformed("a labelled date carries no usable instant"))?;
+                .ok_or_else(|| malformed("a labelled date carries no instant"))?;
+            let when = instant(when)?;
             dates.push(Date {
                 label: d.label.clone(),
                 occurs_at: when,

--- a/crates/altaird/src/write/entity.rs
+++ b/crates/altaird/src/write/entity.rs
@@ -1,0 +1,871 @@
+//! The five verbs, on an entity.
+//!
+//! Everything here runs inside one transaction that has already taken the
+//! change sequence's lock; see [`super::changes`] for why that ordering
+//! matters.
+//!
+//! # What this item writes, and what it leaves to 2.2
+//!
+//! The shared model — title, dates, category and the position inside it,
+//! assignments, audience, bulk — is written here. **Type-specific content is
+//! not.** A create makes the side-table row with its defaults so nothing is
+//! ever half-formed, and the fields inside `content.specific` are left for
+//! Wave 2.2, which owns bodies, anchors, the ladder, and cycle prevention in
+//! nested containers.
+//!
+//! Two types are refused for reasons that expire, which is the honest answer
+//! rather than an omission:
+//!
+//! - **A file**, until 2.3. The schema requires a file to name a body, and
+//!   there is no way to have uploaded one.
+//! - **A routine, a focus session, or a check-in**, until each domain is
+//!   designed. The schema deliberately creates no table for them, so there is
+//!   nothing to put a row in.
+
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+use uuid::Uuid;
+
+use crate::store::audience::AUDIENCE_COLUMN;
+use crate::store::entity::{EntityRow, EntityType, LifecycleState, available_for_write};
+use crate::store::ids::{EntityId, MemberId, MemberRef};
+use crate::store::{WriteScope, WriteTx};
+
+use super::changes::{self, EntityChange};
+use super::content::{Date, Malformed, PartWrite};
+use super::outcome::{ConflictParts, Outcome};
+use super::provenance;
+
+/// One intent's worth of context: the transaction, who is writing, and when.
+pub struct Ctx<'a> {
+    pub tx: &'a mut WriteTx,
+    pub member: MemberId,
+    pub at: DateTime<Utc>,
+}
+
+impl Ctx<'_> {
+    fn author(&self) -> MemberRef {
+        MemberRef::from_uuid(self.member.as_uuid())
+    }
+}
+
+/// A refusal raised from inside the apply path, which the spine turns into an
+/// acknowledgement after rolling the transaction back.
+pub enum Refusal {
+    NotAvailable,
+    Malformed(String),
+}
+
+impl From<Malformed> for Refusal {
+    fn from(m: Malformed) -> Self {
+        Self::Malformed(m.0)
+    }
+}
+
+/// Either a refusal or a store fault. The two are kept apart all the way out:
+/// a refusal is an answer, a fault is the instance failing and produces no
+/// acknowledgement at all.
+pub enum Failed {
+    Refused(Refusal),
+    Store(sqlx::Error),
+}
+
+impl From<sqlx::Error> for Failed {
+    fn from(e: sqlx::Error) -> Self {
+        Self::Store(e)
+    }
+}
+
+impl From<Refusal> for Failed {
+    fn from(r: Refusal) -> Self {
+        Self::Refused(r)
+    }
+}
+
+impl From<Malformed> for Failed {
+    fn from(m: Malformed) -> Self {
+        Self::Refused(Refusal::Malformed(m.0))
+    }
+}
+
+pub type Applied<T> = Result<T, Failed>;
+
+/// Every member named must answer to a real membership.
+///
+/// **A foreign key cannot reach inside an array**, which is what the schema
+/// says about the audience column and is the reason this check exists at all.
+/// It covers assignments too, where a foreign key does exist, so that a bad
+/// identifier is a refusal rather than a constraint violation that takes the
+/// whole transaction down with a message nobody can act on.
+pub async fn memberships_exist(tx: &mut WriteTx, ids: &[Uuid]) -> Applied<bool> {
+    if ids.is_empty() {
+        return Ok(true);
+    }
+    let mut wanted: Vec<Uuid> = ids.to_vec();
+    wanted.sort_unstable();
+    wanted.dedup();
+    let row = sqlx::query("SELECT count(*) AS n FROM membership WHERE id = ANY($1)")
+        .bind(&wanted)
+        .fetch_one(tx.conn())
+        .await?;
+    Ok(row.try_get::<i64, _>("n")? == wanted.len() as i64)
+}
+
+/// The value a part currently holds, rendered by the same code the arriving
+/// value goes through.
+async fn current(ctx: &mut Ctx<'_>, row: &EntityRow, part: &PartWrite) -> Applied<PartWrite> {
+    Ok(match part {
+        PartWrite::Title(_) => PartWrite::Title(row.title.clone()),
+        PartWrite::Dates(_) => {
+            let rows = sqlx::query(
+                "SELECT label, occurs_at, bring_forward FROM entity_date \
+                 WHERE entity_id = $1 ORDER BY ordinal",
+            )
+            .bind(row.id.as_uuid())
+            .fetch_all(ctx.tx.conn())
+            .await?;
+            let mut dates = Vec::with_capacity(rows.len());
+            for r in &rows {
+                dates.push(Date {
+                    label: r.try_get("label")?,
+                    occurs_at: r.try_get("occurs_at")?,
+                    bring_forward: r.try_get("bring_forward")?,
+                });
+            }
+            PartWrite::Dates(dates)
+        }
+        PartWrite::Category(_) => PartWrite::Category(row.category_id),
+        PartWrite::CategoryPosition(_) => PartWrite::CategoryPosition(row.category_position),
+        PartWrite::Assignments(_) => {
+            let rows = sqlx::query("SELECT member_id FROM entity_assignment WHERE entity_id = $1")
+                .bind(row.id.as_uuid())
+                .fetch_all(ctx.tx.conn())
+                .await?;
+            let mut ids = Vec::with_capacity(rows.len());
+            for r in &rows {
+                ids.push(r.try_get("member_id")?);
+            }
+            PartWrite::Assignments(ids)
+        }
+        PartWrite::Audience(_) => PartWrite::Audience(
+            row.audience
+                .iter()
+                .copied()
+                .map(MemberRef::as_uuid)
+                .collect(),
+        ),
+        PartWrite::Bulk(_) => PartWrite::Bulk(Some(row.bulk)),
+    })
+}
+
+/// Apply one part to the store. Assumes it has already been validated.
+async fn apply_part(ctx: &mut Ctx<'_>, entity: EntityId, part: &PartWrite) -> Applied<()> {
+    match part {
+        PartWrite::Title(v) => {
+            // search_text is maintained by the write path from the title and
+            // whatever the type contributes, because those live in side tables
+            // and a generated column cannot reach them. Only the title
+            // contributes here; the type's share arrives with 2.2.
+            sqlx::query("UPDATE entity SET title = $2, search_text = $3 WHERE id = $1")
+                .bind(entity.as_uuid())
+                .bind(v.as_deref())
+                .bind(v.as_deref().unwrap_or(""))
+                .execute(ctx.tx.conn())
+                .await?;
+        }
+        PartWrite::Dates(dates) => {
+            sqlx::query("DELETE FROM entity_date WHERE entity_id = $1")
+                .bind(entity.as_uuid())
+                .execute(ctx.tx.conn())
+                .await?;
+            for (ordinal, d) in dates.iter().enumerate() {
+                sqlx::query(
+                    "INSERT INTO entity_date (entity_id, ordinal, label, occurs_at, bring_forward) \
+                     VALUES ($1, $2, $3, $4, $5)",
+                )
+                .bind(entity.as_uuid())
+                .bind(i32::try_from(ordinal).unwrap_or(i32::MAX))
+                .bind(&d.label)
+                .bind(d.occurs_at)
+                .bind(d.bring_forward)
+                .execute(ctx.tx.conn())
+                .await?;
+            }
+        }
+        PartWrite::Category(v) => {
+            sqlx::query("UPDATE entity SET category_id = $2 WHERE id = $1")
+                .bind(entity.as_uuid())
+                .bind(v.map(EntityId::as_uuid))
+                .execute(ctx.tx.conn())
+                .await?;
+        }
+        PartWrite::CategoryPosition(v) => {
+            sqlx::query("UPDATE entity SET category_position = $2 WHERE id = $1")
+                .bind(entity.as_uuid())
+                .bind(*v)
+                .execute(ctx.tx.conn())
+                .await?;
+        }
+        PartWrite::Assignments(ids) => {
+            sqlx::query("DELETE FROM entity_assignment WHERE entity_id = $1")
+                .bind(entity.as_uuid())
+                .execute(ctx.tx.conn())
+                .await?;
+            for id in ids {
+                sqlx::query(
+                    "INSERT INTO entity_assignment (entity_id, member_id) VALUES ($1, $2) \
+                     ON CONFLICT DO NOTHING",
+                )
+                .bind(entity.as_uuid())
+                .bind(id)
+                .execute(ctx.tx.conn())
+                .await?;
+            }
+        }
+        PartWrite::Audience(ids) => {
+            let sql = format!("UPDATE entity SET {AUDIENCE_COLUMN} = $2 WHERE id = $1");
+            sqlx::query(sqlx::AssertSqlSafe(sql))
+                .bind(entity.as_uuid())
+                .bind(ids)
+                .execute(ctx.tx.conn())
+                .await?;
+        }
+        PartWrite::Bulk(v) => {
+            sqlx::query("UPDATE entity SET bulk = $2 WHERE id = $1")
+                .bind(entity.as_uuid())
+                .bind(v.unwrap_or(false))
+                .execute(ctx.tx.conn())
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+/// Checks a part owes before it is applied, and the placement the instance
+/// makes rather than the client.
+///
+/// Returns any extra part the instance moved as a consequence — a position,
+/// when a category changed.
+async fn validate_and_place(
+    ctx: &mut Ctx<'_>,
+    entering: Option<EntityId>,
+    part: &PartWrite,
+) -> Applied<Option<PartWrite>> {
+    match part {
+        PartWrite::Audience(ids) | PartWrite::Assignments(ids) => {
+            if !memberships_exist(ctx.tx, ids).await? {
+                return Err(Refusal::NotAvailable.into());
+            }
+            Ok(None)
+        }
+        PartWrite::CategoryPosition(_) => Err(Refusal::Malformed(
+            "position is assigned by the instance, which appends on entry to a container; \
+             explicit reordering is not served yet"
+                .into(),
+        )
+        .into()),
+        PartWrite::Category(Some(category)) => {
+            // The container has to be one this member can see, and it has to be
+            // a category. Both refusals are the same nothing.
+            let found = available_for_write(ctx.tx, ctx.member, *category, WriteScope::Active)
+                .await?
+                .ok_or(Refusal::NotAvailable)?;
+            if found.entity_type != EntityType::Category {
+                return Err(Refusal::NotAvailable.into());
+            }
+            // Entering a container places the entity at the end. This holds
+            // whether the entity is newly created, moved from another
+            // container, or restored, and it is safe as a read-then-write only
+            // because the sequence row is already held.
+            let entering_this = entering != Some(*category);
+            if entering_this {
+                let next = crate::store::entity::next_category_position(ctx.tx, *category).await?;
+                return Ok(Some(PartWrite::CategoryPosition(Some(next))));
+            }
+            Ok(None)
+        }
+        // Leaving a container forgets the position. Nothing is carried and
+        // nothing needs repair.
+        PartWrite::Category(None) => Ok(Some(PartWrite::CategoryPosition(None))),
+        _ => Ok(None),
+    }
+}
+
+/// The side-table row a type carries beyond the shared model, with its
+/// defaults.
+///
+/// Note and shopping list have no table: a body is its blocks in order and
+/// there is nothing else, which is a result rather than an omission.
+async fn make_type_row(ctx: &mut Ctx<'_>, entity: EntityId, kind: EntityType) -> Applied<()> {
+    let table = match kind {
+        EntityType::Campaign => "campaign",
+        EntityType::Arc => "arc",
+        EntityType::Quest => "quest",
+        EntityType::Item => "item",
+        EntityType::Location => "location",
+        EntityType::Category => "category",
+        EntityType::Note | EntityType::ShoppingList => return Ok(()),
+        EntityType::File => {
+            return Err(Refusal::Malformed(
+                "a file names a body that must be uploaded first, and PutBody is not served yet"
+                    .into(),
+            )
+            .into());
+        }
+        EntityType::Routine | EntityType::FocusSession | EntityType::CheckIn => {
+            return Err(Refusal::Malformed(
+                "this type's content is not yet designed and the store has no table for it".into(),
+            )
+            .into());
+        }
+    };
+    let sql = format!("INSERT INTO {table} (entity_id) VALUES ($1)");
+    sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(entity.as_uuid())
+        .execute(ctx.tx.conn())
+        .await?;
+    Ok(())
+}
+
+/// A category's creation default, which acts once and is never inherited.
+async fn creation_default_audience(ctx: &mut Ctx<'_>, category: EntityId) -> Applied<Vec<Uuid>> {
+    let row =
+        sqlx::query("SELECT creation_default_audience AS a FROM category WHERE entity_id = $1")
+            .bind(category.as_uuid())
+            .fetch_optional(ctx.tx.conn())
+            .await?;
+    Ok(row
+        .map(|r| r.try_get::<Vec<Uuid>, _>("a"))
+        .transpose()?
+        .unwrap_or_default())
+}
+
+/// Create an entity.
+pub async fn create(
+    ctx: &mut Ctx<'_>,
+    id: EntityId,
+    created_at: Option<DateTime<Utc>>,
+    capture_method: &str,
+    parts: Vec<PartWrite>,
+    kind: EntityType,
+) -> Applied<Outcome> {
+    // A create naming something that is already here is not a second entity.
+    // The outbox's idempotence is carried by intent identity, but the substrate
+    // states the rule about entities directly — the same entity submitted twice
+    // produces one entity, not two — and a create arriving under a fresh intent
+    // identity is exactly that case.
+    if let Some(existing) =
+        available_for_write(ctx.tx, ctx.member, id, WriteScope::AnyIncludingErased).await?
+    {
+        // A tombstone is not a free identity. Recreating under an erased id
+        // would reuse an identity somebody erased, and anything that once
+        // pointed at it would silently reattach.
+        if existing.lifecycle == LifecycleState::Erased || existing.entity_type != kind {
+            return Err(Refusal::NotAvailable.into());
+        }
+        return Ok(Outcome::applied_entity(id, existing.counter));
+    }
+    // Either it is not there, or it is there and invisible. The second is a
+    // refusal and the first is a create, and the two are told apart by trying
+    // the insert: an identifier the member cannot see still collides on the
+    // primary key, and the collision is caught by the spine as a fault-free
+    // refusal rather than by asking a question that would answer it.
+
+    let created_at = created_at.unwrap_or(ctx.at);
+
+    // Audience is private to the author unless the write says otherwise, or the
+    // category it lands in states a creation default. The default acts once, at
+    // creation, and an explicit audience outranks it.
+    let stated_audience = parts.iter().any(|p| matches!(p, PartWrite::Audience(_)));
+    let category = parts.iter().find_map(|p| match p {
+        PartWrite::Category(Some(c)) => Some(*c),
+        _ => None,
+    });
+
+    let sql = format!(
+        "INSERT INTO entity \
+         (id, type, title, author_member_id, created_at, updated_at, capture_method, \
+          bulk, {AUDIENCE_COLUMN}, lifecycle, counter, search_text) \
+         VALUES ($1, $2::entity_type, NULL, $3, $4, $5, $6, false, '{{}}', 'active', 1, '')"
+    );
+    sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(id.as_uuid())
+        .bind(type_name(kind))
+        .bind(ctx.member.as_uuid())
+        .bind(created_at)
+        .bind(ctx.at)
+        .bind(capture_method)
+        .execute(ctx.tx.conn())
+        .await?;
+
+    make_type_row(ctx, id, kind).await?;
+
+    let mut written = Vec::new();
+    for part in &parts {
+        if let Some(extra) = validate_and_place(ctx, None, part).await? {
+            apply_part(ctx, id, &extra).await?;
+            written.push(extra.part());
+        }
+        apply_part(ctx, id, part).await?;
+        written.push(part.part());
+    }
+
+    if !stated_audience && let Some(category) = category {
+        let default = creation_default_audience(ctx, category).await?;
+        if !default.is_empty() {
+            if !memberships_exist(ctx.tx, &default).await? {
+                return Err(Refusal::NotAvailable.into());
+            }
+            let part = PartWrite::Audience(default);
+            apply_part(ctx, id, &part).await?;
+            written.push(part.part());
+        }
+    }
+
+    provenance::record(ctx.tx, id, &written, 1, ctx.member).await?;
+
+    let after = read_audience(ctx, id).await?;
+    changes::entity_written(
+        ctx.tx,
+        ctx.at,
+        &EntityChange {
+            entity: id,
+            // Nothing was there, so there is no audience before. Null rather
+            // than empty: empty means private to the author, which is a state
+            // the entity was never in.
+            audience_before: None,
+            audience_after: Some(after),
+            author_before: None,
+            author_after: Some(ctx.author()),
+            changed_blocks: Vec::new(),
+        },
+    )
+    .await?;
+
+    Ok(Outcome::applied_entity(id, 1))
+}
+
+async fn read_audience(ctx: &mut Ctx<'_>, id: EntityId) -> Applied<Vec<MemberRef>> {
+    let row = available_for_write(ctx.tx, ctx.member, id, WriteScope::AnyIncludingErased).await?;
+    Ok(row.map(|r| r.audience).unwrap_or_default())
+}
+
+fn type_name(kind: EntityType) -> &'static str {
+    match kind {
+        EntityType::Campaign => "campaign",
+        EntityType::Arc => "arc",
+        EntityType::Quest => "quest",
+        EntityType::Routine => "routine",
+        EntityType::FocusSession => "focus_session",
+        EntityType::CheckIn => "check_in",
+        EntityType::Note => "note",
+        EntityType::File => "file",
+        EntityType::Item => "item",
+        EntityType::Location => "location",
+        EntityType::ShoppingList => "shopping_list",
+        EntityType::Category => "category",
+    }
+}
+
+/// Edit an entity, or recreate it where the entity was erased.
+pub async fn edit(
+    ctx: &mut Ctx<'_>,
+    id: EntityId,
+    base_counter: i64,
+    parts: Vec<PartWrite>,
+    stated_type: Option<EntityType>,
+) -> Applied<Outcome> {
+    let row = available_for_write(ctx.tx, ctx.member, id, WriteScope::AnyIncludingErased)
+        .await?
+        .ok_or(Refusal::NotAvailable)?;
+
+    // Type is fixed at creation. The store cannot see that it is fixed, so this
+    // is the check that makes it true.
+    if let Some(stated) = stated_type
+        && stated != row.entity_type
+    {
+        return Err(Refusal::Malformed("an edit may not change an entity's type".into()).into());
+    }
+
+    if row.lifecycle == LifecycleState::Erased {
+        return recreate(ctx, &row, parts).await;
+    }
+
+    let mut touching = Vec::new();
+    let mut written = Vec::new();
+    let counter = row.counter + 1;
+
+    for part in &parts {
+        if let Some(extra) = validate_and_place(ctx, row.category_id, part).await? {
+            let stored = current(ctx, &row, &extra).await?;
+            touching.push((extra.part(), extra.text(), stored.text()));
+            apply_part(ctx, id, &extra).await?;
+            written.push(extra.part());
+        }
+        let stored = current(ctx, &row, part).await?;
+        touching.push((part.part(), part.text(), stored.text()));
+        apply_part(ctx, id, part).await?;
+        written.push(part.part());
+    }
+
+    // A stale base is never a rejection. What it can be is a conflict, and only
+    // over the parts that actually overlap what moved since.
+    let mut conflict = ConflictParts::default();
+    if base_counter < row.counter {
+        let moved = provenance::moved_since(ctx.tx, id, base_counter).await?;
+        let retained = provenance::detect(&touching, &moved, ctx.member);
+        for r in &retained {
+            conflict.push(&r.part);
+        }
+        provenance::retain(ctx.tx, id, &retained, ctx.at).await?;
+    }
+
+    provenance::record(ctx.tx, id, &written, counter, ctx.member).await?;
+    sqlx::query("UPDATE entity SET counter = $2, updated_at = $3 WHERE id = $1")
+        .bind(id.as_uuid())
+        .bind(counter)
+        .bind(ctx.at)
+        .execute(ctx.tx.conn())
+        .await?;
+
+    let after = read_audience(ctx, id).await?;
+    changes::entity_written(
+        ctx.tx,
+        ctx.at,
+        &EntityChange {
+            entity: id,
+            audience_before: Some(row.audience.clone()),
+            audience_after: Some(after),
+            author_before: row.author,
+            author_after: row.author,
+            changed_blocks: Vec::new(),
+        },
+    )
+    .await?;
+
+    Ok(Outcome::Applied {
+        entities: vec![id],
+        relations: Vec::new(),
+        counter: Some(counter),
+        conflict: (!conflict.is_empty()).then_some(conflict),
+    })
+}
+
+/// An edit arrived for an entity that was erased.
+///
+/// **The erasure stands and so does the person's work.** The identity is new
+/// and is stated rather than inferred, because anything that pointed at the
+/// erased entity pointed at something that no longer exists.
+///
+/// **Audience is private to the author, whatever it was before.** A deliberate
+/// departure from recreating faithfully: erasure is the affordance for
+/// something that should not have been there, and a device that was offline
+/// recreating it with a household audience would re-expose the thing erasure
+/// exists to remove. Broadening is trivial and narrowing is unreliable, so the
+/// closed default is the safe one.
+async fn recreate(
+    ctx: &mut Ctx<'_>,
+    tombstone: &EntityRow,
+    parts: Vec<PartWrite>,
+) -> Applied<Outcome> {
+    let new = EntityId::from_uuid(Uuid::new_v4());
+    let parts: Vec<PartWrite> = parts
+        .into_iter()
+        .filter(|p| !matches!(p, PartWrite::Audience(_)))
+        .collect();
+
+    let outcome = create(
+        ctx,
+        new,
+        Some(ctx.at),
+        &tombstone.capture_method,
+        parts,
+        tombstone.entity_type,
+    )
+    .await?;
+
+    let counter = match outcome {
+        Outcome::Applied { counter, .. } => counter.unwrap_or(1),
+        _ => 1,
+    };
+    Ok(Outcome::Recreated {
+        original: tombstone.id,
+        new,
+        counter,
+    })
+}
+
+/// Put entities into the holding state, as part of one act.
+///
+/// **A removal that cannot land has already happened.** An identifier this
+/// member cannot see, one that does not exist, and one that is already removed
+/// all converge on the end state the person asked for, so none of them is a
+/// refusal. Reporting one would tell them only that the thing they wanted is
+/// the thing that occurred — and, in the first case, would answer a question
+/// about whether something exists.
+pub async fn remove(ctx: &mut Ctx<'_>, ids: &[EntityId], group: Uuid) -> Applied<Vec<EntityId>> {
+    let mut removed = Vec::new();
+    for id in ids {
+        let Some(row) = available_for_write(ctx.tx, ctx.member, *id, WriteScope::Active).await?
+        else {
+            continue;
+        };
+        sqlx::query(
+            "UPDATE entity SET lifecycle = 'deleted', deleted_at = $2, \
+             deletion_group_id = $3, counter = counter + 1, updated_at = $2 WHERE id = $1",
+        )
+        .bind(id.as_uuid())
+        .bind(ctx.at)
+        .bind(group)
+        .execute(ctx.tx.conn())
+        .await?;
+
+        changes::entity_written(
+            ctx.tx,
+            ctx.at,
+            &EntityChange {
+                entity: *id,
+                audience_before: Some(row.audience.clone()),
+                audience_after: Some(row.audience),
+                author_before: row.author,
+                author_after: row.author,
+                changed_blocks: Vec::new(),
+            },
+        )
+        .await?;
+        removed.push(*id);
+    }
+    Ok(removed)
+}
+
+/// Bring an entity back, and optionally the rest of the act it was removed in.
+///
+/// **Restoring is never blocked by something else still being removed.** A
+/// quest whose campaign is gone comes back as a quest with no campaign, which
+/// is a valid thing to be.
+pub async fn restore(
+    ctx: &mut Ctx<'_>,
+    id: EntityId,
+    include_group: bool,
+) -> Applied<(Vec<EntityId>, Option<Uuid>)> {
+    let row = available_for_write(ctx.tx, ctx.member, id, WriteScope::Extant)
+        .await?
+        .ok_or(Refusal::NotAvailable)?;
+
+    // Already active: the end state the person asked for is already true.
+    if row.lifecycle == LifecycleState::Active {
+        return Ok((vec![id], None));
+    }
+
+    let group = row.deletion_group_id;
+    let mut rows = vec![row];
+    if include_group && let Some(group) = group {
+        for other in crate::store::entity::holding_group(ctx.tx, group, ctx.member).await? {
+            if other.id != id {
+                rows.push(other);
+            }
+        }
+    }
+
+    let mut restored = Vec::new();
+    for row in &rows {
+        sqlx::query(
+            "UPDATE entity SET lifecycle = 'active', deleted_at = NULL, \
+             deletion_group_id = NULL, counter = counter + 1, updated_at = $2 WHERE id = $1",
+        )
+        .bind(row.id.as_uuid())
+        .bind(ctx.at)
+        .execute(ctx.tx.conn())
+        .await?;
+
+        // Entering a container places the entity at the end, and that holds for
+        // a restoration exactly as it does for a create or a move. The position
+        // it had before it left is not carried back.
+        if let Some(category) = row.category_id {
+            let next = crate::store::entity::next_category_position(ctx.tx, category).await?;
+            let part = PartWrite::CategoryPosition(Some(next));
+            apply_part(ctx, row.id, &part).await?;
+            provenance::record(ctx.tx, row.id, &[part.part()], row.counter + 1, ctx.member).await?;
+        }
+
+        changes::entity_written(
+            ctx.tx,
+            ctx.at,
+            &EntityChange {
+                entity: row.id,
+                audience_before: Some(row.audience.clone()),
+                audience_after: Some(row.audience.clone()),
+                author_before: row.author,
+                author_after: row.author,
+                changed_blocks: Vec::new(),
+            },
+        )
+        .await?;
+        restored.push(row.id);
+    }
+
+    Ok((restored, include_group.then_some(group).flatten()))
+}
+
+/// Every table an entity's content lives in, other than the entity row.
+///
+/// **The schema's cascading deletes never fire under erasure**, and this list
+/// is the consequence. Every one of them hangs off a delete of the `entity`
+/// row, and erasure strips content and leaves a tombstone rather than deleting
+/// it — so a cascade that reads as though it were doing the work is doing
+/// nothing at all. The comment above `event_record` in migration one describing
+/// its cascade as erasure describes something that never happens.
+///
+/// Order matters in one place: relations are removed before blocks, because a
+/// relation may anchor into one.
+const DEPENDENT_TABLES: &[&str] = &[
+    "conflict",
+    "embedding",
+    "derived_text",
+    "entity_version",
+    "derivation_queue",
+    "block",
+    "entity_date",
+    "entity_assignment",
+    "entity_property_value",
+    "event_record",
+];
+
+/// Strip an entity to a tombstone.
+///
+/// **The record goes before the bytes.** Bytes are the object store's and
+/// arrive with Wave 2.3; the ordering is stated here because this is where it
+/// will be added, and inverting it is the failure the creation rule exists to
+/// prevent, lasting indefinitely.
+///
+/// Converges like a removal: an identifier that is not available is already in
+/// the end state the person asked for.
+pub async fn erase(ctx: &mut Ctx<'_>, ids: &[EntityId]) -> Applied<(Vec<EntityId>, Vec<Uuid>)> {
+    let mut erased = Vec::new();
+    let mut relations_gone = Vec::new();
+
+    for id in ids {
+        let Some(row) = available_for_write(ctx.tx, ctx.member, *id, WriteScope::Extant).await?
+        else {
+            continue;
+        };
+
+        // Erasing either endpoint removes the relation outright, which is what
+        // erasure means everywhere. This is the entry easiest to miss, because
+        // a relation's two endpoints are declared as cascading and the
+        // declaration reads as though it were doing the work.
+        let rows = sqlx::query(
+            "DELETE FROM relation WHERE from_entity_id = $1 OR to_entity_id = $1 RETURNING id",
+        )
+        .bind(id.as_uuid())
+        .fetch_all(ctx.tx.conn())
+        .await?;
+        for r in &rows {
+            let relation: Uuid = r.try_get("id")?;
+            changes::relation_gone(ctx.tx, ctx.at, relation).await?;
+            relations_gone.push(relation);
+        }
+
+        for table in DEPENDENT_TABLES {
+            let column = if *table == "event_record" {
+                "item_id"
+            } else {
+                "entity_id"
+            };
+            let sql = format!("DELETE FROM {table} WHERE {column} = $1");
+            sqlx::query(sqlx::AssertSqlSafe(sql))
+                .bind(id.as_uuid())
+                .execute(ctx.tx.conn())
+                .await?;
+        }
+        provenance::erase(ctx.tx, *id).await?;
+
+        // The side table, which holds what the type carries beyond the shared
+        // model. Named by the row's own type rather than tried against all of
+        // them, so a type gaining a table is one line here.
+        if let Some(table) = side_table(row.entity_type) {
+            let sql = format!("DELETE FROM {table} WHERE entity_id = $1");
+            sqlx::query(sqlx::AssertSqlSafe(sql))
+                .bind(id.as_uuid())
+                .execute(ctx.tx.conn())
+                .await?;
+        }
+
+        // A container that is gone holds nothing. The substrate's rule for a
+        // deleted category — an entity whose category is deleted becomes
+        // uncategorised, which is a valid state requiring no repair — applies a
+        // fortiori to an erased one, and leaving the reference would point
+        // every member of the category at a tombstone.
+        //
+        // The type-specific containers, the ladder and nested locations, are
+        // Wave 2.2's for the same reason their content is.
+        if row.entity_type == EntityType::Category {
+            for orphan in crate::store::entity::uncategorise_all(ctx.tx, *id, ctx.at).await? {
+                changes::entity_written(
+                    ctx.tx,
+                    ctx.at,
+                    &EntityChange {
+                        entity: orphan.id,
+                        audience_before: Some(orphan.audience.clone()),
+                        audience_after: Some(orphan.audience),
+                        author_before: orphan.author,
+                        author_after: orphan.author,
+                        changed_blocks: Vec::new(),
+                    },
+                )
+                .await?;
+            }
+        }
+
+        // The tombstone. Everything a person put here is gone; what remains is
+        // the identity, the type, and the authorship — which never changes —
+        // so that an edit arriving from a device that was away is recognisable
+        // as a recreation, and so the sequence can say the entity is gone.
+        let sql = format!(
+            "UPDATE entity SET title = NULL, search_text = '', capture_method = '', \
+             bulk = false, category_id = NULL, category_position = NULL, \
+             {AUDIENCE_COLUMN} = '{{}}', lifecycle = 'erased', deleted_at = NULL, \
+             deletion_group_id = NULL, counter = counter + 1, updated_at = $2 \
+             WHERE id = $1"
+        );
+        sqlx::query(sqlx::AssertSqlSafe(sql))
+            .bind(id.as_uuid())
+            .bind(ctx.at)
+            .execute(ctx.tx.conn())
+            .await?;
+
+        changes::entity_gone(
+            ctx.tx,
+            ctx.at,
+            &EntityChange {
+                entity: *id,
+                audience_before: Some(row.audience.clone()),
+                audience_after: Some(Vec::new()),
+                author_before: row.author,
+                author_after: row.author,
+                changed_blocks: Vec::new(),
+            },
+        )
+        .await?;
+        erased.push(*id);
+    }
+
+    Ok((erased, relations_gone))
+}
+
+fn side_table(kind: EntityType) -> Option<&'static str> {
+    match kind {
+        EntityType::Campaign => Some("campaign"),
+        EntityType::Arc => Some("arc"),
+        EntityType::Quest => Some("quest"),
+        EntityType::File => Some("file"),
+        EntityType::Item => Some("item"),
+        EntityType::Location => Some("location"),
+        EntityType::Category => Some("category"),
+        EntityType::Note
+        | EntityType::ShoppingList
+        | EntityType::Routine
+        | EntityType::FocusSession
+        | EntityType::CheckIn => None,
+    }
+}

--- a/crates/altaird/src/write/entity.rs
+++ b/crates/altaird/src/write/entity.rs
@@ -381,11 +381,17 @@ pub async fn create(
         }
         return Ok(Outcome::applied_entity(id, existing.counter));
     }
-    // Either it is not there, or it is there and invisible. The second is a
-    // refusal and the first is a create, and the two are told apart by trying
-    // the insert: an identifier the member cannot see still collides on the
-    // primary key, and the collision is caught by the spine as a fault-free
-    // refusal rather than by asking a question that would answer it.
+    // Either it is not there, or it is there and invisible. The lookup above
+    // cannot tell those apart — that is what the audience predicate is for —
+    // so the insert does, and it does it without ever raising a store fault.
+    //
+    // `ON CONFLICT DO NOTHING` with the row count read is the whole mechanism.
+    // A bare insert makes the invisible case a primary-key violation, which
+    // reaches the caller as a store fault while an unused identifier reaches
+    // them as a success, and a fault that appears only when something is there
+    // is an oracle for whether something is there. This is the exact
+    // disclosure the single refusal reason exists to prevent, arriving through
+    // the error channel rather than through the answer.
 
     let created_at = created_at.unwrap_or(ctx.at);
 
@@ -402,9 +408,10 @@ pub async fn create(
         "INSERT INTO entity \
          (id, type, title, author_member_id, created_at, updated_at, capture_method, \
           bulk, {AUDIENCE_COLUMN}, lifecycle, counter, search_text) \
-         VALUES ($1, $2::entity_type, NULL, $3, $4, $5, $6, false, '{{}}', 'active', 1, '')"
+         VALUES ($1, $2::entity_type, NULL, $3, $4, $5, $6, false, '{{}}', 'active', 1, '') \
+         ON CONFLICT (id) DO NOTHING"
     );
-    sqlx::query(sqlx::AssertSqlSafe(sql))
+    let inserted = sqlx::query(sqlx::AssertSqlSafe(sql))
         .bind(id.as_uuid())
         .bind(type_name(kind))
         .bind(ctx.member.as_uuid())
@@ -413,6 +420,9 @@ pub async fn create(
         .bind(capture_method)
         .execute(ctx.tx.conn())
         .await?;
+    if inserted.rows_affected() == 0 {
+        return Err(Refusal::NotAvailable.into());
+    }
 
     make_type_row(ctx, id, kind).await?;
 

--- a/crates/altaird/src/write/entity.rs
+++ b/crates/altaird/src/write/entity.rs
@@ -159,7 +159,18 @@ async fn current(ctx: &mut Ctx<'_>, row: &EntityRow, part: &PartWrite) -> Applie
 }
 
 /// Apply one part to the store. Assumes it has already been validated.
-async fn apply_part(ctx: &mut Ctx<'_>, entity: EntityId, part: &PartWrite) -> Applied<()> {
+///
+/// `placement` is the position the instance assigned as a consequence, which is
+/// only ever set alongside a category. **The two move in one statement**,
+/// because the store's own check says a category and a position are either both
+/// there or both absent: writing them in sequence puts the row through a state
+/// the schema refuses, whichever order the sequence is in.
+async fn apply_part(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    part: &PartWrite,
+    placement: Option<&PartWrite>,
+) -> Applied<()> {
     match part {
         PartWrite::Title(v) => {
             // search_text is maintained by the write path from the title and
@@ -193,9 +204,14 @@ async fn apply_part(ctx: &mut Ctx<'_>, entity: EntityId, part: &PartWrite) -> Ap
             }
         }
         PartWrite::Category(v) => {
-            sqlx::query("UPDATE entity SET category_id = $2 WHERE id = $1")
+            let position = match placement {
+                Some(PartWrite::CategoryPosition(p)) => *p,
+                _ => None,
+            };
+            sqlx::query("UPDATE entity SET category_id = $2, category_position = $3 WHERE id = $1")
                 .bind(entity.as_uuid())
                 .bind(v.map(EntityId::as_uuid))
+                .bind(position)
                 .execute(ctx.tx.conn())
                 .await?;
         }
@@ -402,12 +418,12 @@ pub async fn create(
 
     let mut written = Vec::new();
     for part in &parts {
-        if let Some(extra) = validate_and_place(ctx, None, part).await? {
-            apply_part(ctx, id, &extra).await?;
-            written.push(extra.part());
-        }
-        apply_part(ctx, id, part).await?;
+        let placement = validate_and_place(ctx, None, part).await?;
+        apply_part(ctx, id, part, placement.as_ref()).await?;
         written.push(part.part());
+        if let Some(placement) = &placement {
+            written.push(placement.part());
+        }
     }
 
     if !stated_audience && let Some(category) = category {
@@ -417,7 +433,7 @@ pub async fn create(
                 return Err(Refusal::NotAvailable.into());
             }
             let part = PartWrite::Audience(default);
-            apply_part(ctx, id, &part).await?;
+            apply_part(ctx, id, &part, None).await?;
             written.push(part.part());
         }
     }
@@ -496,16 +512,18 @@ pub async fn edit(
     let counter = row.counter + 1;
 
     for part in &parts {
-        if let Some(extra) = validate_and_place(ctx, row.category_id, part).await? {
-            let stored = current(ctx, &row, &extra).await?;
-            touching.push((extra.part(), extra.text(), stored.text()));
-            apply_part(ctx, id, &extra).await?;
-            written.push(extra.part());
-        }
+        let placement = validate_and_place(ctx, row.category_id, part).await?;
         let stored = current(ctx, &row, part).await?;
         touching.push((part.part(), part.text(), stored.text()));
-        apply_part(ctx, id, part).await?;
+        if let Some(placement) = &placement {
+            let stored = current(ctx, &row, placement).await?;
+            touching.push((placement.part(), placement.text(), stored.text()));
+        }
+        apply_part(ctx, id, part, placement.as_ref()).await?;
         written.push(part.part());
+        if let Some(placement) = &placement {
+            written.push(placement.part());
+        }
     }
 
     // A stale base is never a rejection. What it can be is a conflict, and only
@@ -684,7 +702,7 @@ pub async fn restore(
         if let Some(category) = row.category_id {
             let next = crate::store::entity::next_category_position(ctx.tx, category).await?;
             let part = PartWrite::CategoryPosition(Some(next));
-            apply_part(ctx, row.id, &part).await?;
+            apply_part(ctx, row.id, &part, None).await?;
             provenance::record(ctx.tx, row.id, &[part.part()], row.counter + 1, ctx.member).await?;
         }
 

--- a/crates/altaird/src/write/intent.rs
+++ b/crates/altaird/src/write/intent.rs
@@ -1,0 +1,213 @@
+//! Intent identity, and the acknowledgement the instance already issued.
+//!
+//! # Why the acknowledgement is held rather than recomputed
+//!
+//! Replay is idempotent: resubmitting an intent returns the acknowledgement the
+//! instance already issued, unchanged, rather than producing a second effect.
+//! That promise cannot be kept by re-deriving an answer, because the answer
+//! depends on state that has since moved — a counter, a conflict, whether the
+//! entity has since been erased. It is kept by holding what was said.
+//!
+//! **The row is written in the transaction it acknowledges.** A row here and no
+//! write, or a write and no row here, break the promise in different
+//! directions: the first answers "applied" for something that never happened,
+//! the second applies a second effect on the next retry. There is no ordering
+//! of two transactions that fixes this, which is why there is only one.
+//!
+//! # Why identity alone is not enough
+//!
+//! An intent identity comes from a client, so it is an assertion rather than a
+//! fact. The same value arriving from a different member is not the same
+//! intent, and the stored answer is not theirs to receive — it names entities
+//! they may have no business knowing exist.
+//!
+//! So a replay is looked up by identity *and* member, and an identity held by
+//! somebody else is refused as [`Outcome::not_available`], which is the same
+//! nothing every other unavailable thing produces. Refusing it as a distinct
+//! condition would turn the intent table into an oracle for identifiers.
+
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+use uuid::Uuid;
+
+use crate::store::WriteTx;
+use crate::store::ids::EntityId;
+
+use super::outcome::{ConflictParts, Outcome, RefusalReason};
+
+/// What was found under an intent identity.
+pub enum Held {
+    /// This member submitted it before, and this is what they were told.
+    Mine(Outcome),
+    /// Somebody else holds the identity. Answered as nothing; see the module
+    /// docs.
+    SomebodyElses,
+    /// Never seen.
+    Absent,
+}
+
+/// Look an intent up by its identity.
+pub async fn held(tx: &mut WriteTx, intent: Uuid, member: Uuid) -> sqlx::Result<Held> {
+    let row = sqlx::query(
+        "SELECT member_id, outcome::text AS outcome, entity_ids, relation_ids, counter, \
+         conflict_content_fields, conflict_specific_fields, conflict_block_ids, \
+         refusal::text AS refusal, refusal_detail, original_entity_id, new_entity_id \
+         FROM intent WHERE id = $1",
+    )
+    .bind(intent)
+    .fetch_optional(tx.conn())
+    .await?;
+
+    let Some(row) = row else {
+        return Ok(Held::Absent);
+    };
+    if row.try_get::<Uuid, _>("member_id")? != member {
+        return Ok(Held::SomebodyElses);
+    }
+
+    let outcome = match row.try_get::<String, _>("outcome")?.as_str() {
+        "applied" => {
+            let conflict = ConflictParts {
+                content_fields: row
+                    .try_get::<Option<Vec<i32>>, _>("conflict_content_fields")?
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|n| n as u32)
+                    .collect(),
+                specific_fields: row
+                    .try_get::<Option<Vec<i32>>, _>("conflict_specific_fields")?
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|n| n as u32)
+                    .collect(),
+                block_ids: row
+                    .try_get::<Option<Vec<Uuid>>, _>("conflict_block_ids")?
+                    .unwrap_or_default(),
+            };
+            Outcome::Applied {
+                entities: row
+                    .try_get::<Option<Vec<Uuid>>, _>("entity_ids")?
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(EntityId::from_uuid)
+                    .collect(),
+                relations: row
+                    .try_get::<Option<Vec<Uuid>>, _>("relation_ids")?
+                    .unwrap_or_default(),
+                counter: row.try_get("counter")?,
+                conflict: (!conflict.is_empty()).then_some(conflict),
+            }
+        }
+        "refused" => Outcome::Refused {
+            reason: match row.try_get::<String, _>("refusal")?.as_str() {
+                "malformed" => RefusalReason::Malformed,
+                _ => RefusalReason::NotAvailable,
+            },
+            detail: row
+                .try_get::<Option<String>, _>("refusal_detail")?
+                .unwrap_or_default(),
+        },
+        _ => Outcome::Recreated {
+            original: EntityId::from_uuid(row.try_get("original_entity_id")?),
+            new: EntityId::from_uuid(row.try_get("new_entity_id")?),
+            counter: row.try_get::<Option<i64>, _>("counter")?.unwrap_or(1),
+        },
+    };
+
+    Ok(Held::Mine(outcome))
+}
+
+/// Write the acknowledgement this transaction is about to commit.
+///
+/// Every column beyond the outcome belongs to one outcome and is null for the
+/// others, which is the price migration one paid for one table over three.
+pub async fn hold(
+    tx: &mut WriteTx,
+    intent: Uuid,
+    member: Uuid,
+    at: DateTime<Utc>,
+    outcome: &Outcome,
+) -> sqlx::Result<()> {
+    let (name, entities, relations, counter, conflict, refusal, detail, original, new) =
+        match outcome {
+            Outcome::Applied {
+                entities,
+                relations,
+                counter,
+                conflict,
+            } => (
+                "applied",
+                Some(entities.iter().map(|e| e.as_uuid()).collect::<Vec<_>>()),
+                Some(relations.clone()),
+                *counter,
+                conflict.clone(),
+                None,
+                None,
+                None,
+                None,
+            ),
+            Outcome::Refused { reason, detail } => (
+                "refused",
+                None,
+                None,
+                None,
+                None,
+                Some(match reason {
+                    RefusalReason::NotAvailable => "not_available",
+                    RefusalReason::Malformed => "malformed",
+                }),
+                Some(detail.clone()),
+                None,
+                None,
+            ),
+            Outcome::Recreated {
+                original,
+                new,
+                counter,
+            } => (
+                "recreated",
+                None,
+                None,
+                Some(*counter),
+                None,
+                None,
+                None,
+                Some(original.as_uuid()),
+                Some(new.as_uuid()),
+            ),
+        };
+
+    let conflict = conflict.unwrap_or_default();
+    sqlx::query(
+        "INSERT INTO intent \
+         (id, member_id, received_at, outcome, entity_ids, relation_ids, counter, \
+          conflict_content_fields, conflict_specific_fields, conflict_block_ids, \
+          refusal, refusal_detail, original_entity_id, new_entity_id) \
+         VALUES ($1, $2, $3, $4::intent_outcome, $5, $6, $7, $8, $9, $10, \
+                 $11::refusal_reason, $12, $13, $14)",
+    )
+    .bind(intent)
+    .bind(member)
+    .bind(at)
+    .bind(name)
+    .bind(entities)
+    .bind(relations)
+    .bind(counter)
+    .bind(as_i32(&conflict.content_fields))
+    .bind(as_i32(&conflict.specific_fields))
+    .bind(&conflict.block_ids)
+    .bind(refusal)
+    .bind(detail)
+    .bind(original)
+    .bind(new)
+    .execute(tx.conn())
+    .await?;
+    Ok(())
+}
+
+/// The schema stores field numbers as `integer[]` and the wire carries them as
+/// `uint32`. Field numbers are permanent and small, so the narrowing cannot
+/// lose one.
+fn as_i32(v: &[u32]) -> Option<Vec<i32>> {
+    (!v.is_empty()).then(|| v.iter().map(|n| *n as i32).collect())
+}

--- a/crates/altaird/src/write/intent.rs
+++ b/crates/altaird/src/write/intent.rs
@@ -121,13 +121,31 @@ pub async fn held(tx: &mut WriteTx, intent: Uuid, member: Uuid) -> sqlx::Result<
 ///
 /// Every column beyond the outcome belongs to one outcome and is null for the
 /// others, which is the price migration one paid for one table over three.
+///
+/// # Returns false when somebody else got there first
+///
+/// Two submissions of one intent identity can both find it absent and both
+/// proceed. They meet here, and `ON CONFLICT DO NOTHING` is what makes the
+/// loser's answer *the acknowledgement already issued* rather than a store
+/// fault. A bare insert makes a concurrent replay indistinguishable from the
+/// instance being down, which is precisely backwards: the instance is fine and
+/// the answer already exists. A retry after a stalled or dropped submission is
+/// exactly this shape, and it is what an outbox does by design.
+///
+/// The row count is trustworthy. Postgres blocks a conflicting insert until
+/// the transaction holding the key ends, and lets it through if that
+/// transaction rolls back — so zero rows means a *committed* row is there, not
+/// a racing one that may yet vanish.
+///
+/// The caller must discard whatever it wrote before answering: the effect
+/// belongs to the transaction that won.
 pub async fn hold(
     tx: &mut WriteTx,
     intent: Uuid,
     member: Uuid,
     at: DateTime<Utc>,
     outcome: &Outcome,
-) -> sqlx::Result<()> {
+) -> sqlx::Result<bool> {
     let (name, entities, relations, counter, conflict, refusal, detail, original, new) =
         match outcome {
             Outcome::Applied {
@@ -178,13 +196,14 @@ pub async fn hold(
         };
 
     let conflict = conflict.unwrap_or_default();
-    sqlx::query(
+    let held = sqlx::query(
         "INSERT INTO intent \
          (id, member_id, received_at, outcome, entity_ids, relation_ids, counter, \
           conflict_content_fields, conflict_specific_fields, conflict_block_ids, \
           refusal, refusal_detail, original_entity_id, new_entity_id) \
          VALUES ($1, $2, $3, $4::intent_outcome, $5, $6, $7, $8, $9, $10, \
-                 $11::refusal_reason, $12, $13, $14)",
+                 $11::refusal_reason, $12, $13, $14) \
+         ON CONFLICT (id) DO NOTHING",
     )
     .bind(intent)
     .bind(member)
@@ -202,7 +221,7 @@ pub async fn hold(
     .bind(new)
     .execute(tx.conn())
     .await?;
-    Ok(())
+    Ok(held.rows_affected() == 1)
 }
 
 /// The schema stores field numbers as `integer[]` and the wire carries them as

--- a/crates/altaird/src/write/mod.rs
+++ b/crates/altaird/src/write/mod.rs
@@ -49,7 +49,7 @@ use crate::auth::Member;
 use crate::store::begin_write;
 use crate::store::ids::{EntityId, MemberId};
 
-use content::{entity_type, identifier, parts_written};
+use content::{entity_type, identifier, instant, parts_written};
 use entity::{Ctx, Failed, Refusal};
 use outcome::{Outcome, RefusalReason};
 
@@ -241,9 +241,11 @@ async fn act(ctx: &mut Ctx<'_>, intent: &v1::Intent) -> Result<Outcome, Failed> 
                 let kind = entity_type(content)?;
                 let parts = parts_written(content)?;
                 let id = EntityId::from_uuid(identifier(&e.entity_id)?);
-                let created_at = e.created_at.as_ref().and_then(|t| {
-                    chrono::DateTime::from_timestamp(t.seconds, u32::try_from(t.nanos).unwrap_or(0))
-                });
+                // Absent is ordinary and means "the instance's clock". Present
+                // and unreadable is a malformed message, and it goes through the
+                // same parser a labelled date does — see `content::instant` for
+                // why the two used to disagree.
+                let created_at = e.created_at.as_ref().map(instant).transpose()?;
                 entity::create(ctx, id, created_at, &e.capture_method, parts, kind).await
             }
             Some(v1::create::Subject::Relation(r)) => {
@@ -276,7 +278,17 @@ async fn act(ctx: &mut Ctx<'_>, intent: &v1::Intent) -> Result<Outcome, Failed> 
                     .transpose()?;
                 let parts = parts_written(content)?;
                 let id = EntityId::from_uuid(identifier(&e.entity_id)?);
-                let base = i64::try_from(e.base_counter).unwrap_or(i64::MAX);
+                // Clamping was worse than it looks. A base counter larger than
+                // any counter the store can hold reads as *current* against
+                // every entity, so a garbled value silently skipped conflict
+                // detection entirely — the one mechanism this item exists to
+                // build — rather than being refused as the unreadable message
+                // it is.
+                let base = i64::try_from(e.base_counter).map_err(|_| {
+                    Refusal::Malformed(
+                        "a base counter is a counter this instance could have issued".into(),
+                    )
+                })?;
                 entity::edit(ctx, id, base, parts, stated).await
             }
             Some(v1::edit::Subject::Relation(r)) => {

--- a/crates/altaird/src/write/mod.rs
+++ b/crates/altaird/src/write/mod.rs
@@ -1,0 +1,369 @@
+//! The write path: the only way anything enters the store.
+//!
+//! # One transaction per intent
+//!
+//! **A bulk capture is explicitly not one unit.** Two hundred files where the
+//! hundredth fails leaves ninety-nine captured, and the wire has no shape for
+//! all-or-nothing to be expressed in — a submission is always a list and the
+//! answer is always a list of the same length. So each intent gets its own
+//! transaction, and this is forced rather than chosen. It is worth saying out
+//! loud because the reflex, on seeing a batch, is to batch.
+//!
+//! What is atomic is one intent: the write it makes, the entries it puts in the
+//! change sequence, and the intent row holding the acknowledgement all commit
+//! together or none of them do.
+//!
+//! # A refusal is committed too
+//!
+//! An intent that is refused still writes its intent row, because the
+//! acknowledgement is held and a replay has to get the same answer. A refusal
+//! discovered partway through applying therefore rolls the transaction back and
+//! opens a second one holding nothing but the refusal. That is the only place
+//! two transactions are used for one intent, and the second writes no entity
+//! content at all.
+//!
+//! # What is a fault and what is an answer
+//!
+//! A refusal is an answer: it is committed, it is replayed, and the submission
+//! it was part of still succeeds. **A store fault is not.** Nothing is
+//! acknowledged, the caller's outbox holds, and the caller waits — which is the
+//! same wait an unreachable instance produces, because to the person they are
+//! the same thing.
+
+pub mod changes;
+pub mod content;
+pub mod entity;
+pub mod intent;
+pub mod outcome;
+pub mod parts;
+pub mod provenance;
+pub mod relation;
+
+use chrono::Utc;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use altair_proto::v1;
+
+use crate::auth::Member;
+use crate::store::begin_write;
+use crate::store::ids::{EntityId, MemberId};
+
+use content::{entity_type, identifier, parts_written};
+use entity::{Ctx, Failed, Refusal};
+use outcome::{Outcome, RefusalReason};
+
+/// The instance failing, never a caller's intent failing.
+///
+/// Deliberately narrow. Everything a caller can do wrong is an [`Outcome`].
+#[derive(Debug)]
+pub struct Fault(pub sqlx::Error);
+
+impl std::fmt::Display for Fault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "the structured store was unavailable: {}", self.0)
+    }
+}
+
+impl std::error::Error for Fault {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+/// The write path.
+#[derive(Clone)]
+pub struct WritePath {
+    pool: PgPool,
+}
+
+impl WritePath {
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Apply a submission, one intent at a time.
+    ///
+    /// **Never all or nothing.** The answer has one acknowledgement per intent,
+    /// in the order submitted, and an intent that was refused does not affect
+    /// the one after it.
+    ///
+    /// # Errors
+    ///
+    /// Only [`Fault`], and only where the store itself could not be reached or
+    /// written. No property of an intent produces one.
+    pub async fn submit(
+        &self,
+        member: &Member,
+        intents: &[v1::Intent],
+    ) -> Result<Vec<v1::Acknowledgement>, Fault> {
+        let mut acknowledgements = Vec::with_capacity(intents.len());
+        for intent in intents {
+            acknowledgements.push(self.one(member, intent).await?);
+        }
+        Ok(acknowledgements)
+    }
+
+    async fn one(
+        &self,
+        member: &Member,
+        intent: &v1::Intent,
+    ) -> Result<v1::Acknowledgement, Fault> {
+        // The identity is the client's, and a malformed one cannot be held
+        // against a replay, so it is answered without a row. There is nothing
+        // to be idempotent about: a resubmission of the same bytes gets the
+        // same answer by computing it again.
+        let Ok(id) = identifier(&intent.intent_id) else {
+            return Ok(acknowledge(
+                &intent.intent_id,
+                &Outcome::malformed("an intent identity is 16 bytes"),
+            ));
+        };
+
+        let outcome = self.apply(member, id, intent).await?;
+        Ok(acknowledge(&intent.intent_id, &outcome))
+    }
+
+    async fn apply(
+        &self,
+        member: &Member,
+        id: Uuid,
+        intent: &v1::Intent,
+    ) -> Result<Outcome, Fault> {
+        let at = Utc::now();
+        // The write path's requester. `assert_participating` is what the
+        // audience predicate trusts, and this is a legitimate caller of it:
+        // token validation resolved the subject to a membership and filtered
+        // departed members before a `Member` existed.
+        let requester = MemberId::assert_participating(member.membership_id());
+
+        let mut tx = begin_write(&self.pool).await.map_err(Fault)?;
+
+        match intent::held(&mut tx, id, member.membership_id())
+            .await
+            .map_err(Fault)?
+        {
+            intent::Held::Mine(outcome) => {
+                // Nothing was written, so there is nothing to commit. Rolling
+                // back is the honest ending, and it is what makes replay free.
+                tx.rollback().await.map_err(Fault)?;
+                return Ok(outcome);
+            }
+            intent::Held::SomebodyElses => {
+                tx.rollback().await.map_err(Fault)?;
+                return Ok(Outcome::not_available());
+            }
+            intent::Held::Absent => {}
+        }
+
+        // Before anything is written. See `changes` for why this is first.
+        changes::hold_the_sequence(&mut tx).await.map_err(Fault)?;
+
+        let mut ctx = Ctx {
+            tx: &mut tx,
+            member: requester,
+            at,
+        };
+        let applied = act(&mut ctx, intent).await;
+
+        let outcome = match applied {
+            Ok(outcome) => outcome,
+            Err(Failed::Store(e)) => {
+                tx.rollback().await.ok();
+                return Err(Fault(e));
+            }
+            Err(Failed::Refused(refusal)) => {
+                // Whatever this intent had already written is discarded, and a
+                // second transaction holds nothing but the refusal.
+                tx.rollback().await.map_err(Fault)?;
+                let outcome = match refusal {
+                    Refusal::NotAvailable => Outcome::not_available(),
+                    Refusal::Malformed(detail) => Outcome::malformed(detail),
+                };
+                let mut tx = begin_write(&self.pool).await.map_err(Fault)?;
+                intent::hold(&mut tx, id, member.membership_id(), at, &outcome)
+                    .await
+                    .map_err(Fault)?;
+                tx.commit().await.map_err(Fault)?;
+                return Ok(outcome);
+            }
+        };
+
+        intent::hold(&mut tx, id, member.membership_id(), at, &outcome)
+            .await
+            .map_err(Fault)?;
+        tx.commit().await.map_err(Fault)?;
+        Ok(outcome)
+    }
+}
+
+/// Dispatch one intent's action.
+async fn act(ctx: &mut Ctx<'_>, intent: &v1::Intent) -> Result<Outcome, Failed> {
+    use v1::intent::Action;
+
+    match intent.action.as_ref() {
+        Some(Action::Create(create)) => match create.subject.as_ref() {
+            Some(v1::create::Subject::Entity(e)) => {
+                let content = e.content.as_ref().ok_or_else(|| {
+                    Refusal::Malformed("a create carries the content that says what it is".into())
+                })?;
+                let kind = entity_type(content)?;
+                let parts = parts_written(content)?;
+                let id = EntityId::from_uuid(identifier(&e.entity_id)?);
+                let created_at = e.created_at.as_ref().and_then(|t| {
+                    chrono::DateTime::from_timestamp(t.seconds, u32::try_from(t.nanos).unwrap_or(0))
+                });
+                entity::create(ctx, id, created_at, &e.capture_method, parts, kind).await
+            }
+            Some(v1::create::Subject::Relation(r)) => {
+                let content = r.content.as_ref().ok_or_else(|| {
+                    Refusal::Malformed("a relation create carries the relation".into())
+                })?;
+                let id = identifier(&r.relation_id)?;
+                let id = relation::create(ctx, id, content).await?;
+                Ok(Outcome::Applied {
+                    entities: Vec::new(),
+                    relations: vec![id],
+                    counter: None,
+                    conflict: None,
+                })
+            }
+            None => Err(Refusal::Malformed("a create names no subject".into()).into()),
+        },
+
+        Some(Action::Edit(edit)) => match edit.subject.as_ref() {
+            Some(v1::edit::Subject::Entity(e)) => {
+                let content = e.content.as_ref().ok_or_else(|| {
+                    Refusal::Malformed("an edit carries the content it is writing".into())
+                })?;
+                // The type is the tag, and an edit need not restate it. Where
+                // it does, it must agree.
+                let stated = content
+                    .specific
+                    .as_ref()
+                    .map(|_| entity_type(content))
+                    .transpose()?;
+                let parts = parts_written(content)?;
+                let id = EntityId::from_uuid(identifier(&e.entity_id)?);
+                let base = i64::try_from(e.base_counter).unwrap_or(i64::MAX);
+                entity::edit(ctx, id, base, parts, stated).await
+            }
+            Some(v1::edit::Subject::Relation(r)) => {
+                let content = r.content.as_ref().ok_or_else(|| {
+                    Refusal::Malformed("a relation edit carries the relation".into())
+                })?;
+                let id = identifier(&r.relation_id)?;
+                let id = relation::edit(ctx, id, content).await?;
+                Ok(Outcome::Applied {
+                    entities: Vec::new(),
+                    relations: vec![id],
+                    counter: None,
+                    conflict: None,
+                })
+            }
+            None => Err(Refusal::Malformed("an edit names no subject".into()).into()),
+        },
+
+        Some(Action::Remove(remove)) => {
+            // Everything named in one Remove is one act, and that grouping is
+            // retained so that restoring any one of them can bring back the
+            // rest — including the connections the same act removed.
+            let group = Uuid::new_v4();
+            let mut entities = Vec::new();
+            for b in &remove.entity_ids {
+                entities.push(EntityId::from_uuid(identifier(b)?));
+            }
+            let mut relations = Vec::new();
+            for b in &remove.relation_ids {
+                relations.push(identifier(b)?);
+            }
+            let entities = entity::remove(ctx, &entities, group).await?;
+            let relations = relation::remove(ctx, &relations, group).await?;
+            Ok(Outcome::Applied {
+                entities,
+                relations,
+                counter: None,
+                conflict: None,
+            })
+        }
+
+        Some(Action::Erase(erase)) => {
+            let mut ids = Vec::new();
+            for b in &erase.entity_ids {
+                ids.push(EntityId::from_uuid(identifier(b)?));
+            }
+            let (entities, relations) = entity::erase(ctx, &ids).await?;
+            Ok(Outcome::Applied {
+                entities,
+                relations,
+                counter: None,
+                conflict: None,
+            })
+        }
+
+        Some(Action::Restore(restore)) => {
+            let id = EntityId::from_uuid(identifier(&restore.entity_id)?);
+            let (entities, group) = entity::restore(ctx, id, restore.include_group).await?;
+            let relations = match group {
+                Some(group) => relation::restore_group(ctx, group).await?,
+                None => Vec::new(),
+            };
+            Ok(Outcome::Applied {
+                entities,
+                relations,
+                counter: None,
+                conflict: None,
+            })
+        }
+
+        None => Err(Refusal::Malformed("an intent names no action".into()).into()),
+    }
+}
+
+/// The acknowledgement, in the wire's shape.
+fn acknowledge(intent_id: &[u8], outcome: &Outcome) -> v1::Acknowledgement {
+    use v1::acknowledgement::Outcome as Wire;
+
+    let outcome = match outcome {
+        Outcome::Applied {
+            entities,
+            relations,
+            counter,
+            conflict,
+        } => Wire::Applied(v1::Applied {
+            entity_ids: entities
+                .iter()
+                .map(|e| e.as_uuid().as_bytes().to_vec())
+                .collect(),
+            relation_ids: relations.iter().map(|r| r.as_bytes().to_vec()).collect(),
+            counter: counter.unwrap_or(0).try_into().unwrap_or(0),
+            conflict: conflict.as_ref().map(|c| v1::ConflictRetained {
+                content_fields: c.content_fields.clone(),
+                specific_fields: c.specific_fields.clone(),
+                block_ids: c.block_ids.iter().map(|b| b.as_bytes().to_vec()).collect(),
+            }),
+        }),
+        Outcome::Refused { reason, detail } => Wire::Refused(v1::Refused {
+            reason: match reason {
+                RefusalReason::NotAvailable => v1::RefusalReason::NotAvailable as i32,
+                RefusalReason::Malformed => v1::RefusalReason::Malformed as i32,
+            },
+            detail: detail.clone(),
+        }),
+        Outcome::Recreated {
+            original,
+            new,
+            counter,
+        } => Wire::Recreated(v1::Recreated {
+            original_entity_id: original.as_uuid().as_bytes().to_vec(),
+            new_entity_id: new.as_uuid().as_bytes().to_vec(),
+            counter: (*counter).try_into().unwrap_or(0),
+        }),
+    };
+
+    v1::Acknowledgement {
+        intent_id: intent_id.to_vec(),
+        outcome: Some(outcome),
+    }
+}

--- a/crates/altaird/src/write/mod.rs
+++ b/crates/altaird/src/write/mod.rs
@@ -182,19 +182,49 @@ impl WritePath {
                     Refusal::Malformed(detail) => Outcome::malformed(detail),
                 };
                 let mut tx = begin_write(&self.pool).await.map_err(Fault)?;
-                intent::hold(&mut tx, id, member.membership_id(), at, &outcome)
+                let held = intent::hold(&mut tx, id, member.membership_id(), at, &outcome)
                     .await
                     .map_err(Fault)?;
+                if !held {
+                    tx.rollback().await.map_err(Fault)?;
+                    return self.replay(id, member).await;
+                }
                 tx.commit().await.map_err(Fault)?;
                 return Ok(outcome);
             }
         };
 
-        intent::hold(&mut tx, id, member.membership_id(), at, &outcome)
+        // Somebody else acknowledged this intent while this transaction was
+        // working. Their answer is the answer, and everything written here is
+        // discarded — which is what keeps "a second effect" impossible rather
+        // than merely unlikely.
+        if !intent::hold(&mut tx, id, member.membership_id(), at, &outcome)
             .await
-            .map_err(Fault)?;
+            .map_err(Fault)?
+        {
+            tx.rollback().await.map_err(Fault)?;
+            return self.replay(id, member).await;
+        }
         tx.commit().await.map_err(Fault)?;
         Ok(outcome)
+    }
+
+    /// The acknowledgement already issued for an intent, read on its own.
+    ///
+    /// Reached only when a concurrent submission of the same identity won the
+    /// race. It cannot find nothing: the insert that lost only lost because a
+    /// committed row is there.
+    async fn replay(&self, id: Uuid, member: &Member) -> Result<Outcome, Fault> {
+        let mut tx = begin_write(&self.pool).await.map_err(Fault)?;
+        let held = intent::held(&mut tx, id, member.membership_id())
+            .await
+            .map_err(Fault)?;
+        tx.rollback().await.map_err(Fault)?;
+        Ok(match held {
+            intent::Held::Mine(outcome) => outcome,
+            // Another member holds it, which is the same nothing as always.
+            intent::Held::SomebodyElses | intent::Held::Absent => Outcome::not_available(),
+        })
     }
 }
 

--- a/crates/altaird/src/write/outcome.rs
+++ b/crates/altaird/src/write/outcome.rs
@@ -1,0 +1,115 @@
+//! What an intent produced, in the three shapes the wire has.
+//!
+//! Separate from the wire types so that nothing in the write path has to hold a
+//! generated message, and so that the store's enum, the wire's oneof, and this
+//! cannot quietly grow a fourth member each.
+
+use uuid::Uuid;
+
+use crate::store::ids::EntityId;
+
+use super::parts::Part;
+
+/// Parts whose two values are both retained, in the shape the wire names them.
+///
+/// Empty is not the same as absent: an acknowledgement carries a conflict only
+/// where one was detected, so the caller checks [`ConflictParts::is_empty`]
+/// rather than sending an empty one.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConflictParts {
+    pub content_fields: Vec<u32>,
+    pub specific_fields: Vec<u32>,
+    pub block_ids: Vec<Uuid>,
+}
+
+impl ConflictParts {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.content_fields.is_empty()
+            && self.specific_fields.is_empty()
+            && self.block_ids.is_empty()
+    }
+
+    pub fn push(&mut self, part: &Part) {
+        match part {
+            Part::Content(p) => self.content_fields.push(p.field_number()),
+            Part::Specific(n) => self.specific_fields.push(*n),
+            Part::Block(id) => self.block_ids.push(*id),
+        }
+    }
+}
+
+/// Why an intent was refused.
+///
+/// **The two are indistinguishable from outside and that is the point.**
+/// `NotAvailable` covers an entity that does not exist and one the submitting
+/// member cannot see, and nothing anywhere — not the reason, not the detail,
+/// not the gRPC status — tells them apart, so a refusal never reveals that
+/// something is there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefusalReason {
+    NotAvailable,
+    Malformed,
+}
+
+/// What the instance answered, and will answer again on replay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    Applied {
+        entities: Vec<EntityId>,
+        relations: Vec<Uuid>,
+        /// The counter after the write, where a single entity was written.
+        counter: Option<i64>,
+        conflict: Option<ConflictParts>,
+    },
+    Refused {
+        reason: RefusalReason,
+        /// Free text for a person reading a log, never parsed by a client.
+        ///
+        /// **Empty for [`RefusalReason::NotAvailable`], always.** A detail
+        /// distinguishing "no such entity" from "not yours to see" would undo
+        /// the whole point of there being one reason, and it would do it in the
+        /// field nobody thinks of as carrying meaning.
+        detail: String,
+    },
+    Recreated {
+        original: EntityId,
+        new: EntityId,
+        counter: i64,
+    },
+}
+
+impl Outcome {
+    /// A refusal that says nothing, which is the only kind
+    /// [`RefusalReason::NotAvailable`] has.
+    #[must_use]
+    pub fn not_available() -> Self {
+        Self::Refused {
+            reason: RefusalReason::NotAvailable,
+            detail: String::new(),
+        }
+    }
+
+    /// A refusal for an intent that could not be read as a well-formed one.
+    ///
+    /// The detail is safe to be specific: malformed is a statement about the
+    /// message the caller sent, which the caller already holds.
+    #[must_use]
+    pub fn malformed(detail: impl Into<String>) -> Self {
+        Self::Refused {
+            reason: RefusalReason::Malformed,
+            detail: detail.into(),
+        }
+    }
+
+    /// Applied, affecting one entity, with no conflict.
+    #[must_use]
+    pub fn applied_entity(entity: EntityId, counter: i64) -> Self {
+        Self::Applied {
+            entities: vec![entity],
+            relations: Vec::new(),
+            counter: Some(counter),
+            conflict: None,
+        }
+    }
+}

--- a/crates/altaird/src/write/parts.rs
+++ b/crates/altaird/src/write/parts.rs
@@ -1,0 +1,206 @@
+//! What a part is called, in the three places that have to agree about it.
+//!
+//! **A write is scoped to the part that changed**, and the substrate decides a
+//! conflict at that grain: same part, both values retained; different parts,
+//! merged with nobody involved. So a part is not an implementation detail. It
+//! is the unit three separate things name:
+//!
+//! - **The wire** names it by field number, inside `EntityContent` or inside
+//!   the type-specific message, or by block identity.
+//! - **`entity_part_counter`** names it by text, or by block identity.
+//! - **The `conflict` row** names it the same way, because it is the same part.
+//!
+//! Migration one recorded the drift risk as gap (d): *"a conflicted part is
+//! named by text here and by a field number on the wire. Something has to hold
+//! that mapping, and wherever it lives it can drift."* This module is that
+//! something, and `tests/write_parts.rs` is what stops it drifting: the mapping
+//! round-trips, and every content part the wire can address appears in it.
+//!
+//! # Why the field number and not the field name
+//!
+//! DR-004 makes field numbers permanent and names reserved. A part addressed by
+//! number survives a field being renamed, which is the change most likely to
+//! happen; a part addressed by the proto's own identifier would silently
+//! re-point. The text in the store is a stable spelling chosen here, not the
+//! proto's identifier read at build time, and the round-trip test is what ties
+//! the two together.
+//!
+//! # What is deliberately not here
+//!
+//! **Values.** Both retained sides of a conflict cross as text whatever the
+//! part's own kind is, which the proto records as its gap (g) and the schema
+//! inherits as its gap (c). Rendering a value as text needs the value, so it
+//! belongs where the content is read; this module holds only names.
+
+use uuid::Uuid;
+
+use crate::store::audience::AUDIENCE_COLUMN;
+
+/// A part of an entity: the unit a write is scoped to and a conflict is decided
+/// at.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Part {
+    /// A field of `EntityContent`, shared by every type.
+    Content(ContentPart),
+    /// A field of the type-specific message. Carried by number because the set
+    /// differs per type and the type is fixed at creation, so a number is
+    /// unambiguous once the entity exists.
+    ///
+    /// Wave 2.1 writes no type content — the plan gives that to 2.2 — so
+    /// nothing produces one of these yet. The variant is here because the
+    /// store shape, the wire shape, and the round-trip test all have to
+    /// account for it, and adding it later would mean revisiting all three.
+    Specific(u32),
+    /// A block of a body. Named by identity rather than by position, because
+    /// position is what an edit to a neighbour changes.
+    ///
+    /// Also 2.2's, for the same reason: blocks arrive with bodies.
+    Block(Uuid),
+}
+
+/// The parts of `EntityContent`, which every type carries.
+///
+/// The `specific` field is not one of these. It is the tag that says which type
+/// the entity is, and the type is fixed at creation, so it is not a part a
+/// write can address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ContentPart {
+    Title,
+    Dates,
+    Category,
+    Assignments,
+    Audience,
+    Bulk,
+    CategoryPosition,
+}
+
+/// Every content part, in field-number order. The round-trip test walks this,
+/// so a variant added without a number or a name fails rather than going
+/// unmapped.
+pub const ALL_CONTENT_PARTS: &[ContentPart] = &[
+    ContentPart::Title,
+    ContentPart::Dates,
+    ContentPart::Category,
+    ContentPart::Assignments,
+    ContentPart::Audience,
+    ContentPart::Bulk,
+    ContentPart::CategoryPosition,
+];
+
+impl ContentPart {
+    /// The field number in `EntityContent`. Permanent, per DR-004.
+    #[must_use]
+    pub fn field_number(self) -> u32 {
+        match self {
+            Self::Title => 1,
+            Self::Dates => 2,
+            Self::Category => 3,
+            Self::Assignments => 4,
+            Self::Audience => 5,
+            // 6 is reserved: it was the entity-level arrangement key, and an
+            // order now belongs to a container.
+            Self::Bulk => 7,
+            Self::CategoryPosition => 8,
+        }
+    }
+
+    /// The part a field number names, or `None` if the number names no
+    /// addressable part.
+    ///
+    /// `None` is what makes *"a cleared number naming no field"* refusable:
+    /// a `cleared` list is a client's assertion about this message, and a
+    /// number that is reserved, unknown, or the `cleared` field itself is not
+    /// a part anything can clear.
+    #[must_use]
+    pub fn from_field_number(number: u32) -> Option<Self> {
+        ALL_CONTENT_PARTS
+            .iter()
+            .copied()
+            .find(|p| p.field_number() == number)
+    }
+
+    /// The spelling `entity_part_counter.field_name` and `conflict.field_name`
+    /// both use.
+    ///
+    /// Audience takes its name from the store's column constant rather than
+    /// spelling it out. Two reasons, and the second is the load-bearing one:
+    /// the part and the column genuinely are the same word, and
+    /// `tests/one_predicate.rs` refuses any source outside `store/audience.rs`
+    /// that names the column, so a literal here would fail it. That test is
+    /// aimed at a paraphrased predicate rather than at this, and taking the
+    /// name from the constant satisfies it honestly rather than by evasion.
+    #[must_use]
+    pub fn store_name(self) -> &'static str {
+        match self {
+            Self::Title => "title",
+            Self::Dates => "dates",
+            Self::Category => "category_id",
+            Self::Assignments => "assigned_member_ids",
+            Self::Audience => AUDIENCE_COLUMN,
+            Self::Bulk => "bulk",
+            Self::CategoryPosition => "category_position",
+        }
+    }
+
+    /// The inverse of [`ContentPart::store_name`].
+    #[must_use]
+    pub fn from_store_name(name: &str) -> Option<Self> {
+        ALL_CONTENT_PARTS
+            .iter()
+            .copied()
+            .find(|p| p.store_name() == name)
+    }
+}
+
+/// The prefix a type-specific part's stored name carries.
+///
+/// Prefixed rather than bare, so a type-specific field number can never be read
+/// as a content part's name, and so a reader of the table can tell the two
+/// apart without knowing the entity's type.
+const SPECIFIC_PREFIX: &str = "specific.";
+
+/// How a part is keyed in `entity_part_counter` and in `conflict`: exactly one
+/// of a text name and a block identity, which is the check both tables carry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PartKey {
+    Field(String),
+    Block(Uuid),
+}
+
+impl Part {
+    /// How this part is written to the two tables keyed by it.
+    #[must_use]
+    pub fn key(&self) -> PartKey {
+        match self {
+            Self::Content(p) => PartKey::Field(p.store_name().to_owned()),
+            Self::Specific(n) => PartKey::Field(format!("{SPECIFIC_PREFIX}{n}")),
+            Self::Block(id) => PartKey::Block(*id),
+        }
+    }
+
+    /// The part a stored key names.
+    ///
+    /// `None` for a field name this module does not recognise, which is a part
+    /// written by a version of the instance that knew a name this one does not.
+    /// Treating that as unknown rather than guessing is the only safe reading:
+    /// a part nobody can name is a part nobody can conflict on, and inventing a
+    /// name for it would let two different parts collide.
+    #[must_use]
+    pub fn from_key(key: &PartKey) -> Option<Self> {
+        match key {
+            PartKey::Block(id) => Some(Self::Block(*id)),
+            PartKey::Field(name) => {
+                if let Some(rest) = name.strip_prefix(SPECIFIC_PREFIX) {
+                    return rest.parse().ok().map(Self::Specific);
+                }
+                ContentPart::from_store_name(name).map(Self::Content)
+            }
+        }
+    }
+}
+
+impl From<ContentPart> for Part {
+    fn from(p: ContentPart) -> Self {
+        Self::Content(p)
+    }
+}

--- a/crates/altaird/src/write/provenance.rs
+++ b/crates/altaird/src/write/provenance.rs
@@ -1,0 +1,237 @@
+//! Per-part write provenance, and the conflict rule that reads it.
+//!
+//! # The rule, stated once
+//!
+//! An edit declares the counter it was based on. Three outcomes, from the
+//! substrate:
+//!
+//! - Base current: apply.
+//! - Base stale, the parts this write touches disjoint from what moved since:
+//!   **apply, no conflict.**
+//! - Base stale, overlapping: **conflict.** Both values are retained, and the
+//!   write still applies.
+//!
+//! **A stale base is never a rejection.** The counter detects concurrency; it
+//! does not gate admission, and no write is ever sent back to be retried. This
+//! is the point at which reject-and-retry — the familiar shape of optimistic
+//! concurrency control — would be reached for and would be wrong: a device
+//! returning after three weeks cannot win a retry race against a household that
+//! has been using the system meanwhile, so it would spin, then give up, in
+//! exactly the case the durability guarantees exist for.
+//!
+//! # Writes producing the same value are not divergent
+//!
+//! Stated separately in the vision document and easy to drop: *whatever their
+//! base counter said*. Two people resolving one conflict the same way is the
+//! likely case, and forming a second conflict out of two people agreeing is the
+//! machinery working against its own purpose. So an overlapping part whose
+//! arriving value equals the value already stored is not a conflict, and the
+//! comparison is over the text rendering both sides would be retained as.
+//!
+//! # Why a side table
+//!
+//! Answering "which parts moved between counter N and now" needs a record of
+//! it. Nothing in migration one had one. See `0002_write_provenance.sql` for
+//! the two shapes rejected and why.
+
+use std::collections::HashMap;
+
+use sqlx::Row;
+use uuid::Uuid;
+
+use crate::store::WriteTx;
+use crate::store::ids::{EntityId, MemberId, MemberRef};
+
+use super::parts::{Part, PartKey};
+
+/// A part that moved since some base counter, and who moved it.
+#[derive(Debug, Clone)]
+pub struct Moved {
+    pub part: Part,
+    pub by: MemberRef,
+}
+
+/// Every part of this entity that moved strictly after `base`.
+///
+/// Strictly after: a part that last moved *at* the base counter is a part the
+/// editing client had already seen, so it is not something that moved since.
+pub async fn moved_since(
+    tx: &mut WriteTx,
+    entity: EntityId,
+    base: i64,
+) -> sqlx::Result<Vec<Moved>> {
+    let rows = sqlx::query(
+        "SELECT field_name, block_id, member_id FROM entity_part_counter \
+         WHERE entity_id = $1 AND counter > $2",
+    )
+    .bind(entity.as_uuid())
+    .bind(base)
+    .fetch_all(tx.conn())
+    .await?;
+
+    let mut moved = Vec::with_capacity(rows.len());
+    for r in &rows {
+        let key = match (
+            r.try_get::<Option<String>, _>("field_name")?,
+            r.try_get::<Option<Uuid>, _>("block_id")?,
+        ) {
+            (Some(name), None) => PartKey::Field(name),
+            (None, Some(id)) => PartKey::Block(id),
+            // The table's own check refuses both and neither, so this is
+            // unreachable rather than defended against.
+            _ => continue,
+        };
+        // A name this build does not know is a part it cannot conflict on. See
+        // `Part::from_key` for why guessing would be worse than skipping.
+        if let Some(part) = Part::from_key(&key) {
+            moved.push(Moved {
+                part,
+                by: MemberRef::from_uuid(r.try_get("member_id")?),
+            });
+        }
+    }
+    Ok(moved)
+}
+
+/// Record that these parts moved at `counter`, written by `member`.
+///
+/// Upserts, because a part moves many times and only the last time matters.
+pub async fn record(
+    tx: &mut WriteTx,
+    entity: EntityId,
+    parts: &[Part],
+    counter: i64,
+    member: MemberId,
+) -> sqlx::Result<()> {
+    for part in parts {
+        let (field, block) = match part.key() {
+            PartKey::Field(name) => (Some(name), None),
+            PartKey::Block(id) => (None, Some(id)),
+        };
+        sqlx::query(
+            "INSERT INTO entity_part_counter \
+             (entity_id, field_name, block_id, counter, member_id) \
+             VALUES ($1, $2, $3, $4, $5) \
+             ON CONFLICT (entity_id, field_name, block_id) \
+             DO UPDATE SET counter = excluded.counter, member_id = excluded.member_id",
+        )
+        .bind(entity.as_uuid())
+        .bind(field)
+        .bind(block)
+        .bind(counter)
+        .bind(member.as_uuid())
+        .execute(tx.conn())
+        .await?;
+    }
+    Ok(())
+}
+
+/// Everything provenance holds about one entity, removed on erasure.
+///
+/// Erasure does not delete the entity row — it leaves a tombstone — so the
+/// schema's cascades never fire and every dependent row is removed explicitly.
+pub async fn erase(tx: &mut WriteTx, entity: EntityId) -> sqlx::Result<()> {
+    sqlx::query("DELETE FROM entity_part_counter WHERE entity_id = $1")
+        .bind(entity.as_uuid())
+        .execute(tx.conn())
+        .await?;
+    Ok(())
+}
+
+/// One part whose two values are both retained.
+#[derive(Debug, Clone)]
+pub struct Retained {
+    pub part: Part,
+    /// The arriving value, which becomes the entity's current value.
+    pub mine: String,
+    /// Who is submitting this write.
+    pub mine_member: MemberId,
+    /// The value this write displaced.
+    pub theirs: Option<String>,
+    /// Who last moved the part before this write.
+    pub theirs_member: MemberRef,
+}
+
+/// Decide, for one write, which of its parts conflict.
+///
+/// `touching` is what the write addresses, paired with the text each side would
+/// be retained as: the arriving value, and the value already stored. Both are
+/// optional because clearing a part is setting it to nothing.
+///
+/// Returns the subset that overlaps what moved since `base` and disagrees with
+/// it. Everything else applies silently, which is the whole point of scoping a
+/// write to its parts.
+pub fn detect(
+    touching: &[(Part, Option<String>, Option<String>)],
+    moved: &[Moved],
+    member: MemberId,
+) -> Vec<Retained> {
+    let by_part: HashMap<&Part, &Moved> = moved.iter().map(|m| (&m.part, m)).collect();
+
+    touching
+        .iter()
+        .filter_map(|(part, arriving, stored)| {
+            let m = by_part.get(part)?;
+            // Writes producing the same value are not divergent, whatever their
+            // base counter said.
+            if arriving == stored {
+                return None;
+            }
+            Some(Retained {
+                part: part.clone(),
+                mine: arriving.clone().unwrap_or_default(),
+                mine_member: member,
+                theirs: stored.clone(),
+                theirs_member: m.by,
+            })
+        })
+        .collect()
+}
+
+/// Retain both values of a conflicted part on the entity.
+///
+/// # Which side is `mine`
+///
+/// The store's two slots are named `mine` and `theirs`, and the wire's are too,
+/// but the wire's are **reader-relative**: a client renders whichever side
+/// carries its own member as "mine". A stored row cannot be reader-relative, so
+/// the names here are slots and the member id on each side is the fact that
+/// matters — which is exactly what the substrate requires, that *whose edit
+/// each value was is known and may be shown*.
+///
+/// The reading taken, stated so it is not re-derived: **`mine` is the arriving
+/// value** — the one this write applies, submitted by the member who will read
+/// the acknowledgement — and **`theirs` is the value it displaced**. It is the
+/// reading that makes the acknowledgement's own perspective the stored one, and
+/// nothing downstream may key on the slot name without also reading the member.
+pub async fn retain(
+    tx: &mut WriteTx,
+    entity: EntityId,
+    retained: &[Retained],
+    at: chrono::DateTime<chrono::Utc>,
+) -> sqlx::Result<()> {
+    for r in retained {
+        let (field, block) = match r.part.key() {
+            PartKey::Field(name) => (Some(name), None),
+            PartKey::Block(id) => (None, Some(id)),
+        };
+        sqlx::query(
+            "INSERT INTO conflict \
+             (id, entity_id, field_name, block_id, mine_member_id, mine_value, \
+              theirs_member_id, theirs_value, detected_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        )
+        .bind(Uuid::new_v4())
+        .bind(entity.as_uuid())
+        .bind(field)
+        .bind(block)
+        .bind(r.mine_member.as_uuid())
+        .bind(&r.mine)
+        .bind(r.theirs_member.as_uuid())
+        .bind(r.theirs.as_deref())
+        .bind(at)
+        .execute(tx.conn())
+        .await?;
+    }
+    Ok(())
+}

--- a/crates/altaird/src/write/relation.rs
+++ b/crates/altaird/src/write/relation.rs
@@ -69,16 +69,46 @@ struct Resolved {
 
 /// An exact decimal, as text, for a `numeric` column.
 ///
-/// Units and nanos carry the same sign, as a duration does, so the two are
-/// composed rather than concatenated: a negative amount is meaningful
-/// information about a cupboard and rendering it as `-3.500000000` by string
-/// surgery is where that goes wrong.
-fn decimal(d: &v1::Decimal) -> String {
+/// **Range is checked here**, which is one of the schema's owed checks —
+/// *everything the wire shape implies: identifier length, decimal range, a
+/// field both present and cleared, a cleared number naming no field*. Two
+/// shapes are refusable rather than renderable, and both were silently
+/// mis-rendered until a cross-model review found them:
+///
+/// - **A fraction of a billion or more.** `{ units: 1, nanos: 1_500_000_000 }`
+///   is not 2.5, and formatting it into a fixed nine-place field produces
+///   `1.15` — a different number, stated with total confidence. A household's
+///   stock is the last place to guess.
+/// - **Opposite signs.** The wire says units and nanos carry the same sign, as
+///   a duration does. `{ units: 1, nanos: -250_000_000 }` is either 0.75 or
+///   -1.25 depending on which half you believe, so it is neither.
+///
+/// A negative amount itself is ordinary and is rendered: availability is the
+/// asserted amount minus what live relations commit, and negative availability
+/// is meaningful information about a cupboard.
+fn decimal(d: &v1::Decimal) -> Result<String, Refusal> {
+    const BILLION: i64 = 1_000_000_000;
     let nanos = i64::from(d.nanos);
+
+    if nanos.abs() >= BILLION {
+        return Err(Refusal::Malformed(
+            "a decimal's nanos are a fraction of one unit, and this one is a whole unit or more"
+                .into(),
+        ));
+    }
+    if (d.units > 0 && nanos < 0) || (d.units < 0 && nanos > 0) {
+        return Err(Refusal::Malformed(
+            "a decimal's units and nanos carry the same sign, as a duration does".into(),
+        ));
+    }
+
     let negative = d.units < 0 || nanos < 0;
     let whole = d.units.unsigned_abs();
     let fraction = nanos.unsigned_abs();
-    format!("{}{whole}.{fraction:09}", if negative { "-" } else { "" })
+    Ok(format!(
+        "{}{whole}.{fraction:09}",
+        if negative { "-" } else { "" }
+    ))
 }
 
 /// Endpoints, type, and type-declared properties, checked against everything
@@ -142,7 +172,7 @@ async fn resolve(ctx: &mut Ctx<'_>, content: &v1::RelationContent) -> Applied<Re
                 Ok(v1::UsesResolution::Consumed) => "consumed",
                 _ => "unresolved",
             };
-            (Some(decimal(q)), Some(resolution))
+            (Some(decimal(q)?), Some(resolution))
         }
         (Some(_), _) => {
             return Err(Refusal::Malformed(
@@ -183,7 +213,7 @@ async fn resolve(ctx: &mut Ctx<'_>, content: &v1::RelationContent) -> Applied<Re
 ///
 /// Only active relations count. One sitting in holding is not a connection that
 /// exists, and forming it again is the person's answer to having removed it.
-async fn is_duplicate(ctx: &mut Ctx<'_>, r: &Resolved) -> Applied<bool> {
+async fn is_duplicate(ctx: &mut Ctx<'_>, r: &Resolved, itself: Option<Uuid>) -> Applied<bool> {
     if r.relation_type.is_some() {
         return Ok(false);
     }
@@ -191,13 +221,23 @@ async fn is_duplicate(ctx: &mut Ctx<'_>, r: &Resolved) -> Applied<bool> {
         "SELECT 1 AS found FROM relation \
          WHERE from_entity_id = $1 AND to_entity_id = $2 \
            AND relation_type_id IS NULL AND anchor_entity_id IS NULL \
-           AND lifecycle = 'active' LIMIT 1",
+           AND lifecycle = 'active' AND ($3::uuid IS NULL OR id <> $3) LIMIT 1",
     )
     .bind(r.from.as_uuid())
     .bind(r.to.as_uuid())
+    .bind(itself)
     .fetch_optional(ctx.tx.conn())
     .await?;
     Ok(row.is_some())
+}
+
+/// The refusal a duplicate produces, in one place because two verbs raise it.
+fn already_recorded() -> Refusal {
+    Refusal::Malformed(
+        "this connection is already recorded, and an untyped unanchored relation is \
+         the same connection however it is submitted"
+            .into(),
+    )
 }
 
 /// Create a relation.
@@ -209,20 +249,23 @@ pub async fn create(ctx: &mut Ctx<'_>, id: Uuid, content: &v1::RelationContent) 
     }
 
     let r = resolve(ctx, content).await?;
-    if is_duplicate(ctx, &r).await? {
-        return Err(Refusal::Malformed(
-            "this connection is already recorded, and an untyped unanchored relation is \
-             the same connection however it is submitted"
-                .into(),
-        )
-        .into());
+    if is_duplicate(ctx, &r, None).await? {
+        return Err(already_recorded().into());
     }
 
-    sqlx::query(
+    // `ON CONFLICT DO NOTHING`, with the row count read rather than ignored.
+    // `load` above answered `None` both for an identifier nothing holds and for
+    // one held by a relation this member cannot see, and only the first of
+    // those may be created. A bare insert turns the second into a primary-key
+    // violation, which leaves this path as a store fault where an unused
+    // identifier would have succeeded — and a fault that appears only when
+    // something is there is an oracle for whether something is there.
+    let inserted = sqlx::query(
         "INSERT INTO relation \
          (id, from_entity_id, to_entity_id, relation_type_id, quantity, resolution, \
           author_member_id, created_at) \
-         VALUES ($1, $2, $3, $4, $5::numeric, $6::uses_resolution, $7, $8)",
+         VALUES ($1, $2, $3, $4, $5::numeric, $6::uses_resolution, $7, $8) \
+         ON CONFLICT (id) DO NOTHING",
     )
     .bind(id)
     .bind(r.from.as_uuid())
@@ -234,6 +277,9 @@ pub async fn create(ctx: &mut Ctx<'_>, id: Uuid, content: &v1::RelationContent) 
     .bind(ctx.at)
     .execute(ctx.tx.conn())
     .await?;
+    if inserted.rows_affected() == 0 {
+        return Err(Refusal::NotAvailable.into());
+    }
 
     changes::relation_written(ctx.tx, ctx.at, id).await?;
     Ok(id)
@@ -274,6 +320,14 @@ pub async fn edit(ctx: &mut Ctx<'_>, id: Uuid, content: &v1::RelationContent) ->
         return Err(Refusal::NotAvailable.into());
     }
     let r = resolve(ctx, content).await?;
+
+    // An edit can make a relation into a duplicate as easily as a create can:
+    // clearing the type off one of two relations between the same pair leaves
+    // two untyped unanchored records of one connection. The relation being
+    // edited is excluded, or an edit that changes nothing would refuse itself.
+    if is_duplicate(ctx, &r, Some(id)).await? {
+        return Err(already_recorded().into());
+    }
 
     sqlx::query(
         "UPDATE relation SET from_entity_id = $2, to_entity_id = $3, relation_type_id = $4, \

--- a/crates/altaird/src/write/relation.rs
+++ b/crates/altaird/src/write/relation.rs
@@ -1,0 +1,352 @@
+//! The five verbs, on a relation.
+//!
+//! # Types are declarations, not branches
+//!
+//! **Nothing here names a relation type.** Whether a relation is read from one
+//! end or from both, and whether it may carry a quantity, are read out of
+//! `relation_type` as two booleans and interpreted. There is no `match` on
+//! *blocks*, *uses*, or *references* anywhere, and there must not be one.
+//!
+//! This is a build constraint from the relation types specification rather than
+//! a style preference: *the constraint worth honouring meanwhile is to build
+//! these as declarations the system interprets rather than as hardcoded
+//! branches, so that exposing the extension point later is exposing what
+//! already exists.* It is free now and a rewrite later. `tests/write_relations.rs`
+//! proves it by declaring a type the shipped set has never contained and
+//! showing it gets the whole of both behaviours.
+//!
+//! # Canonical ordering
+//!
+//! One record joins two entities and is traversable from either end; there is
+//! no reverse row. Where the type is symmetric or absent, the endpoints have no
+//! privileged order, so the same connection submitted as A→B and as B→A would
+//! be two records of one fact. The write path puts them in a canonical order —
+//! by identifier, which carries no meaning and is therefore the only stable
+//! thing to sort by (DR-007) — so it cannot be recorded twice.
+//!
+//! A constraint cannot do this, because symmetry is a property of the type
+//! declaration and a check constraint cannot reach another table.
+
+use sqlx::Row;
+use uuid::Uuid;
+
+use altair_proto::v1;
+
+use crate::store::entity::available_for_write;
+use crate::store::ids::EntityId;
+use crate::store::{WriteScope, WriteTx};
+
+use super::changes;
+use super::content::identifier;
+use super::entity::{Applied, Ctx, Refusal};
+
+/// What a relation type declares. Read, never branched on.
+struct Declaration {
+    is_asymmetric: bool,
+    is_quantified: bool,
+}
+
+async fn declaration(tx: &mut WriteTx, id: Uuid) -> Applied<Declaration> {
+    let row = sqlx::query("SELECT is_asymmetric, is_quantified FROM relation_type WHERE id = $1")
+        .bind(id)
+        .fetch_optional(tx.conn())
+        .await?
+        .ok_or(Refusal::NotAvailable)?;
+    Ok(Declaration {
+        is_asymmetric: row.try_get("is_asymmetric")?,
+        is_quantified: row.try_get("is_quantified")?,
+    })
+}
+
+/// A relation as this write path holds one, after validation.
+struct Resolved {
+    from: EntityId,
+    to: EntityId,
+    relation_type: Option<Uuid>,
+    quantity: Option<String>,
+    resolution: Option<&'static str>,
+}
+
+/// An exact decimal, as text, for a `numeric` column.
+///
+/// Units and nanos carry the same sign, as a duration does, so the two are
+/// composed rather than concatenated: a negative amount is meaningful
+/// information about a cupboard and rendering it as `-3.500000000` by string
+/// surgery is where that goes wrong.
+fn decimal(d: &v1::Decimal) -> String {
+    let nanos = i64::from(d.nanos);
+    let negative = d.units < 0 || nanos < 0;
+    let whole = d.units.unsigned_abs();
+    let fraction = nanos.unsigned_abs();
+    format!("{}{whole}.{fraction:09}", if negative { "-" } else { "" })
+}
+
+/// Endpoints, type, and type-declared properties, checked against everything
+/// that is not the store's to check.
+async fn resolve(ctx: &mut Ctx<'_>, content: &v1::RelationContent) -> Applied<Resolved> {
+    let (Some(from), Some(to)) = (&content.from_entity_id, &content.to_entity_id) else {
+        return Err(Refusal::Malformed(
+            "a relation joins two entities and this names fewer".into(),
+        )
+        .into());
+    };
+    let from = EntityId::from_uuid(identifier(from)?);
+    let to = EntityId::from_uuid(identifier(to)?);
+    if from == to {
+        return Err(
+            Refusal::Malformed("a relation joins two entities, not one to itself".into()).into(),
+        );
+    }
+
+    // Both ends have to be visible. A relation whose far end a member cannot
+    // see would show them that something is there, which is the disclosure the
+    // single refusal reason exists to prevent.
+    for end in [from, to] {
+        if available_for_write(ctx.tx, ctx.member, end, WriteScope::Extant)
+            .await?
+            .is_none()
+        {
+            return Err(Refusal::NotAvailable.into());
+        }
+    }
+
+    let relation_type = content
+        .relation_type_id
+        .as_ref()
+        .map(|b| identifier(b))
+        .transpose()?;
+
+    let declared = match relation_type {
+        Some(id) => Some(declaration(ctx.tx, id).await?),
+        None => None,
+    };
+
+    // An anchor locates into a body, and bodies arrive with Wave 2.2. Refused
+    // rather than dropped: silently discarding where somebody formed a
+    // connection is the kind of loss an acknowledgement should never hide.
+    if content.anchor.is_some() {
+        return Err(Refusal::Malformed(
+            "an anchor locates into a block, and bodies are not served yet".into(),
+        )
+        .into());
+    }
+
+    // Properties the type declares, and no others.
+    let (quantity, resolution) = match (&content.uses, &declared) {
+        (Some(uses), Some(d)) if d.is_quantified => {
+            let q = uses.quantity.as_ref().ok_or_else(|| {
+                Refusal::Malformed("a quantified relation carries a quantity".into())
+            })?;
+            let resolution = match v1::UsesResolution::try_from(uses.resolution) {
+                Ok(v1::UsesResolution::Returned) => "returned",
+                Ok(v1::UsesResolution::Consumed) => "consumed",
+                _ => "unresolved",
+            };
+            (Some(decimal(q)), Some(resolution))
+        }
+        (Some(_), _) => {
+            return Err(Refusal::Malformed(
+                "this relation's type declares no properties, and properties follow from the type"
+                    .into(),
+            )
+            .into());
+        }
+        _ => (None, None),
+    };
+
+    // Where the type is symmetric or absent, neither end is privileged, so the
+    // pair is put in a canonical order and the same connection cannot be
+    // recorded twice.
+    let symmetric = declared.as_ref().is_none_or(|d| !d.is_asymmetric);
+    let (from, to) = if symmetric && to.as_uuid() < from.as_uuid() {
+        (to, from)
+    } else {
+        (from, to)
+    };
+
+    Ok(Resolved {
+        from,
+        to,
+        relation_type,
+        quantity,
+        resolution,
+    })
+}
+
+/// Refuse a duplicate untyped unanchored relation.
+///
+/// **Only that shape.** Migration one records why this is not a unique index: a
+/// relation that loses its anchor when its block is removed becomes unanchored,
+/// would collide with an existing relation between the same pair, and the block
+/// removal would fail. A body edit must never fail because a relation lost an
+/// anchor, and that outranks refusing a duplicate structurally.
+///
+/// Only active relations count. One sitting in holding is not a connection that
+/// exists, and forming it again is the person's answer to having removed it.
+async fn is_duplicate(ctx: &mut Ctx<'_>, r: &Resolved) -> Applied<bool> {
+    if r.relation_type.is_some() {
+        return Ok(false);
+    }
+    let row = sqlx::query(
+        "SELECT 1 AS found FROM relation \
+         WHERE from_entity_id = $1 AND to_entity_id = $2 \
+           AND relation_type_id IS NULL AND anchor_entity_id IS NULL \
+           AND lifecycle = 'active' LIMIT 1",
+    )
+    .bind(r.from.as_uuid())
+    .bind(r.to.as_uuid())
+    .fetch_optional(ctx.tx.conn())
+    .await?;
+    Ok(row.is_some())
+}
+
+/// Create a relation.
+pub async fn create(ctx: &mut Ctx<'_>, id: Uuid, content: &v1::RelationContent) -> Applied<Uuid> {
+    // Already here: one relation, not two. The same convergence a create of an
+    // entity gets, and for the same reason.
+    if let Some(existing) = load(ctx, id).await? {
+        return Ok(existing.0);
+    }
+
+    let r = resolve(ctx, content).await?;
+    if is_duplicate(ctx, &r).await? {
+        return Err(Refusal::Malformed(
+            "this connection is already recorded, and an untyped unanchored relation is \
+             the same connection however it is submitted"
+                .into(),
+        )
+        .into());
+    }
+
+    sqlx::query(
+        "INSERT INTO relation \
+         (id, from_entity_id, to_entity_id, relation_type_id, quantity, resolution, \
+          author_member_id, created_at) \
+         VALUES ($1, $2, $3, $4, $5::numeric, $6::uses_resolution, $7, $8)",
+    )
+    .bind(id)
+    .bind(r.from.as_uuid())
+    .bind(r.to.as_uuid())
+    .bind(r.relation_type)
+    .bind(r.quantity.as_deref())
+    .bind(r.resolution)
+    .bind(ctx.member.as_uuid())
+    .bind(ctx.at)
+    .execute(ctx.tx.conn())
+    .await?;
+
+    changes::relation_written(ctx.tx, ctx.at, id).await?;
+    Ok(id)
+}
+
+/// The relation, if it is there and both its ends are visible to this member.
+async fn load(ctx: &mut Ctx<'_>, id: Uuid) -> Applied<Option<(Uuid, String)>> {
+    let row = sqlx::query(
+        "SELECT id, from_entity_id, to_entity_id, lifecycle::text AS lifecycle \
+         FROM relation WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(ctx.tx.conn())
+    .await?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    for column in ["from_entity_id", "to_entity_id"] {
+        let end = EntityId::from_uuid(row.try_get(column)?);
+        if available_for_write(ctx.tx, ctx.member, end, WriteScope::AnyIncludingErased)
+            .await?
+            .is_none()
+        {
+            return Ok(None);
+        }
+    }
+    Ok(Some((row.try_get("id")?, row.try_get("lifecycle")?)))
+}
+
+/// Edit a relation.
+///
+/// **Unconditional, and last write wins.** Relations carry no write counter
+/// anywhere in the documents, which the proto records as its gap (a): moot in
+/// v0 with one device, and not moot afterwards. Nothing here pretends
+/// otherwise, and nothing detects a concurrent relation edit.
+pub async fn edit(ctx: &mut Ctx<'_>, id: Uuid, content: &v1::RelationContent) -> Applied<Uuid> {
+    if load(ctx, id).await?.is_none() {
+        return Err(Refusal::NotAvailable.into());
+    }
+    let r = resolve(ctx, content).await?;
+
+    sqlx::query(
+        "UPDATE relation SET from_entity_id = $2, to_entity_id = $3, relation_type_id = $4, \
+         quantity = $5::numeric, resolution = $6::uses_resolution WHERE id = $1",
+    )
+    .bind(id)
+    .bind(r.from.as_uuid())
+    .bind(r.to.as_uuid())
+    .bind(r.relation_type)
+    .bind(r.quantity.as_deref())
+    .bind(r.resolution)
+    .execute(ctx.tx.conn())
+    .await?;
+
+    changes::relation_written(ctx.tx, ctx.at, id).await?;
+    Ok(id)
+}
+
+/// Put relations into the holding state, as part of one act.
+///
+/// Converges exactly as an entity removal does.
+pub async fn remove(ctx: &mut Ctx<'_>, ids: &[Uuid], group: Uuid) -> Applied<Vec<Uuid>> {
+    let mut removed = Vec::new();
+    for id in ids {
+        match load(ctx, *id).await? {
+            Some((_, lifecycle)) if lifecycle == "active" => {}
+            _ => continue,
+        }
+        sqlx::query(
+            "UPDATE relation SET lifecycle = 'deleted', deleted_at = $2, \
+             deletion_group_id = $3 WHERE id = $1",
+        )
+        .bind(id)
+        .bind(ctx.at)
+        .bind(group)
+        .execute(ctx.tx.conn())
+        .await?;
+        // A removed relation is gone from the stream, not a relation carrying a
+        // lifecycle: the wire's `Relation` has no lifecycle field to put one in.
+        changes::relation_gone(ctx.tx, ctx.at, *id).await?;
+        removed.push(*id);
+    }
+    Ok(removed)
+}
+
+/// Bring back the relations one act removed.
+///
+/// **A relation comes back with the act that removed it, and there is no
+/// restoring one on its own.** The asymmetry with entities is deliberate:
+/// nothing lists removed connections for a person to notice one missing from,
+/// and forming a connection again costs a gesture, which is not true of an
+/// entity whose content nobody can retype from memory.
+pub async fn restore_group(ctx: &mut Ctx<'_>, group: Uuid) -> Applied<Vec<Uuid>> {
+    let rows = sqlx::query("SELECT id FROM relation WHERE deletion_group_id = $1")
+        .bind(group)
+        .fetch_all(ctx.tx.conn())
+        .await?;
+
+    let mut restored = Vec::new();
+    for row in &rows {
+        let id: Uuid = row.try_get("id")?;
+        if load(ctx, id).await?.is_none() {
+            continue;
+        }
+        sqlx::query(
+            "UPDATE relation SET lifecycle = 'active', deleted_at = NULL, \
+             deletion_group_id = NULL WHERE id = $1",
+        )
+        .bind(id)
+        .execute(ctx.tx.conn())
+        .await?;
+        changes::relation_written(ctx.tx, ctx.at, id).await?;
+        restored.push(id);
+    }
+    Ok(restored)
+}

--- a/crates/altaird/tests/common/mod.rs
+++ b/crates/altaird/tests/common/mod.rs
@@ -382,8 +382,8 @@ pub fn relation_id(ack: &v1::Acknowledgement) -> Uuid {
     Uuid::from_bytes(bytes)
 }
 
-pub fn timestamp(at: DateTime<Utc>) -> prost_types::Timestamp {
-    prost_types::Timestamp {
+pub fn timestamp(at: DateTime<Utc>) -> altair_proto::prost_types::Timestamp {
+    altair_proto::prost_types::Timestamp {
         seconds: at.timestamp(),
         nanos: at.timestamp_subsec_nanos() as i32,
     }

--- a/crates/altaird/tests/common/mod.rs
+++ b/crates/altaird/tests/common/mod.rs
@@ -1,0 +1,390 @@
+//! Shared setup for the write path's tests.
+//!
+//! Everything here is scaffolding. Nothing in it asserts anything, so a change
+//! that makes a test pass has to be a change to the instance rather than to
+//! this file.
+
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use altair_proto::v1;
+use altaird::auth::Member;
+use altaird::store::ids::EntityId;
+use altaird::testing::TestDb;
+use altaird::write::WritePath;
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+use uuid::Uuid;
+
+/// A household with two members, and a write path over it.
+pub struct World {
+    pub db: Arc<TestDb>,
+    pub household: Uuid,
+    pub one: Member,
+    pub two: Member,
+    pub write: WritePath,
+}
+
+impl World {
+    pub async fn new() -> Self {
+        let db = TestDb::new().await;
+        let household = Uuid::new_v4();
+        sqlx::query("INSERT INTO household (id, name, created_at) VALUES ($1, $2, now())")
+            .bind(household)
+            .bind("test")
+            .execute(&db.pool)
+            .await
+            .expect("household");
+
+        let one = seed_member(&db.pool, household, "one").await;
+        let two = seed_member(&db.pool, household, "two").await;
+        let write = WritePath::new(db.pool.clone());
+        Self {
+            db,
+            household,
+            one,
+            two,
+            write,
+        }
+    }
+
+    /// Submit one intent and take the single acknowledgement back.
+    pub async fn submit(&self, member: &Member, action: v1::intent::Action) -> v1::Acknowledgement {
+        self.submit_as(member, Uuid::new_v4(), action).await
+    }
+
+    /// Submit under a stated intent identity, so a replay can reuse it.
+    pub async fn submit_as(
+        &self,
+        member: &Member,
+        intent: Uuid,
+        action: v1::intent::Action,
+    ) -> v1::Acknowledgement {
+        let acks = self
+            .write
+            .submit(
+                member,
+                &[v1::Intent {
+                    intent_id: intent.as_bytes().to_vec(),
+                    action: Some(action),
+                }],
+            )
+            .await
+            .expect("the store was reachable");
+        acks.into_iter().next().expect("one intent, one answer")
+    }
+
+    /// Create an entity of a type, with content, and return its identity.
+    pub async fn create(
+        &self,
+        member: &Member,
+        kind: v1::entity_content::Specific,
+        content: v1::EntityContent,
+    ) -> EntityId {
+        let id = Uuid::new_v4();
+        let ack = self
+            .submit(
+                member,
+                create_entity(
+                    id,
+                    v1::EntityContent {
+                        specific: Some(kind),
+                        ..content
+                    },
+                ),
+            )
+            .await;
+        assert!(
+            matches!(ack.outcome, Some(v1::acknowledgement::Outcome::Applied(_))),
+            "create was not applied: {:?}",
+            ack.outcome
+        );
+        EntityId::from_uuid(id)
+    }
+
+    /// A note with a title and nothing else, which is the cheapest entity.
+    pub async fn note(&self, member: &Member, title: &str) -> EntityId {
+        self.create(
+            member,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            v1::EntityContent {
+                title: Some(title.into()),
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    pub async fn counter(&self, id: EntityId) -> i64 {
+        sqlx::query("SELECT counter FROM entity WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_one(&self.db.pool)
+            .await
+            .expect("entity")
+            .try_get("counter")
+            .expect("counter")
+    }
+
+    pub async fn title(&self, id: EntityId) -> Option<String> {
+        sqlx::query("SELECT title FROM entity WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_one(&self.db.pool)
+            .await
+            .expect("entity")
+            .try_get("title")
+            .expect("title")
+    }
+
+    pub async fn lifecycle(&self, id: EntityId) -> String {
+        sqlx::query("SELECT lifecycle::text AS l FROM entity WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_one(&self.db.pool)
+            .await
+            .expect("entity")
+            .try_get("l")
+            .expect("lifecycle")
+    }
+
+    pub async fn category_position(&self, id: EntityId) -> Option<i32> {
+        sqlx::query("SELECT category_position AS p FROM entity WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_one(&self.db.pool)
+            .await
+            .expect("entity")
+            .try_get("p")
+            .expect("position")
+    }
+
+    pub async fn relation_lifecycle(&self, id: Uuid) -> Option<String> {
+        sqlx::query("SELECT lifecycle::text AS l FROM relation WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&self.db.pool)
+            .await
+            .expect("query")
+            .map(|r| r.try_get("l").expect("lifecycle"))
+    }
+
+    /// The change sequence, in position order.
+    pub async fn changes(&self) -> Vec<Change> {
+        sqlx::query(
+            "SELECT position, kind::text AS kind, entity_id, relation_id, \
+             audience_before, audience_after FROM change ORDER BY position",
+        )
+        .fetch_all(&self.db.pool)
+        .await
+        .expect("changes")
+        .iter()
+        .map(|r| Change {
+            position: r.try_get("position").unwrap(),
+            kind: r.try_get("kind").unwrap(),
+            entity: r.try_get("entity_id").unwrap(),
+            relation: r.try_get("relation_id").unwrap(),
+            audience_before: r.try_get("audience_before").unwrap(),
+            audience_after: r.try_get("audience_after").unwrap(),
+        })
+        .collect()
+    }
+
+    pub async fn conflicts(&self, id: EntityId) -> Vec<Conflict> {
+        sqlx::query(
+            "SELECT field_name, mine_member_id, mine_value, theirs_member_id, theirs_value \
+             FROM conflict WHERE entity_id = $1 ORDER BY field_name",
+        )
+        .bind(id.as_uuid())
+        .fetch_all(&self.db.pool)
+        .await
+        .expect("conflicts")
+        .iter()
+        .map(|r| Conflict {
+            field: r.try_get("field_name").unwrap(),
+            mine_member: r.try_get("mine_member_id").unwrap(),
+            mine: r.try_get("mine_value").unwrap(),
+            theirs_member: r.try_get("theirs_member_id").unwrap(),
+            theirs: r.try_get("theirs_value").unwrap(),
+        })
+        .collect()
+    }
+
+    /// How many rows a table holds for one entity, for the erasure test.
+    pub async fn rows_for(&self, table: &str, column: &str, id: EntityId) -> i64 {
+        let sql = format!("SELECT count(*) AS n FROM {table} WHERE {column} = $1");
+        sqlx::query(sqlx::AssertSqlSafe(sql))
+            .bind(id.as_uuid())
+            .fetch_one(&self.db.pool)
+            .await
+            .expect("count")
+            .try_get("n")
+            .expect("n")
+    }
+
+    /// Declare a relation type. **Never one of the shipped set**: the point is
+    /// that behaviour comes from the declaration.
+    pub async fn declare_type(&self, label: &str, asymmetric: bool, quantified: bool) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO relation_type (id, label, is_asymmetric, is_quantified) \
+             VALUES ($1, $2, $3, $4)",
+        )
+        .bind(id)
+        .bind(label)
+        .bind(asymmetric)
+        .bind(quantified)
+        .execute(&self.db.pool)
+        .await
+        .expect("relation type");
+        id
+    }
+}
+
+pub struct Change {
+    pub position: i64,
+    pub kind: String,
+    pub entity: Option<Uuid>,
+    pub relation: Option<Uuid>,
+    pub audience_before: Option<Vec<Uuid>>,
+    pub audience_after: Option<Vec<Uuid>>,
+}
+
+pub struct Conflict {
+    pub field: Option<String>,
+    pub mine_member: Option<Uuid>,
+    pub mine: Option<String>,
+    pub theirs_member: Option<Uuid>,
+    pub theirs: Option<String>,
+}
+
+async fn seed_member(pool: &sqlx::PgPool, household: Uuid, subject: &str) -> Member {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO membership (id, household_id, subject, display_name, joined_at) \
+         VALUES ($1, $2, $3, $3, now())",
+    )
+    .bind(id)
+    .bind(household)
+    .bind(subject)
+    .execute(pool)
+    .await
+    .expect("membership");
+    Member::for_test(id, household, subject, false)
+}
+
+// --- intent constructors -------------------------------------------------
+
+pub fn create_entity(id: Uuid, content: v1::EntityContent) -> v1::intent::Action {
+    v1::intent::Action::Create(v1::Create {
+        subject: Some(v1::create::Subject::Entity(v1::CreateEntity {
+            entity_id: id.as_bytes().to_vec(),
+            created_at: None,
+            capture_method: "test".into(),
+            content: Some(content),
+        })),
+    })
+}
+
+pub fn edit_entity(id: EntityId, base: u64, content: v1::EntityContent) -> v1::intent::Action {
+    v1::intent::Action::Edit(v1::Edit {
+        subject: Some(v1::edit::Subject::Entity(v1::EditEntity {
+            entity_id: id.as_uuid().as_bytes().to_vec(),
+            base_counter: base,
+            content: Some(content),
+        })),
+    })
+}
+
+pub fn create_relation(id: Uuid, content: v1::RelationContent) -> v1::intent::Action {
+    v1::intent::Action::Create(v1::Create {
+        subject: Some(v1::create::Subject::Relation(v1::CreateRelation {
+            relation_id: id.as_bytes().to_vec(),
+            content: Some(content),
+        })),
+    })
+}
+
+pub fn edit_relation(id: Uuid, content: v1::RelationContent) -> v1::intent::Action {
+    v1::intent::Action::Edit(v1::Edit {
+        subject: Some(v1::edit::Subject::Relation(v1::EditRelation {
+            relation_id: id.as_bytes().to_vec(),
+            content: Some(content),
+        })),
+    })
+}
+
+pub fn remove(entities: &[EntityId], relations: &[Uuid]) -> v1::intent::Action {
+    v1::intent::Action::Remove(v1::Remove {
+        entity_ids: entities
+            .iter()
+            .map(|e| e.as_uuid().as_bytes().to_vec())
+            .collect(),
+        relation_ids: relations.iter().map(|r| r.as_bytes().to_vec()).collect(),
+    })
+}
+
+pub fn erase(entities: &[EntityId]) -> v1::intent::Action {
+    v1::intent::Action::Erase(v1::Erase {
+        entity_ids: entities
+            .iter()
+            .map(|e| e.as_uuid().as_bytes().to_vec())
+            .collect(),
+    })
+}
+
+pub fn restore(entity: EntityId, include_group: bool) -> v1::intent::Action {
+    v1::intent::Action::Restore(v1::Restore {
+        entity_id: entity.as_uuid().as_bytes().to_vec(),
+        include_group,
+    })
+}
+
+pub fn relation_between(from: EntityId, to: EntityId) -> v1::RelationContent {
+    v1::RelationContent {
+        from_entity_id: Some(from.as_uuid().as_bytes().to_vec()),
+        to_entity_id: Some(to.as_uuid().as_bytes().to_vec()),
+        ..Default::default()
+    }
+}
+
+// --- acknowledgement readers ---------------------------------------------
+
+pub fn applied(ack: &v1::Acknowledgement) -> &v1::Applied {
+    match &ack.outcome {
+        Some(v1::acknowledgement::Outcome::Applied(a)) => a,
+        other => panic!("expected applied, got {other:?}"),
+    }
+}
+
+pub fn refused(ack: &v1::Acknowledgement) -> &v1::Refused {
+    match &ack.outcome {
+        Some(v1::acknowledgement::Outcome::Refused(r)) => r,
+        other => panic!("expected refused, got {other:?}"),
+    }
+}
+
+pub fn recreated(ack: &v1::Acknowledgement) -> &v1::Recreated {
+    match &ack.outcome {
+        Some(v1::acknowledgement::Outcome::Recreated(r)) => r,
+        other => panic!("expected recreated, got {other:?}"),
+    }
+}
+
+pub fn is_not_available(ack: &v1::Acknowledgement) -> bool {
+    match &ack.outcome {
+        Some(v1::acknowledgement::Outcome::Refused(r)) => {
+            r.reason == v1::RefusalReason::NotAvailable as i32
+        }
+        _ => false,
+    }
+}
+
+pub fn relation_id(ack: &v1::Acknowledgement) -> Uuid {
+    let a = applied(ack);
+    let bytes: [u8; 16] = a.relation_ids[0].clone().try_into().expect("16 bytes");
+    Uuid::from_bytes(bytes)
+}
+
+pub fn timestamp(at: DateTime<Utc>) -> prost_types::Timestamp {
+    prost_types::Timestamp {
+        seconds: at.timestamp(),
+        nanos: at.timestamp_subsec_nanos() as i32,
+    }
+}

--- a/crates/altaird/tests/object_store_boundary.rs
+++ b/crates/altaird/tests/object_store_boundary.rs
@@ -197,6 +197,35 @@ fn is_allowed(path: &Path) -> bool {
     ALLOWED.iter().any(|allowed| relative.starts_with(allowed))
 }
 
+/// Whether a line names a token, rather than merely containing its letters.
+///
+/// **Matched at a word boundary on the left.** `WritePath::new` contains
+/// `Path::`, and the write path is a component of the instance with nothing to
+/// say about bytes. A substring scan calls it a violation, and the only ways
+/// out of that would be to rename a thing after the guard that misreads it, or
+/// to add it to the exceptions — which would spend the list's credibility on a
+/// false alarm.
+///
+/// Only the left boundary is checked. The tokens are prefixes on purpose:
+/// `fs::` has to catch `fs::read`, and `File::open` has to catch it wherever it
+/// is called.
+fn names(line: &str, token: &str) -> bool {
+    let identifier = |c: char| c.is_ascii_alphanumeric() || c == '_';
+    if !token.starts_with(identifier) {
+        return line.contains(token);
+    }
+    let mut from = 0;
+    while let Some(at) = line[from..].find(token) {
+        let at = from + at;
+        let preceded = line[..at].chars().next_back().is_some_and(identifier);
+        if !preceded {
+            return true;
+        }
+        from = at + token.len();
+    }
+    false
+}
+
 /// Reach around the interface and this fails, naming the file and the line.
 #[test]
 fn nothing_outside_the_object_store_touches_the_bytes() {
@@ -209,7 +238,7 @@ fn nothing_outside_the_object_store_touches_the_bytes() {
         let source = fs::read_to_string(&path).expect("read a source file");
         for (number, line) in source.lines().enumerate() {
             for token in REACHING_AROUND {
-                if line.contains(token) {
+                if names(line, token) {
                     violations.push(format!(
                         "{}:{}: `{token}` in `{}`",
                         relative(&path),

--- a/crates/altaird/tests/one_predicate.rs
+++ b/crates/altaird/tests/one_predicate.rs
@@ -107,6 +107,32 @@ fn the_predicate_sql_exists_once_in_the_tree() {
     );
 }
 
+/// Whether a source issues SQL at all.
+///
+/// The wire calls its audience field by the same word the column uses, because
+/// they are the same word, so the write path's reader of `EntityContent` names
+/// it while having nothing to do with the store. That is a transcription and
+/// not a predicate, and the thing that tells the two apart is that a predicate
+/// has to reach the database.
+///
+/// **What this catches and what it does not.** A paraphrased predicate has to
+/// run, so it has to be in a file that queries; such a file naming the column
+/// fails. A file that only *defines* a paraphrase as a constant for another
+/// file to run would slip through, and that is a known gap of the same kind as
+/// the ones the module documentation already records.
+fn issues_sql(text: &str) -> bool {
+    let flat = text.to_ascii_lowercase();
+    // Two needles, both unmistakable. Every query in this workspace goes
+    // through sqlx, and a bare SQL constant carries a bound position. Prose
+    // needles were tried and rejected: "where" is an ordinary English word and
+    // these files are written in prose.
+    //
+    // Assembled rather than written, like the other needles here.
+    ["sqlx".to_owned(), ["$", "1"].concat()]
+        .iter()
+        .any(|needle| flat.contains(needle))
+}
+
 #[test]
 fn nothing_else_in_the_tree_names_the_audience_column() {
     // Assembled rather than written, so the scan does not find this file.
@@ -118,7 +144,7 @@ fn nothing_else_in_the_tree_names_the_audience_column() {
         .filter(|p| !p.ends_with(HOME))
         .filter(|p| {
             std::fs::read_to_string(p)
-                .map(|t| t.contains(&column))
+                .map(|t| t.contains(&column) && issues_sql(&t))
                 .unwrap_or(false)
         })
         .map(|p| p.display().to_string())
@@ -126,10 +152,10 @@ fn nothing_else_in_the_tree_names_the_audience_column() {
 
     assert!(
         offenders.is_empty(),
-        "{offenders:?} name the audience column. Reasoning about audience \
-         belongs in {HOME}, and a paraphrase of the predicate is a second \
-         implementation whatever it is spelled like. If a query needs the \
-         column's value, select it through the constant there."
+        "{offenders:?} name the audience column and issue SQL. Reasoning about \
+         audience belongs in {HOME}, and a paraphrase of the predicate is a \
+         second implementation whatever it is spelled like. If a query needs \
+         the column's value, select it through the constant there."
     );
 
     // And the one place still does.
@@ -167,9 +193,22 @@ fn nothing_outside_the_store_layer_queries_the_entity_table() {
             .collect::<Vec<_>>()
             .join(" ");
         // Assembled, not written, like the other needles.
+        //
+        // Matched at a word boundary. `FROM entity_date` and
+        // `FROM entity_part_counter` are queries over other tables that happen
+        // to start with the same word, and a substring scan calls them
+        // offenders — which is a false alarm that would be silenced by moving
+        // real work into the store layer for no reason.
         for shape in [["from", "entity"].join(" "), ["join", "entity"].join(" ")] {
-            if flat.contains(&shape) {
-                offenders.push(format!("{} ({shape})", path.display()));
+            let mut rest = flat.as_str();
+            while let Some(at) = rest.find(&shape) {
+                let after = &rest[at + shape.len()..];
+                let continues = after.starts_with(|c: char| c.is_ascii_alphanumeric() || c == '_');
+                if !continues {
+                    offenders.push(format!("{} ({shape})", path.display()));
+                    break;
+                }
+                rest = after;
             }
         }
     }

--- a/crates/altaird/tests/one_predicate.rs
+++ b/crates/altaird/tests/one_predicate.rs
@@ -30,6 +30,27 @@ use std::path::{Path, PathBuf};
 /// Where the predicate is allowed to live.
 const HOME: &str = "crates/altaird/src/store/audience.rs";
 
+/// Whether a source is test code rather than the instance.
+///
+/// **Two of the three checks below apply to the instance only, and this is the
+/// line.** The claim being protected is that the write path and the read path
+/// call one predicate; a test asserting that they do has to be able to see
+/// past it. A test that could only read the store through the audience-scoped
+/// surface would be checking the predicate against itself, and it would report
+/// success for a predicate that admitted everybody.
+///
+/// So a test may query `entity` directly and may name the column, and the
+/// suite is where the ground truth an assertion compares against comes from.
+///
+/// The first check — the predicate's own SQL, counted across the whole tree —
+/// is deliberately **not** scoped this way, because a literal paste is a
+/// literal paste wherever it lands and a test has no business holding one.
+fn is_test_source(path: &Path) -> bool {
+    let separator = std::path::MAIN_SEPARATOR_STR;
+    path.to_string_lossy()
+        .contains(&["", "tests", ""].join(separator))
+}
+
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
@@ -142,6 +163,7 @@ fn nothing_else_in_the_tree_names_the_audience_column() {
     let offenders: Vec<String> = sources(&root)
         .into_iter()
         .filter(|p| !p.ends_with(HOME))
+        .filter(|p| !is_test_source(p))
         .filter(|p| {
             std::fs::read_to_string(p)
                 .map(|t| t.contains(&column) && issues_sql(&t))
@@ -181,7 +203,7 @@ fn nothing_outside_the_store_layer_queries_the_entity_table() {
     let root = repo_root();
     let mut offenders: Vec<String> = Vec::new();
     for path in sources(&root) {
-        if path.to_string_lossy().contains(&store) {
+        if path.to_string_lossy().contains(&store) || is_test_source(&path) {
             continue;
         }
         let Ok(text) = std::fs::read_to_string(&path) else {

--- a/crates/altaird/tests/submission_call.rs
+++ b/crates/altaird/tests/submission_call.rs
@@ -1,0 +1,385 @@
+//! The submission call, served.
+//!
+//! Two of Wave 2.1's requirements are observable only here and are not testable
+//! from an internal function: **a batch is never all or nothing**, and **a
+//! refusal reveals nothing, which DR-004 extends to the status code**. This is
+//! also token validation's first caller, which was otherwise built and unused.
+
+mod common;
+
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use altair_proto::v1;
+use altaird::auth::{Authenticator, IssuerConfig, JwksSource, JwksUnavailable, KeyCache};
+use altaird::service::Instance;
+use altaird::write::WritePath;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use common::*;
+use jsonwebtoken::jwk::JwkSet;
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use ring::rand::SystemRandom;
+use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair, KeyPair};
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+use tonic::Code;
+use uuid::Uuid;
+
+const ISSUER: &str = "https://auth.example.test/application/o/altair/";
+const AUDIENCE: &str = "altair";
+
+/// A "now" far enough from zero that a token can expire without the arithmetic
+/// going negative.
+const NOW: i64 = 1_780_000_000;
+
+// --- a provider that exists only here ------------------------------------
+
+struct Key {
+    kid: String,
+    encoding: EncodingKey,
+    jwk: Value,
+}
+
+fn key() -> Key {
+    let rng = SystemRandom::new();
+    let pkcs8 =
+        EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng).expect("key pair");
+    let pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8.as_ref(), &rng)
+        .expect("read back");
+    let point = pair.public_key().as_ref();
+    let kid = "test".to_owned();
+    Key {
+        jwk: json!({
+            "kty": "EC", "crv": "P-256", "alg": "ES256", "use": "sig", "kid": kid,
+            "x": URL_SAFE_NO_PAD.encode(&point[1..33]),
+            "y": URL_SAFE_NO_PAD.encode(&point[33..65]),
+        }),
+        kid,
+        encoding: EncodingKey::from_ec_der(pkcs8.as_ref()),
+    }
+}
+
+impl Key {
+    fn mint(&self, subject: &str, exp: i64) -> String {
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(self.kid.clone());
+        let claims = json!({
+            "iss": ISSUER, "aud": AUDIENCE, "sub": subject,
+            "iat": exp - 3600, "exp": exp,
+        });
+        jsonwebtoken::encode(&header, &claims, &self.encoding).expect("mint")
+    }
+}
+
+type Fetching<'a> = Pin<Box<dyn Future<Output = Result<JwkSet, JwksUnavailable>> + Send + 'a>>;
+
+/// Keys served without a network, which is what the source being a trait is
+/// for.
+struct Keys(JwkSet);
+
+impl JwksSource for Keys {
+    fn fetch(&self) -> Fetching<'_> {
+        let set = self.0.clone();
+        Box::pin(async move { Ok(set) })
+    }
+}
+
+// --- an instance on a port -----------------------------------------------
+
+struct Served {
+    world: World,
+    key: Key,
+    addr: SocketAddr,
+}
+
+impl Served {
+    async fn new() -> Self {
+        let world = World::new().await;
+        let key = key();
+        let keys: JwkSet =
+            serde_json::from_value(json!({ "keys": [key.jwk.clone()] })).expect("jwks");
+
+        let auth = Authenticator::new(
+            IssuerConfig {
+                issuer: ISSUER.into(),
+                audience: AUDIENCE.into(),
+            },
+            KeyCache::new(Arc::new(Keys(keys))),
+            world.db.pool.clone(),
+        );
+
+        let instance = Instance::new(Arc::new(auth), WritePath::new(world.db.pool.clone()));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(v1::altair_server::AltairServer::new(instance))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+                .await
+                .ok();
+        });
+
+        Self { world, key, addr }
+    }
+
+    async fn client(&self) -> v1::altair_client::AltairClient<tonic::transport::Channel> {
+        let channel = tonic::transport::Channel::from_shared(format!("http://{}", self.addr))
+            .expect("uri")
+            .connect()
+            .await
+            .expect("connect");
+        v1::altair_client::AltairClient::new(channel)
+    }
+
+    /// A request carrying a credential, or none at all.
+    fn request<T>(&self, message: T, credential: Option<&str>) -> tonic::Request<T> {
+        let mut request = tonic::Request::new(message);
+        if let Some(token) = credential {
+            request.metadata_mut().insert(
+                "authorization",
+                format!("Bearer {token}").parse().expect("header"),
+            );
+        }
+        request
+    }
+
+    fn token_for_one(&self) -> String {
+        // Far in the future, so the real clock accepts it.
+        self.key
+            .mint(self.world.one.subject(), NOW + 10 * 365 * 86_400)
+    }
+}
+
+fn intent(action: v1::intent::Action) -> v1::Intent {
+    v1::Intent {
+        intent_id: Uuid::new_v4().as_bytes().to_vec(),
+        action: Some(action),
+    }
+}
+
+fn note(title: &str) -> v1::EntityContent {
+    v1::EntityContent {
+        title: Some(title.into()),
+        specific: Some(v1::entity_content::Specific::Note(
+            v1::NoteContent::default(),
+        )),
+        ..Default::default()
+    }
+}
+
+fn nowhere() -> altaird::store::ids::EntityId {
+    altaird::store::ids::EntityId::from_uuid(Uuid::new_v4())
+}
+
+// --- the two things only the wire can show -------------------------------
+
+#[tokio::test]
+async fn a_submission_whose_every_intent_is_refused_still_answers_success() {
+    let served = Served::new().await;
+    let mut client = served.client().await;
+
+    let response = client
+        .submit(served.request(
+            v1::SubmitRequest {
+                intents: vec![
+                    intent(edit_entity(nowhere(), 1, note("nowhere"))),
+                    intent(edit_entity(nowhere(), 1, note("nowhere either"))),
+                ],
+            },
+            Some(&served.token_for_one()),
+        ))
+        .await
+        .expect("a submission of refusals is a successful submission");
+
+    let acks = response.into_inner().acknowledgements;
+    assert_eq!(acks.len(), 2);
+    assert!(acks.iter().all(is_not_available));
+    assert!(
+        acks.iter().all(|a| refused(a).detail.is_empty()),
+        "any other status, or any detail, would say at the transport the thing \
+         the single refusal reason exists to avoid saying"
+    );
+}
+
+#[tokio::test]
+async fn a_batch_is_never_all_or_nothing() {
+    let served = Served::new().await;
+    let mut client = served.client().await;
+
+    let first = Uuid::new_v4();
+    let last = Uuid::new_v4();
+
+    let acks = client
+        .submit(served.request(
+            v1::SubmitRequest {
+                intents: vec![
+                    intent(create_entity(first, note("first"))),
+                    intent(edit_entity(nowhere(), 1, note("nowhere"))),
+                    intent(create_entity(last, note("last"))),
+                ],
+            },
+            Some(&served.token_for_one()),
+        ))
+        .await
+        .expect("submitted")
+        .into_inner()
+        .acknowledgements;
+
+    assert_eq!(acks.len(), 3, "one acknowledgement per intent, in order");
+    assert!(matches!(
+        acks[0].outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    assert!(is_not_available(&acks[1]));
+    assert!(
+        matches!(
+            acks[2].outcome,
+            Some(v1::acknowledgement::Outcome::Applied(_))
+        ),
+        "two hundred files where the hundredth fails leaves ninety-nine captured"
+    );
+
+    assert_eq!(
+        served
+            .world
+            .title(altaird::store::ids::EntityId::from_uuid(last))
+            .await
+            .as_deref(),
+        Some("last")
+    );
+}
+
+// --- the credential ------------------------------------------------------
+
+#[tokio::test]
+async fn a_valid_token_writes_as_the_member_it_names() {
+    let served = Served::new().await;
+    let mut client = served.client().await;
+    let id = Uuid::new_v4();
+
+    client
+        .submit(served.request(
+            v1::SubmitRequest {
+                intents: vec![intent(create_entity(id, note("mine")))],
+            },
+            Some(&served.token_for_one()),
+        ))
+        .await
+        .expect("submitted");
+
+    // Member two cannot act on it, so the author was member one.
+    let ack = served
+        .world
+        .submit(
+            &served.world.two,
+            edit_entity(
+                altaird::store::ids::EntityId::from_uuid(id),
+                1,
+                note("theirs"),
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack));
+}
+
+#[tokio::test]
+async fn an_absent_credential_reaches_no_query_surface() {
+    let served = Served::new().await;
+    let mut client = served.client().await;
+
+    let status = client
+        .submit(served.request(
+            v1::SubmitRequest {
+                intents: vec![intent(create_entity(Uuid::new_v4(), note("unbidden")))],
+            },
+            None,
+        ))
+        .await
+        .expect_err("an unauthenticated request is not served");
+
+    assert_eq!(status.code(), Code::Unauthenticated);
+    assert_eq!(
+        served.world.changes().await.len(),
+        0,
+        "unauthenticated reached the write path"
+    );
+}
+
+#[tokio::test]
+async fn an_expired_credential_and_a_forged_one_are_the_same_wait() {
+    let served = Served::new().await;
+    let mut client = served.client().await;
+
+    let expired = served.key.mint(served.world.one.subject(), NOW - 86_400);
+    let forged = key().mint(served.world.one.subject(), NOW + 10 * 365 * 86_400);
+
+    let mut statuses = Vec::new();
+    for credential in [expired, forged] {
+        let status = client
+            .submit(served.request(
+                v1::SubmitRequest {
+                    intents: vec![intent(create_entity(Uuid::new_v4(), note("held")))],
+                },
+                Some(&credential),
+            ))
+            .await
+            .expect_err("neither is served");
+        statuses.push((status.code(), status.message().to_owned()));
+    }
+
+    assert_eq!(
+        statuses[0], statuses[1],
+        "a forged token and an expired one are literally indistinguishable, and \
+         DR-005 defines both as the wait"
+    );
+    assert_eq!(statuses[0].0, Code::Unauthenticated);
+}
+
+// --- the five that are not served ----------------------------------------
+
+#[tokio::test]
+async fn the_five_calls_this_build_does_not_serve_say_so_deliberately() {
+    let served = Served::new().await;
+    let mut client = served.client().await;
+    let token = served.token_for_one();
+
+    let codes = vec![
+        client
+            .query(served.request(v1::QueryRequest::default(), Some(&token)))
+            .await
+            .expect_err("query")
+            .code(),
+        client
+            .changes(served.request(v1::ChangesRequest::default(), Some(&token)))
+            .await
+            .expect_err("changes")
+            .code(),
+        client
+            .get_health(served.request(v1::HealthRequest::default(), Some(&token)))
+            .await
+            .expect_err("health")
+            .code(),
+        client
+            .put_body(served.request(
+                tokio_stream::iter(Vec::<v1::BodyChunk>::new()),
+                Some(&token),
+            ))
+            .await
+            .expect_err("put body")
+            .code(),
+        client
+            .get_body(served.request(v1::BodyRequest::default(), Some(&token)))
+            .await
+            .expect_err("get body")
+            .code(),
+    ];
+
+    assert!(
+        codes.iter().all(|c| *c == Code::Unimplemented),
+        "the five are absent on purpose, and waiting will not clear it: {codes:?}"
+    );
+}

--- a/crates/altaird/tests/write_lifecycle.rs
+++ b/crates/altaird/tests/write_lifecycle.rs
@@ -1,0 +1,497 @@
+//! Removal, grouped removal, restoration, erasure, and recreation.
+//!
+//! **The intent is to retain.** Anything that becomes permanent does so
+//! visibly, predictably, and never as a side effect of something else, and
+//! these are the assertions that make that a property of the instance rather
+//! than of a document.
+
+mod common;
+
+use altair_proto::v1;
+use altaird::store::ids::EntityId;
+use common::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+fn note_content(title: &str) -> v1::EntityContent {
+    v1::EntityContent {
+        title: Some(title.into()),
+        specific: Some(v1::entity_content::Specific::Note(
+            v1::NoteContent::default(),
+        )),
+        ..Default::default()
+    }
+}
+
+// --- removal and restoration --------------------------------------------
+
+#[tokio::test]
+async fn removal_is_a_change_carrying_a_lifecycle_and_not_an_absence() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "regrettable").await;
+    w.submit(&w.one, remove(&[id], &[])).await;
+
+    assert_eq!(w.lifecycle(id).await, "deleted");
+    let changes = w.changes().await;
+    assert_eq!(
+        changes.last().expect("a change").kind,
+        "entity_written",
+        "a removal is a change carrying a lifecycle state, not a disappearance"
+    );
+}
+
+#[tokio::test]
+async fn a_deletion_of_several_is_remembered_as_one_act() {
+    let w = World::new().await;
+    let a = w.note(&w.one, "a").await;
+    let b = w.note(&w.one, "b").await;
+    let c = w.note(&w.one, "c").await;
+
+    w.submit(&w.one, remove(&[a, b], &[])).await;
+    w.submit(&w.one, remove(&[c], &[])).await;
+
+    // Restoring any of them can bring back the rest of that act, and only that
+    // act: c was removed separately and is not dragged back.
+    let ack = w.submit(&w.one, restore(a, true)).await;
+    assert_eq!(applied(&ack).entity_ids.len(), 2);
+    assert_eq!(w.lifecycle(a).await, "active");
+    assert_eq!(w.lifecycle(b).await, "active");
+    assert_eq!(
+        w.lifecycle(c).await,
+        "deleted",
+        "restoring a container must not drag back entities deleted separately"
+    );
+}
+
+#[tokio::test]
+async fn restoring_one_on_its_own_leaves_the_rest_of_the_act_alone() {
+    let w = World::new().await;
+    let a = w.note(&w.one, "a").await;
+    let b = w.note(&w.one, "b").await;
+    w.submit(&w.one, remove(&[a, b], &[])).await;
+
+    w.submit(&w.one, restore(a, false)).await;
+    assert_eq!(w.lifecycle(a).await, "active");
+    assert_eq!(w.lifecycle(b).await, "deleted");
+}
+
+#[tokio::test]
+async fn a_removal_that_cannot_land_has_already_happened() {
+    let w = World::new().await;
+    let theirs = w.note(&w.two, "not mine").await;
+    let missing = EntityId::from_uuid(Uuid::new_v4());
+    let mine = w.note(&w.one, "mine").await;
+    w.submit(&w.one, remove(&[mine], &[])).await;
+
+    // An identifier that is invisible, one that does not exist, and one already
+    // removed all converge on the end state the person asked for.
+    let ack = w
+        .submit(&w.one, remove(&[theirs, missing, mine], &[]))
+        .await;
+    assert!(
+        matches!(ack.outcome, Some(v1::acknowledgement::Outcome::Applied(_))),
+        "reporting this as a failure would say only that the thing they wanted \
+         is the thing that occurred"
+    );
+    assert!(applied(&ack).entity_ids.is_empty());
+    assert_eq!(w.lifecycle(theirs).await, "active");
+}
+
+#[tokio::test]
+async fn restoring_places_the_entity_at_the_end_of_its_container_again() {
+    let w = World::new().await;
+    let category = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let in_category = |title: &str| v1::EntityContent {
+        title: Some(title.into()),
+        category_id: Some(category.as_uuid().as_bytes().to_vec()),
+        ..Default::default()
+    };
+
+    let first = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            in_category("first"),
+        )
+        .await;
+    w.create(
+        &w.one,
+        v1::entity_content::Specific::Note(v1::NoteContent::default()),
+        in_category("second"),
+    )
+    .await;
+
+    assert_eq!(w.category_position(first).await, Some(0));
+    w.submit(&w.one, remove(&[first], &[])).await;
+    w.submit(&w.one, restore(first, false)).await;
+    assert_eq!(
+        w.category_position(first).await,
+        Some(2),
+        "entering a container places the entity at the end, and that holds for \
+         a restoration exactly as it does for a create or a move"
+    );
+}
+
+#[tokio::test]
+async fn restoring_something_active_is_the_state_that_is_already_true() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "here").await;
+    let ack = w.submit(&w.one, restore(id, false)).await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    assert_eq!(w.counter(id).await, 1, "nothing was written");
+}
+
+#[tokio::test]
+async fn restoring_something_this_member_cannot_see_is_nothing() {
+    let w = World::new().await;
+    let theirs = w.note(&w.two, "private").await;
+    w.submit(&w.two, remove(&[theirs], &[])).await;
+    let ack = w.submit(&w.one, restore(theirs, true)).await;
+    assert!(is_not_available(&ack));
+}
+
+// --- erasure -------------------------------------------------------------
+
+#[tokio::test]
+async fn erasure_strips_content_and_leaves_a_tombstone() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "sensitive").await;
+    w.submit(&w.one, erase(&[id])).await;
+
+    assert_eq!(w.lifecycle(id).await, "erased");
+    assert_eq!(w.title(id).await, None, "the title is content");
+
+    let row =
+        sqlx::query("SELECT search_text, capture_method, deleted_at FROM entity WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_one(&w.db.pool)
+            .await
+            .expect("the row survives as a tombstone");
+    assert_eq!(row.try_get::<String, _>("search_text").unwrap(), "");
+    assert_eq!(row.try_get::<String, _>("capture_method").unwrap(), "");
+    assert!(
+        row.try_get::<Option<chrono::DateTime<chrono::Utc>>, _>("deleted_at")
+            .unwrap()
+            .is_none()
+    );
+
+    let changes = w.changes().await;
+    assert_eq!(changes.last().expect("a change").kind, "entity_gone");
+}
+
+#[tokio::test]
+async fn erasure_removes_every_dependent_row_explicitly() {
+    let w = World::new().await;
+    let id = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            v1::EntityContent {
+                title: Some("everything".into()),
+                dates: vec![v1::LabelledDate {
+                    label: "due".into(),
+                    when: Some(timestamp(chrono::Utc::now())),
+                    bring_forward: true,
+                }],
+                assigned_member_ids: vec![w.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+    // The rows Wave 2.1 does not yet write, put there directly, because the
+    // schema's cascades hang off a delete of the entity row and erasure never
+    // performs one.
+    let block = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO block (id, entity_id, body_type, position, text) \
+         VALUES ($1, $2, 'note', 0, 'a paragraph')",
+    )
+    .bind(block)
+    .bind(id.as_uuid())
+    .execute(&w.db.pool)
+    .await
+    .expect("block");
+
+    sqlx::query("INSERT INTO entity_property_value (entity_id, name, value) VALUES ($1, 'k', 'v')")
+        .bind(id.as_uuid())
+        .execute(&w.db.pool)
+        .await
+        .expect("property");
+
+    sqlx::query(
+        "INSERT INTO entity_version (id, entity_id, captured_at, body) \
+         VALUES ($1, $2, now(), 'old')",
+    )
+    .bind(Uuid::new_v4())
+    .bind(id.as_uuid())
+    .execute(&w.db.pool)
+    .await
+    .expect("version");
+
+    sqlx::query(
+        "INSERT INTO derived_text (entity_id, content, producer, produced_at) \
+         VALUES ($1, 'extracted', 'test', now())",
+    )
+    .bind(id.as_uuid())
+    .execute(&w.db.pool)
+    .await
+    .expect("derived text");
+
+    let vector = format!("[{}]", vec!["0"; 1024].join(","));
+    sqlx::query(
+        "INSERT INTO embedding (id, entity_id, model, produced_at, vector) \
+         VALUES ($1, $2, 'test', now(), $3::vector)",
+    )
+    .bind(Uuid::new_v4())
+    .bind(id.as_uuid())
+    .bind(&vector)
+    .execute(&w.db.pool)
+    .await
+    .expect("embedding");
+
+    sqlx::query(
+        "INSERT INTO derivation_queue (entity_id, kind, enqueued_at) \
+         VALUES ($1, 'embedding', now())",
+    )
+    .bind(id.as_uuid())
+    .execute(&w.db.pool)
+    .await
+    .expect("queue");
+
+    sqlx::query(
+        "INSERT INTO conflict (id, entity_id, field_name, mine_value, theirs_value, detected_at) \
+         VALUES ($1, $2, 'title', 'a', 'b', now())",
+    )
+    .bind(Uuid::new_v4())
+    .bind(id.as_uuid())
+    .execute(&w.db.pool)
+    .await
+    .expect("conflict");
+
+    w.submit(&w.one, erase(&[id])).await;
+
+    for (table, column) in [
+        ("block", "entity_id"),
+        ("entity_date", "entity_id"),
+        ("entity_assignment", "entity_id"),
+        ("entity_property_value", "entity_id"),
+        ("entity_version", "entity_id"),
+        ("derived_text", "entity_id"),
+        ("embedding", "entity_id"),
+        ("derivation_queue", "entity_id"),
+        ("conflict", "entity_id"),
+        ("entity_part_counter", "entity_id"),
+    ] {
+        assert_eq!(
+            w.rows_for(table, column, id).await,
+            0,
+            "{table} still holds a row for an erased entity, and its cascade \
+             never fires because erasure does not delete the entity row"
+        );
+    }
+}
+
+#[tokio::test]
+async fn erasing_an_item_removes_its_event_records() {
+    let w = World::new().await;
+    let id = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Item(v1::ItemContent::default()),
+            v1::EntityContent {
+                title: Some("flour".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    sqlx::query(
+        "INSERT INTO event_record (id, item_id, kind, amount, occurred_at, recorded_at) \
+         VALUES ($1, $2, 'purchase', 1, now(), now())",
+    )
+    .bind(Uuid::new_v4())
+    .bind(id.as_uuid())
+    .execute(&w.db.pool)
+    .await
+    .expect("event record");
+
+    w.submit(&w.one, erase(&[id])).await;
+    assert_eq!(w.rows_for("event_record", "item_id", id).await, 0);
+    assert_eq!(
+        w.rows_for("item", "entity_id", id).await,
+        0,
+        "the side table is content too"
+    );
+}
+
+#[tokio::test]
+async fn an_erased_category_holds_nothing() {
+    let w = World::new().await;
+    let category = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let inside = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            v1::EntityContent {
+                title: Some("filed".into()),
+                category_id: Some(category.as_uuid().as_bytes().to_vec()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    w.submit(&w.one, erase(&[category])).await;
+    assert_eq!(
+        w.category_position(inside).await,
+        None,
+        "an entity whose category is gone becomes uncategorised, which is a \
+         valid state requiring no repair"
+    );
+    assert_eq!(
+        w.counter(inside).await,
+        2,
+        "leaving the container is an accepted write, so a client has to learn it"
+    );
+}
+
+#[tokio::test]
+async fn erasure_converges_like_a_removal() {
+    let w = World::new().await;
+    let theirs = w.note(&w.two, "not mine").await;
+    let ack = w.submit(&w.one, erase(&[theirs])).await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    assert!(applied(&ack).entity_ids.is_empty());
+    assert_eq!(w.lifecycle(theirs).await, "active");
+}
+
+// --- recreation ----------------------------------------------------------
+
+#[tokio::test]
+async fn an_edit_arriving_for_an_erased_entity_is_a_recreation() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "original").await;
+    w.submit(&w.one, erase(&[id])).await;
+
+    let ack = w
+        .submit(&w.one, edit_entity(id, 1, note_content("offline work")))
+        .await;
+    let r = recreated(&ack);
+    assert_eq!(r.original_entity_id, id.as_uuid().as_bytes().to_vec());
+    assert_ne!(r.new_entity_id, r.original_entity_id, "the identity is new");
+    assert_eq!(r.counter, 1);
+
+    let new = EntityId::from_uuid(Uuid::from_bytes(
+        r.new_entity_id.clone().try_into().expect("16 bytes"),
+    ));
+    assert_eq!(w.title(new).await.as_deref(), Some("offline work"));
+    assert_eq!(
+        w.lifecycle(id).await,
+        "erased",
+        "the erasure stands, and so does the person's work"
+    );
+}
+
+#[tokio::test]
+async fn a_recreation_is_private_to_the_author_whatever_the_audience_was() {
+    let w = World::new().await;
+    let id = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            v1::EntityContent {
+                title: Some("was shared".into()),
+                audience_member_ids: vec![w.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+    w.submit(&w.one, erase(&[id])).await;
+
+    // The offline device still believes the entity was shared and says so.
+    let ack = w
+        .submit(
+            &w.one,
+            edit_entity(
+                id,
+                1,
+                v1::EntityContent {
+                    title: Some("still working on it".into()),
+                    audience_member_ids: vec![w.two.membership_id().as_bytes().to_vec()],
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let new = EntityId::from_uuid(Uuid::from_bytes(
+        recreated(&ack)
+            .new_entity_id
+            .clone()
+            .try_into()
+            .expect("16 bytes"),
+    ));
+
+    let seen_by_two = w
+        .submit(&w.two, edit_entity(new, 1, note_content("mine now")))
+        .await;
+    assert!(
+        is_not_available(&seen_by_two),
+        "a device that was offline recreating it with a household audience \
+         would re-expose the thing erasure exists to remove"
+    );
+}
+
+#[tokio::test]
+async fn a_create_naming_an_erased_identity_is_nothing() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "gone").await;
+    w.submit(&w.one, erase(&[id])).await;
+
+    let ack = w
+        .submit(&w.one, create_entity(id.as_uuid(), note_content("reused")))
+        .await;
+    assert!(
+        is_not_available(&ack),
+        "a tombstone is not a free identity: anything that once pointed at it \
+         would silently reattach"
+    );
+}
+
+#[tokio::test]
+async fn the_same_entity_submitted_twice_produces_one_entity() {
+    let w = World::new().await;
+    let id = Uuid::new_v4();
+    w.submit(&w.one, create_entity(id, note_content("once")))
+        .await;
+    let again = w
+        .submit(&w.one, create_entity(id, note_content("twice")))
+        .await;
+
+    assert!(matches!(
+        again.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    assert_eq!(
+        w.title(EntityId::from_uuid(id)).await.as_deref(),
+        Some("once"),
+        "the second create is the same entity, not a second one and not an edit"
+    );
+    assert_eq!(w.changes().await.len(), 1);
+}

--- a/crates/altaird/tests/write_parts.rs
+++ b/crates/altaird/tests/write_parts.rs
@@ -1,0 +1,86 @@
+//! The part vocabulary round-trips.
+//!
+//! Migration one recorded the drift risk as gap (d): a conflicted part is named
+//! by text in the store and by a field number on the wire, something has to
+//! hold that mapping, and wherever it lives it can drift. This is what stops it
+//! drifting silently.
+
+use altaird::write::parts::{ALL_CONTENT_PARTS, ContentPart, Part, PartKey};
+use uuid::Uuid;
+
+#[test]
+fn every_content_part_round_trips_through_its_field_number() {
+    for part in ALL_CONTENT_PARTS {
+        assert_eq!(
+            ContentPart::from_field_number(part.field_number()),
+            Some(*part),
+            "{part:?} does not come back from its own field number"
+        );
+    }
+}
+
+#[test]
+fn every_content_part_round_trips_through_its_stored_name() {
+    for part in ALL_CONTENT_PARTS {
+        assert_eq!(
+            ContentPart::from_store_name(part.store_name()),
+            Some(*part),
+            "{part:?} does not come back from its own stored name"
+        );
+    }
+}
+
+#[test]
+fn no_two_parts_share_a_number_or_a_name() {
+    let mut numbers: Vec<u32> = ALL_CONTENT_PARTS.iter().map(|p| p.field_number()).collect();
+    numbers.sort_unstable();
+    let before = numbers.len();
+    numbers.dedup();
+    assert_eq!(before, numbers.len(), "two parts share a field number");
+
+    let mut names: Vec<&str> = ALL_CONTENT_PARTS.iter().map(|p| p.store_name()).collect();
+    names.sort_unstable();
+    let before = names.len();
+    names.dedup();
+    assert_eq!(before, names.len(), "two parts share a stored name");
+}
+
+#[test]
+fn a_number_naming_no_part_is_none() {
+    // 6 is reserved: it was the entity-level arrangement key, and an order now
+    // belongs to a container. 100 is `cleared` itself. 999 was never anything.
+    for number in [0, 6, 100, 999] {
+        assert_eq!(
+            ContentPart::from_field_number(number),
+            None,
+            "field {number} is not a part and must not resolve to one"
+        );
+    }
+}
+
+#[test]
+fn a_type_specific_part_cannot_be_read_as_a_content_part() {
+    let specific = Part::Specific(1);
+    let PartKey::Field(name) = specific.key() else {
+        panic!("a type-specific part is keyed by name");
+    };
+    assert_eq!(ContentPart::from_store_name(&name), None);
+    assert_eq!(Part::from_key(&PartKey::Field(name)), Some(specific));
+}
+
+#[test]
+fn a_block_part_round_trips() {
+    let id = Uuid::new_v4();
+    let part = Part::Block(id);
+    assert_eq!(Part::from_key(&part.key()), Some(part));
+}
+
+#[test]
+fn a_name_this_build_does_not_know_is_not_guessed_at() {
+    assert_eq!(
+        Part::from_key(&PartKey::Field("something_a_later_build_wrote".into())),
+        None,
+        "an unknown part name must stay unknown; inventing one lets two \
+         different parts collide"
+    );
+}

--- a/crates/altaird/tests/write_relations.rs
+++ b/crates/altaird/tests/write_relations.rs
@@ -559,3 +559,136 @@ async fn removing_a_relation_this_member_cannot_see_converges() {
     assert!(applied(&ack).relation_ids.is_empty());
     assert_eq!(w.relation_lifecycle(id).await.as_deref(), Some("active"));
 }
+
+// --- what a cross-model review found -------------------------------------
+
+#[tokio::test]
+async fn an_edit_cannot_make_a_relation_into_a_duplicate() {
+    // Two relations between one pair are legitimate while one of them carries a
+    // type. Clearing that type leaves two untyped unanchored records of one
+    // connection, which the create path refuses and the edit path used not to.
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let kind = w.declare_type("elaborates", true, false).await;
+
+    w.submit(
+        &w.one,
+        create_relation(Uuid::new_v4(), relation_between(a, b)),
+    )
+    .await;
+    let typed = relation_id(
+        &w.submit(
+            &w.one,
+            create_relation(
+                Uuid::new_v4(),
+                v1::RelationContent {
+                    relation_type_id: Some(kind.as_bytes().to_vec()),
+                    ..relation_between(a, b)
+                },
+            ),
+        )
+        .await,
+    );
+
+    let ack = w
+        .submit(&w.one, edit_relation(typed, relation_between(a, b)))
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+}
+
+#[tokio::test]
+async fn an_edit_that_changes_nothing_does_not_refuse_itself() {
+    // The duplicate check has to exclude the relation being edited, or every
+    // no-op edit of an untyped relation collides with itself.
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let id = relation_id(
+        &w.submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(a, b)),
+        )
+        .await,
+    );
+    let ack = w
+        .submit(&w.one, edit_relation(id, relation_between(a, b)))
+        .await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+}
+
+#[tokio::test]
+async fn a_decimal_that_cannot_be_read_is_refused_rather_than_reinterpreted() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let quantified = w.declare_type("commits", true, true).await;
+
+    // A fraction of a whole unit or more. Rendered into a fixed nine-place
+    // field this became 1.15, which is a different number stated confidently.
+    // And opposite signs, which the wire forbids and which read as either 0.75
+    // or -1.25 depending on which half you believe.
+    for bad in [
+        v1::Decimal {
+            units: 1,
+            nanos: 1_500_000_000,
+        },
+        v1::Decimal {
+            units: 1,
+            nanos: -250_000_000,
+        },
+        v1::Decimal {
+            units: -1,
+            nanos: 250_000_000,
+        },
+    ] {
+        let ack = w
+            .submit(
+                &w.one,
+                create_relation(
+                    Uuid::new_v4(),
+                    v1::RelationContent {
+                        relation_type_id: Some(quantified.as_bytes().to_vec()),
+                        uses: Some(v1::UsesProperties {
+                            quantity: Some(bad),
+                            resolution: v1::UsesResolution::Unresolved as i32,
+                        }),
+                        ..relation_between(a, b)
+                    },
+                ),
+            )
+            .await;
+        assert_eq!(
+            refused(&ack).reason,
+            v1::RefusalReason::Malformed as i32,
+            "{bad:?} was accepted and rendered as something else"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_relation_create_naming_an_invisible_identity_is_refused_and_never_faults() {
+    let w = World::new().await;
+    let (theirs_a, theirs_b) = (w.note(&w.two, "a").await, w.note(&w.two, "b").await);
+    let taken = relation_id(
+        &w.submit(
+            &w.two,
+            create_relation(Uuid::new_v4(), relation_between(theirs_a, theirs_b)),
+        )
+        .await,
+    );
+
+    let (mine_a, mine_b) = two_notes(&w).await;
+    let acks = w
+        .write
+        .submit(
+            &w.one,
+            &[v1::Intent {
+                intent_id: Uuid::new_v4().as_bytes().to_vec(),
+                action: Some(create_relation(taken, relation_between(mine_a, mine_b))),
+            }],
+        )
+        .await
+        .expect("an identifier somebody else holds is an answer, not a fault");
+    assert!(is_not_available(&acks[0]));
+}

--- a/crates/altaird/tests/write_relations.rs
+++ b/crates/altaird/tests/write_relations.rs
@@ -1,0 +1,561 @@
+//! Relations: create, edit, remove, restore, and removal by erasure of an end.
+//!
+//! The load-bearing assertion in this file is
+//! [`behaviour_follows_the_declaration_and_not_a_branch`]. Every relation type
+//! declared here is one the shipped set has never contained, so a hardcoded
+//! branch on *blocks*, *uses*, or *references* would fail every one of them.
+
+mod common;
+
+use altair_proto::v1;
+use altaird::store::ids::EntityId;
+use common::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+struct Ends {
+    from: Uuid,
+    to: Uuid,
+    quantity: Option<String>,
+    resolution: Option<String>,
+}
+
+async fn ends(w: &World, id: Uuid) -> Ends {
+    let r = sqlx::query(
+        "SELECT from_entity_id, to_entity_id, quantity::text AS q, \
+         resolution::text AS r FROM relation WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_one(&w.db.pool)
+    .await
+    .expect("relation");
+    Ends {
+        from: r.try_get("from_entity_id").unwrap(),
+        to: r.try_get("to_entity_id").unwrap(),
+        quantity: r.try_get("q").unwrap(),
+        resolution: r.try_get("r").unwrap(),
+    }
+}
+
+async fn two_notes(w: &World) -> (EntityId, EntityId) {
+    (w.note(&w.one, "a").await, w.note(&w.one, "b").await)
+}
+
+// --- creating ------------------------------------------------------------
+
+#[tokio::test]
+async fn a_relation_joins_two_entities_and_is_one_record() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(a, b)),
+        )
+        .await;
+
+    let id = relation_id(&ack);
+    assert_eq!(w.relation_lifecycle(id).await.as_deref(), Some("active"));
+    assert_eq!(
+        w.changes().await.last().expect("a change").kind,
+        "relation_written"
+    );
+}
+
+#[tokio::test]
+async fn an_untyped_relation_is_put_in_canonical_order() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let (low, high) = if a.as_uuid() < b.as_uuid() {
+        (a, b)
+    } else {
+        (b, a)
+    };
+
+    // Submitted the wrong way round.
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(high, low)),
+        )
+        .await;
+    let e = ends(&w, relation_id(&ack)).await;
+    assert_eq!(
+        (e.from, e.to),
+        (low.as_uuid(), high.as_uuid()),
+        "neither end of an untyped relation is privileged, so the same \
+         connection cannot be recorded twice"
+    );
+}
+
+#[tokio::test]
+async fn a_symmetric_type_is_put_in_canonical_order_and_an_asymmetric_one_is_not() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let (low, high) = if a.as_uuid() < b.as_uuid() {
+        (a, b)
+    } else {
+        (b, a)
+    };
+
+    let symmetric = w.declare_type("sits beside", false, false).await;
+    let asymmetric = w.declare_type("outranks", true, false).await;
+
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(
+                Uuid::new_v4(),
+                v1::RelationContent {
+                    relation_type_id: Some(symmetric.as_bytes().to_vec()),
+                    ..relation_between(high, low)
+                },
+            ),
+        )
+        .await;
+    let e = ends(&w, relation_id(&ack)).await;
+    assert_eq!((e.from, e.to), (low.as_uuid(), high.as_uuid()));
+
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(
+                Uuid::new_v4(),
+                v1::RelationContent {
+                    relation_type_id: Some(asymmetric.as_bytes().to_vec()),
+                    ..relation_between(high, low)
+                },
+            ),
+        )
+        .await;
+    let e = ends(&w, relation_id(&ack)).await;
+    assert_eq!(
+        (e.from, e.to),
+        (high.as_uuid(), low.as_uuid()),
+        "direction is a property of an asymmetric relation and must survive"
+    );
+}
+
+#[tokio::test]
+async fn behaviour_follows_the_declaration_and_not_a_branch() {
+    // A type the shipped set has never contained. If anything anywhere matched
+    // on a type's label, this would get neither behaviour.
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let invented = w.declare_type("borrows from", true, true).await;
+
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(
+                Uuid::new_v4(),
+                v1::RelationContent {
+                    relation_type_id: Some(invented.as_bytes().to_vec()),
+                    uses: Some(v1::UsesProperties {
+                        quantity: Some(v1::Decimal {
+                            units: 2,
+                            nanos: 500_000_000,
+                        }),
+                        resolution: v1::UsesResolution::Consumed as i32,
+                    }),
+                    ..relation_between(b, a)
+                },
+            ),
+        )
+        .await;
+
+    let e = ends(&w, relation_id(&ack)).await;
+    assert_eq!(
+        (e.from, e.to),
+        (b.as_uuid(), a.as_uuid()),
+        "an invented asymmetric type gets the asymmetric reading"
+    );
+    assert_eq!(
+        e.quantity.as_deref(),
+        Some("2.500000000"),
+        "an invented quantified type gets to carry a quantity"
+    );
+    assert_eq!(e.resolution.as_deref(), Some("consumed"));
+}
+
+#[tokio::test]
+async fn a_negative_quantity_keeps_its_sign() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let quantified = w.declare_type("owes", true, true).await;
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(
+                Uuid::new_v4(),
+                v1::RelationContent {
+                    relation_type_id: Some(quantified.as_bytes().to_vec()),
+                    uses: Some(v1::UsesProperties {
+                        quantity: Some(v1::Decimal {
+                            units: -3,
+                            nanos: -250_000_000,
+                        }),
+                        resolution: v1::UsesResolution::Unresolved as i32,
+                    }),
+                    ..relation_between(a, b)
+                },
+            ),
+        )
+        .await;
+    assert_eq!(
+        ends(&w, relation_id(&ack)).await.quantity.as_deref(),
+        Some("-3.250000000"),
+        "negative availability is meaningful information about a cupboard"
+    );
+}
+
+#[tokio::test]
+async fn a_property_is_permitted_only_where_the_type_declares_it() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let plain = w.declare_type("mentions", true, false).await;
+
+    let uses = Some(v1::UsesProperties {
+        quantity: Some(v1::Decimal { units: 1, nanos: 0 }),
+        resolution: v1::UsesResolution::Unresolved as i32,
+    });
+
+    // On a type that declares none.
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(
+                Uuid::new_v4(),
+                v1::RelationContent {
+                    relation_type_id: Some(plain.as_bytes().to_vec()),
+                    uses,
+                    ..relation_between(a, b)
+                },
+            ),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+
+    // And on no type at all. An untyped relation carries nothing.
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(
+                Uuid::new_v4(),
+                v1::RelationContent {
+                    uses,
+                    ..relation_between(a, b)
+                },
+            ),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+}
+
+#[tokio::test]
+async fn a_duplicate_untyped_unanchored_relation_is_refused_either_way_round() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    w.submit(
+        &w.one,
+        create_relation(Uuid::new_v4(), relation_between(a, b)),
+    )
+    .await;
+
+    let same = w
+        .submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(a, b)),
+        )
+        .await;
+    assert_eq!(refused(&same).reason, v1::RefusalReason::Malformed as i32);
+
+    let reversed = w
+        .submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(b, a)),
+        )
+        .await;
+    assert_eq!(
+        refused(&reversed).reason,
+        v1::RefusalReason::Malformed as i32,
+        "an untyped unanchored relation is the same connection however it is \
+         submitted"
+    );
+}
+
+#[tokio::test]
+async fn a_typed_relation_is_not_a_duplicate_of_an_untyped_one() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let kind = w.declare_type("annotates", true, false).await;
+
+    w.submit(
+        &w.one,
+        create_relation(Uuid::new_v4(), relation_between(a, b)),
+    )
+    .await;
+    let typed = w
+        .submit(
+            &w.one,
+            create_relation(
+                Uuid::new_v4(),
+                v1::RelationContent {
+                    relation_type_id: Some(kind.as_bytes().to_vec()),
+                    ..relation_between(a, b)
+                },
+            ),
+        )
+        .await;
+    assert!(matches!(
+        typed.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+}
+
+#[tokio::test]
+async fn a_relation_needs_both_ends_visible() {
+    let w = World::new().await;
+    let mine = w.note(&w.one, "mine").await;
+    let theirs = w.note(&w.two, "theirs").await;
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(mine, theirs)),
+        )
+        .await;
+    assert!(
+        is_not_available(&ack),
+        "a relation whose far end a member cannot see would show them that \
+         something is there"
+    );
+}
+
+#[tokio::test]
+async fn a_relation_does_not_join_an_entity_to_itself() {
+    let w = World::new().await;
+    let a = w.note(&w.one, "a").await;
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(a, a)),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+}
+
+#[tokio::test]
+async fn an_unknown_relation_type_is_nothing() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(
+                Uuid::new_v4(),
+                v1::RelationContent {
+                    relation_type_id: Some(Uuid::new_v4().as_bytes().to_vec()),
+                    ..relation_between(a, b)
+                },
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack));
+}
+
+#[tokio::test]
+async fn an_anchor_is_refused_for_a_reason_that_expires() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(
+                Uuid::new_v4(),
+                v1::RelationContent {
+                    anchor: Some(v1::Anchor {
+                        entity_id: a.as_uuid().as_bytes().to_vec(),
+                        block_id: Uuid::new_v4().as_bytes().to_vec(),
+                        phrase: String::new(),
+                    }),
+                    ..relation_between(a, b)
+                },
+            ),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+    assert!(
+        !refused(&ack).detail.is_empty(),
+        "silently discarding where somebody formed a connection is loss an \
+         acknowledgement should never hide"
+    );
+}
+
+// --- editing -------------------------------------------------------------
+
+#[tokio::test]
+async fn a_relation_edit_is_unconditional() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let kind = w.declare_type("supersedes", true, false).await;
+    let created = w
+        .submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(a, b)),
+        )
+        .await;
+    let id = relation_id(&created);
+
+    // No counter, so no base to be stale against: relations carry no write
+    // counter anywhere in the documents, which the proto records as gap (a).
+    let ack = w
+        .submit(
+            &w.one,
+            edit_relation(
+                id,
+                v1::RelationContent {
+                    relation_type_id: Some(kind.as_bytes().to_vec()),
+                    ..relation_between(a, b)
+                },
+            ),
+        )
+        .await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+}
+
+// --- removal, restoration, erasure --------------------------------------
+
+#[tokio::test]
+async fn removing_a_relation_is_reversible_and_it_comes_back_with_the_act() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let id = relation_id(
+        &w.submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(a, b)),
+        )
+        .await,
+    );
+
+    // One act removes the entity and the connection together.
+    w.submit(&w.one, remove(&[a], &[id])).await;
+    assert_eq!(w.relation_lifecycle(id).await.as_deref(), Some("deleted"));
+    assert_eq!(
+        w.changes().await.last().expect("a change").kind,
+        "relation_gone",
+        "the wire's Relation carries no lifecycle, so a removed one is gone"
+    );
+
+    let ack = w.submit(&w.one, restore(a, true)).await;
+    assert_eq!(applied(&ack).relation_ids.len(), 1);
+    assert_eq!(w.relation_lifecycle(id).await.as_deref(), Some("active"));
+    assert_eq!(
+        w.changes().await.last().expect("a change").kind,
+        "relation_written"
+    );
+}
+
+#[tokio::test]
+async fn a_relation_does_not_come_back_on_its_own() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let id = relation_id(
+        &w.submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(a, b)),
+        )
+        .await,
+    );
+    w.submit(&w.one, remove(&[a], &[id])).await;
+
+    // Restoring the entity without its act leaves the connection removed.
+    w.submit(&w.one, restore(a, false)).await;
+    assert_eq!(
+        w.relation_lifecycle(id).await.as_deref(),
+        Some("deleted"),
+        "there is no restoring a connection on its own, and nothing lists \
+         removed connections for a person to notice one missing from"
+    );
+}
+
+#[tokio::test]
+async fn a_removed_connection_can_be_formed_again() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let id = relation_id(
+        &w.submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(a, b)),
+        )
+        .await,
+    );
+    w.submit(&w.one, remove(&[], &[id])).await;
+
+    let again = w
+        .submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(a, b)),
+        )
+        .await;
+    assert!(
+        matches!(
+            again.outcome,
+            Some(v1::acknowledgement::Outcome::Applied(_))
+        ),
+        "one sitting in holding is not a connection that exists, and forming \
+         it again is the person's answer to having removed it"
+    );
+}
+
+#[tokio::test]
+async fn erasing_either_endpoint_removes_the_relation_outright() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let id = relation_id(
+        &w.submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(a, b)),
+        )
+        .await,
+    );
+
+    let ack = w.submit(&w.one, erase(&[b])).await;
+    assert_eq!(applied(&ack).relation_ids.len(), 1);
+    assert_eq!(
+        w.relation_lifecycle(id).await,
+        None,
+        "erasing either endpoint removes the relation outright, which is what \
+         erasure means everywhere"
+    );
+    let changes = w.changes().await;
+    assert!(
+        changes
+            .iter()
+            .any(|c| c.kind == "relation_gone" && c.relation == Some(id)),
+        "the sequence has to be able to speak about something that no longer exists"
+    );
+}
+
+#[tokio::test]
+async fn removing_a_relation_this_member_cannot_see_converges() {
+    let w = World::new().await;
+    let (a, b) = (w.note(&w.two, "a").await, w.note(&w.two, "b").await);
+    let id = relation_id(
+        &w.submit(
+            &w.two,
+            create_relation(Uuid::new_v4(), relation_between(a, b)),
+        )
+        .await,
+    );
+
+    let ack = w.submit(&w.one, remove(&[], &[id])).await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    assert!(applied(&ack).relation_ids.is_empty());
+    assert_eq!(w.relation_lifecycle(id).await.as_deref(), Some("active"));
+}

--- a/crates/altaird/tests/write_spine.rs
+++ b/crates/altaird/tests/write_spine.rs
@@ -978,3 +978,95 @@ async fn a_create_naming_an_invisible_identity_is_refused_and_never_faults() {
         "and it did not overwrite what was there"
     );
 }
+
+#[tokio::test]
+async fn a_timestamp_that_cannot_be_read_is_refused_wherever_it_arrives() {
+    // Two callers parse the same wire shape, and they used to disagree: a
+    // labelled date refused a garbled instant while a create's `created_at`
+    // silently substituted the instance's clock. A client with a broken clock
+    // conversion was then told its capture had been accepted carrying a time it
+    // never sent, which is the quietest way to be wrong about when something
+    // happened.
+    let w = World::new().await;
+
+    let unreadable = [
+        // Nanos that are not a fraction of a second.
+        altair_proto::prost_types::Timestamp {
+            seconds: 1_780_000_000,
+            nanos: -1,
+        },
+        // Seconds naming no representable instant.
+        altair_proto::prost_types::Timestamp {
+            seconds: i64::MAX,
+            nanos: 0,
+        },
+    ];
+
+    for stamp in unreadable {
+        let ack = w
+            .submit(
+                &w.one,
+                v1::intent::Action::Create(v1::Create {
+                    subject: Some(v1::create::Subject::Entity(v1::CreateEntity {
+                        entity_id: Uuid::new_v4().as_bytes().to_vec(),
+                        created_at: Some(stamp),
+                        capture_method: "test".into(),
+                        content: Some(note_content("when?")),
+                    })),
+                }),
+            )
+            .await;
+        assert_eq!(
+            refused(&ack).reason,
+            v1::RefusalReason::Malformed as i32,
+            "{stamp:?} was absorbed rather than refused"
+        );
+
+        let id = w.note(&w.one, "a note").await;
+        let ack = w
+            .submit(
+                &w.one,
+                edit_entity(
+                    id,
+                    1,
+                    v1::EntityContent {
+                        dates: vec![v1::LabelledDate {
+                            label: "due".into(),
+                            when: Some(stamp),
+                            bring_forward: false,
+                        }],
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+    }
+
+    // An absent created_at is ordinary, not malformed: it means the instance's
+    // own clock, which is what a capture with nothing but an identity gets.
+    let id = w.note(&w.one, "no stated time").await;
+    assert_eq!(w.counter(id).await, 1);
+}
+
+#[tokio::test]
+async fn a_base_counter_this_instance_could_not_have_issued_is_refused() {
+    // Clamping it was worse than it looks. A base larger than any counter the
+    // store can hold reads as current against every entity, so the write skips
+    // conflict detection entirely — silently, and only for the input nobody
+    // should be sending.
+    let w = World::new().await;
+    let id = shared_note(&w, "start").await;
+    w.submit(&w.two, edit_entity(id, 1, note_content("theirs")))
+        .await;
+
+    let ack = w
+        .submit(&w.one, edit_entity(id, u64::MAX, note_content("mine")))
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+    assert_eq!(
+        w.title(id).await.as_deref(),
+        Some("theirs"),
+        "and it did not apply while skipping the conflict it should have found"
+    );
+}

--- a/crates/altaird/tests/write_spine.rs
+++ b/crates/altaird/tests/write_spine.rs
@@ -865,3 +865,116 @@ async fn concurrent_writes_produce_dense_positions_and_a_total_container_order()
         "two entities shared a position, so the container's order is not total"
     );
 }
+
+// --- what a cross-model review found -------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn two_submissions_of_one_intent_at_once_both_get_the_acknowledgement() {
+    // The promise is that resubmitting an intent returns the acknowledgement
+    // the instance already issued, unchanged, rather than producing a second
+    // effect. Sequential replay is the easy half. The half that was wrong: two
+    // submissions of the same identity in flight together both find it absent,
+    // both work, and the loser used to answer with a store fault — the instance
+    // saying it is down while holding the answer.
+    //
+    // A retry after a stalled or dropped submission is exactly this shape, and
+    // it is what the outbox does by design.
+    let w = std::sync::Arc::new(World::new().await);
+    let id = w.note(&w.one, "first").await;
+    let intent = Uuid::new_v4();
+
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let mut running = Vec::new();
+    for _ in 0..2 {
+        let w = w.clone();
+        let barrier = barrier.clone();
+        running.push(tokio::spawn(async move {
+            barrier.wait().await;
+            w.submit_as(&w.one, intent, edit_entity(id, 1, note_content("second")))
+                .await
+        }));
+    }
+    let mut acks = Vec::new();
+    for handle in running {
+        acks.push(handle.await.expect("neither call is a fault"));
+    }
+
+    assert_eq!(
+        acks[0], acks[1],
+        "both callers are owed the acknowledgement the instance issued"
+    );
+    assert_eq!(w.counter(id).await, 2, "the effect happened once");
+    assert_eq!(
+        w.changes().await.len(),
+        2,
+        "one create and one edit, not one create and two edits"
+    );
+}
+
+#[tokio::test]
+async fn holding_an_acknowledgement_a_second_time_says_so_rather_than_failing() {
+    // The mechanism the test above exercises end to end, asserted directly,
+    // because the refusal path holds its acknowledgement in a second
+    // transaction that never takes the sequence lock — so its race is real and
+    // cannot be forced from outside the instance. What can be asserted is what
+    // the spine relies on: the second hold reports that it lost, instead of
+    // raising a primary-key violation that reaches a caller as the instance
+    // being down while it is holding their answer.
+    use altaird::store::begin_write;
+    use altaird::write::intent;
+    use altaird::write::outcome::Outcome;
+
+    let w = World::new().await;
+    let id = Uuid::new_v4();
+    let member = w.one.membership_id();
+    let at = chrono::Utc::now();
+    let outcome = Outcome::not_available();
+
+    let mut tx = begin_write(&w.db.pool).await.expect("a transaction");
+    assert!(
+        intent::hold(&mut tx, id, member, at, &outcome)
+            .await
+            .expect("held")
+    );
+    tx.commit().await.expect("committed");
+
+    let mut tx = begin_write(&w.db.pool).await.expect("a transaction");
+    assert!(
+        !intent::hold(&mut tx, id, member, at, &outcome)
+            .await
+            .expect("a second hold is an answer, not a store error"),
+        "the loser has to be told it lost, or it cannot return the \
+         acknowledgement the instance already issued"
+    );
+    tx.rollback().await.expect("rolled back");
+}
+
+#[tokio::test]
+async fn a_create_naming_an_invisible_identity_is_refused_and_never_faults() {
+    // The lookup cannot tell "not there" from "there and not yours" — that is
+    // what the audience predicate is for — so the insert has to, without ever
+    // reaching the error channel. A store fault where an unused identifier
+    // would have succeeded is an oracle for whether something is there,
+    // arriving through the one channel nobody thinks of as an answer.
+    let w = World::new().await;
+    let theirs = w.note(&w.two, "private").await;
+
+    let taken = w
+        .write
+        .submit(
+            &w.one,
+            &[v1::Intent {
+                intent_id: Uuid::new_v4().as_bytes().to_vec(),
+                action: Some(create_entity(theirs.as_uuid(), note_content("mine now"))),
+            }],
+        )
+        .await
+        .expect("an identifier somebody else holds is an answer, not a fault");
+
+    assert!(is_not_available(&taken[0]));
+    assert_eq!(
+        w.title(theirs).await.as_deref(),
+        Some("private"),
+        "and it did not overwrite what was there"
+    );
+}

--- a/crates/altaird/tests/write_spine.rs
+++ b/crates/altaird/tests/write_spine.rs
@@ -1,0 +1,867 @@
+//! The intent spine: identity, the counter, conflict, the change sequence, and
+//! audience.
+//!
+//! Most of the schema's *checks this file cannot make, which the write path
+//! owes* list is here. The lines this item does not own — block recomputation
+//! and identity matching, the graduation half of bulk state, ladder position,
+//! and the horizon — belong to 2.2 and 2.4 and are not asserted.
+
+mod common;
+
+use altair_proto::v1;
+use common::*;
+use uuid::Uuid;
+
+fn note_content(title: &str) -> v1::EntityContent {
+    v1::EntityContent {
+        title: Some(title.into()),
+        specific: Some(v1::entity_content::Specific::Note(
+            v1::NoteContent::default(),
+        )),
+        ..Default::default()
+    }
+}
+
+// --- identity and replay -------------------------------------------------
+
+#[tokio::test]
+async fn a_create_lands_with_a_counter_of_one() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "a thought").await;
+    assert_eq!(w.counter(id).await, 1);
+    assert_eq!(w.title(id).await.as_deref(), Some("a thought"));
+}
+
+#[tokio::test]
+async fn a_replayed_intent_returns_the_first_acknowledgement_and_produces_no_second_effect() {
+    let w = World::new().await;
+    let intent = Uuid::new_v4();
+    let entity = Uuid::new_v4();
+
+    let first = w
+        .submit_as(&w.one, intent, create_entity(entity, note_content("once")))
+        .await;
+    let second = w
+        .submit_as(&w.one, intent, create_entity(entity, note_content("once")))
+        .await;
+
+    assert_eq!(first, second, "a replay is answered with what was answered");
+    assert_eq!(
+        w.changes().await.len(),
+        1,
+        "a replay produced a second change entry, so it produced a second effect"
+    );
+}
+
+#[tokio::test]
+async fn a_replayed_edit_does_not_advance_the_counter_again() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "first").await;
+    let intent = Uuid::new_v4();
+
+    let first = w
+        .submit_as(&w.one, intent, edit_entity(id, 1, note_content("second")))
+        .await;
+    assert_eq!(w.counter(id).await, 2);
+
+    let second = w
+        .submit_as(&w.one, intent, edit_entity(id, 1, note_content("third")))
+        .await;
+    assert_eq!(first, second);
+    assert_eq!(w.counter(id).await, 2, "the replay wrote again");
+    assert_eq!(w.title(id).await.as_deref(), Some("second"));
+}
+
+#[tokio::test]
+async fn the_acknowledgement_is_held_for_a_refusal_too() {
+    let w = World::new().await;
+    let intent = Uuid::new_v4();
+    let missing = altaird::store::ids::EntityId::from_uuid(Uuid::new_v4());
+
+    let first = w
+        .submit_as(&w.one, intent, edit_entity(missing, 1, note_content("x")))
+        .await;
+    assert!(is_not_available(&first));
+
+    let second = w
+        .submit_as(&w.one, intent, edit_entity(missing, 1, note_content("x")))
+        .await;
+    assert_eq!(first, second, "a refusal is an answer and is replayed too");
+}
+
+#[tokio::test]
+async fn an_intent_identity_held_by_another_member_is_nothing() {
+    let w = World::new().await;
+    let intent = Uuid::new_v4();
+    w.submit_as(
+        &w.one,
+        intent,
+        create_entity(Uuid::new_v4(), note_content("mine")),
+    )
+    .await;
+
+    let theirs = w
+        .submit_as(
+            &w.two,
+            intent,
+            create_entity(Uuid::new_v4(), note_content("theirs")),
+        )
+        .await;
+    assert!(
+        is_not_available(&theirs),
+        "an intent identity is a client's assertion, and the held answer is not \
+         another member's to receive"
+    );
+}
+
+// --- the counter and conflict -------------------------------------------
+
+/// A note member two can also see, which is what makes a concurrent edit
+/// possible at all.
+async fn shared_note(w: &World, title: &str) -> altaird::store::ids::EntityId {
+    w.create(
+        &w.one,
+        v1::entity_content::Specific::Note(v1::NoteContent::default()),
+        v1::EntityContent {
+            title: Some(title.into()),
+            audience_member_ids: vec![w.two.membership_id().as_bytes().to_vec()],
+            ..Default::default()
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn a_current_base_applies_with_no_conflict() {
+    let w = World::new().await;
+    let id = shared_note(&w, "start").await;
+    let ack = w
+        .submit(&w.one, edit_entity(id, 1, note_content("next")))
+        .await;
+    assert!(applied(&ack).conflict.is_none());
+    assert_eq!(applied(&ack).counter, 2);
+}
+
+#[tokio::test]
+async fn a_stale_base_is_never_a_rejection() {
+    let w = World::new().await;
+    let id = shared_note(&w, "start").await;
+    w.submit(&w.two, edit_entity(id, 1, note_content("theirs")))
+        .await;
+
+    // Base 1, three counters behind by the time it lands.
+    w.submit(&w.two, edit_entity(id, 2, note_content("theirs again")))
+        .await;
+    let ack = w
+        .submit(&w.one, edit_entity(id, 1, note_content("mine")))
+        .await;
+
+    assert!(
+        matches!(ack.outcome, Some(v1::acknowledgement::Outcome::Applied(_))),
+        "a stale base was rejected, which is the familiar pattern and is wrong here"
+    );
+    assert_eq!(w.title(id).await.as_deref(), Some("mine"));
+}
+
+#[tokio::test]
+async fn a_stale_base_touching_a_different_part_applies_without_conflict() {
+    let w = World::new().await;
+    let id = shared_note(&w, "start").await;
+
+    // Two moves the title.
+    w.submit(&w.two, edit_entity(id, 1, note_content("theirs")))
+        .await;
+
+    // One, still on base 1, writes a date. Disjoint parts.
+    let ack = w
+        .submit(
+            &w.one,
+            edit_entity(
+                id,
+                1,
+                v1::EntityContent {
+                    dates: vec![v1::LabelledDate {
+                        label: "due".into(),
+                        when: Some(timestamp(chrono::Utc::now())),
+                        bring_forward: true,
+                    }],
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    assert!(
+        applied(&ack).conflict.is_none(),
+        "disjoint parts are not a conflict, which is the whole point of scoping \
+         a write to the part that changed"
+    );
+    assert!(w.conflicts(id).await.is_empty());
+    assert_eq!(w.title(id).await.as_deref(), Some("theirs"));
+}
+
+#[tokio::test]
+async fn a_stale_base_touching_the_same_part_retains_both_values() {
+    let w = World::new().await;
+    let id = shared_note(&w, "start").await;
+    w.submit(&w.two, edit_entity(id, 1, note_content("theirs")))
+        .await;
+
+    let ack = w
+        .submit(&w.one, edit_entity(id, 1, note_content("mine")))
+        .await;
+    let a = applied(&ack);
+
+    let conflict = a
+        .conflict
+        .as_ref()
+        .expect("the same part moved and this is a conflict");
+    assert_eq!(conflict.content_fields, vec![1], "the title is field 1");
+
+    // The write still applied. This is not a failure and nothing is sent back.
+    assert_eq!(w.title(id).await.as_deref(), Some("mine"));
+
+    let held = w.conflicts(id).await;
+    assert_eq!(held.len(), 1);
+    assert_eq!(held[0].field.as_deref(), Some("title"));
+    assert_eq!(held[0].mine.as_deref(), Some("mine"));
+    assert_eq!(held[0].theirs.as_deref(), Some("theirs"));
+    assert_eq!(held[0].mine_member, Some(w.one.membership_id()));
+    assert_eq!(
+        held[0].theirs_member,
+        Some(w.two.membership_id()),
+        "whose edit each value was is a fact, and it is the fact that changes \
+         the decision a person is making"
+    );
+}
+
+#[tokio::test]
+async fn writes_producing_the_same_value_are_not_divergent() {
+    let w = World::new().await;
+    let id = shared_note(&w, "start").await;
+    w.submit(&w.two, edit_entity(id, 1, note_content("agreed")))
+        .await;
+
+    // One is stale, touches the same part, and picks the same value. This is
+    // the likely case when two people resolve one conflict.
+    let ack = w
+        .submit(&w.one, edit_entity(id, 1, note_content("agreed")))
+        .await;
+
+    assert!(applied(&ack).conflict.is_none());
+    assert!(
+        w.conflicts(id).await.is_empty(),
+        "two people agreeing produced a conflict"
+    );
+}
+
+// --- the change sequence -------------------------------------------------
+
+#[tokio::test]
+async fn every_write_gets_an_entry_and_positions_follow_commit_order() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "one").await;
+    w.submit(&w.one, edit_entity(id, 1, note_content("two")))
+        .await;
+    w.submit(&w.one, edit_entity(id, 2, note_content("three")))
+        .await;
+
+    let changes = w.changes().await;
+    assert_eq!(changes.len(), 3);
+    assert_eq!(
+        changes.iter().map(|c| c.position).collect::<Vec<_>>(),
+        vec![1, 2, 3],
+        "positions are allocated from one row inside the writing transaction, \
+         so they are dense and in commit order"
+    );
+    assert!(changes.iter().all(|c| c.kind == "entity_written"));
+}
+
+#[tokio::test]
+async fn a_narrowing_records_who_could_see_it_before() {
+    let w = World::new().await;
+    let id = shared_note(&w, "shared").await;
+
+    // Clear the audience: private to the author again.
+    w.submit(
+        &w.one,
+        edit_entity(
+            id,
+            1,
+            v1::EntityContent {
+                cleared: vec![5],
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+
+    let changes = w.changes().await;
+    let last = changes.last().expect("a change");
+    assert_eq!(
+        last.audience_before.as_deref(),
+        Some(&[w.two.membership_id()][..]),
+        "a narrowing has to reach the member who lost sight of the entity, and \
+         the current audience no longer names them"
+    );
+    assert_eq!(last.audience_after.as_deref(), Some(&[][..]));
+}
+
+#[tokio::test]
+async fn a_refused_intent_leaves_no_gap_in_the_sequence() {
+    let w = World::new().await;
+    w.note(&w.one, "one").await;
+    let missing = altaird::store::ids::EntityId::from_uuid(Uuid::new_v4());
+    w.submit(&w.one, edit_entity(missing, 1, note_content("x")))
+        .await;
+    w.note(&w.one, "two").await;
+
+    let positions: Vec<i64> = w.changes().await.iter().map(|c| c.position).collect();
+    assert_eq!(
+        positions,
+        vec![1, 2],
+        "a rolled-back write must leave no gap, or a client cannot tell a hole \
+         it must wait for from one that will never be filled"
+    );
+}
+
+// --- audience ------------------------------------------------------------
+
+#[tokio::test]
+async fn an_entity_this_member_cannot_see_is_refused_exactly_as_a_missing_one() {
+    let w = World::new().await;
+    let theirs = w.note(&w.two, "private").await;
+    let missing = altaird::store::ids::EntityId::from_uuid(Uuid::new_v4());
+
+    let invisible = w
+        .submit(&w.one, edit_entity(theirs, 1, note_content("x")))
+        .await;
+    let absent = w
+        .submit(&w.one, edit_entity(missing, 1, note_content("x")))
+        .await;
+
+    assert_eq!(
+        refused(&invisible),
+        refused(&absent),
+        "nothing distinguishes an entity that does not exist from one the \
+         submitting member cannot see"
+    );
+    assert!(
+        refused(&invisible).detail.is_empty(),
+        "the detail is the field nobody thinks of as carrying meaning, which is \
+         where a disclosure would hide"
+    );
+}
+
+#[tokio::test]
+async fn every_member_in_an_audience_must_answer_to_a_membership() {
+    let w = World::new().await;
+    let ack = w
+        .submit(
+            &w.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    title: Some("shared with nobody".into()),
+                    audience_member_ids: vec![Uuid::new_v4().as_bytes().to_vec()],
+                    specific: Some(v1::entity_content::Specific::Note(
+                        v1::NoteContent::default(),
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(
+        is_not_available(&ack),
+        "a foreign key cannot reach inside an array, so the write path owes this"
+    );
+}
+
+#[tokio::test]
+async fn an_assignment_must_answer_to_a_membership() {
+    let w = World::new().await;
+    let ack = w
+        .submit(
+            &w.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    assigned_member_ids: vec![Uuid::new_v4().as_bytes().to_vec()],
+                    specific: Some(v1::entity_content::Specific::Note(
+                        v1::NoteContent::default(),
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack));
+}
+
+// --- the shape of a well-formed intent -----------------------------------
+
+#[tokio::test]
+async fn an_edit_may_not_change_the_type() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "a note").await;
+    let ack = w
+        .submit(
+            &w.one,
+            edit_entity(
+                id,
+                1,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Item(
+                        v1::ItemContent::default(),
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+}
+
+#[tokio::test]
+async fn a_field_both_present_and_cleared_is_malformed() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "a note").await;
+    let ack = w
+        .submit(
+            &w.one,
+            edit_entity(
+                id,
+                1,
+                v1::EntityContent {
+                    title: Some("set".into()),
+                    cleared: vec![1],
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+}
+
+#[tokio::test]
+async fn a_cleared_number_naming_no_field_is_malformed() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "a note").await;
+    // 6 is reserved and 100 is `cleared` itself.
+    for number in [6u32, 100, 999] {
+        let ack = w
+            .submit(
+                &w.one,
+                edit_entity(
+                    id,
+                    1,
+                    v1::EntityContent {
+                        cleared: vec![number],
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        assert_eq!(
+            refused(&ack).reason,
+            v1::RefusalReason::Malformed as i32,
+            "clearing field {number} should not be readable as an instruction"
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_identifier_of_the_wrong_length_is_malformed() {
+    let w = World::new().await;
+    let ack = w
+        .submit(
+            &w.one,
+            v1::intent::Action::Create(v1::Create {
+                subject: Some(v1::create::Subject::Entity(v1::CreateEntity {
+                    entity_id: vec![1, 2, 3],
+                    created_at: None,
+                    capture_method: "test".into(),
+                    content: Some(note_content("short")),
+                })),
+            }),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+}
+
+#[tokio::test]
+async fn content_with_no_type_is_malformed() {
+    let w = World::new().await;
+    let ack = w
+        .submit(
+            &w.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    title: Some("typeless".into()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+}
+
+#[tokio::test]
+async fn the_types_with_no_table_are_refused_for_a_reason_that_expires() {
+    use v1::entity_content::Specific;
+    let w = World::new().await;
+    let cases = [
+        Specific::Routine(v1::RoutineContent::default()),
+        Specific::FocusSession(v1::FocusSessionContent::default()),
+        Specific::CheckIn(v1::CheckInContent::default()),
+        Specific::File(v1::FileContent::default()),
+    ];
+    for specific in cases {
+        let ack = w
+            .submit(
+                &w.one,
+                create_entity(
+                    Uuid::new_v4(),
+                    v1::EntityContent {
+                        specific: Some(specific),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        assert_eq!(
+            refused(&ack).reason,
+            v1::RefusalReason::Malformed as i32,
+            "refused, and with a detail that says why rather than nothing"
+        );
+        assert!(!refused(&ack).detail.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn every_type_the_store_has_a_table_for_creates_a_row_with_defaults() {
+    use v1::entity_content::Specific;
+    let w = World::new().await;
+    let cases = [
+        (
+            Specific::Campaign(v1::CampaignContent::default()),
+            "campaign",
+        ),
+        (Specific::Arc(v1::ArcContent::default()), "arc"),
+        (Specific::Quest(v1::QuestContent::default()), "quest"),
+        (Specific::Item(v1::ItemContent::default()), "item"),
+        (
+            Specific::Location(v1::LocationContent::default()),
+            "location",
+        ),
+        (
+            Specific::Category(v1::CategoryContent::default()),
+            "category",
+        ),
+    ];
+    for (specific, table) in cases {
+        let id = w
+            .create(&w.one, specific, v1::EntityContent::default())
+            .await;
+        assert_eq!(
+            w.rows_for(table, "entity_id", id).await,
+            1,
+            "{table} has no row, so the entity is half-formed"
+        );
+    }
+    // A note and a shopping list have no table: a body is its blocks in order
+    // and there is nothing else.
+    let note = w.note(&w.one, "no table").await;
+    assert_eq!(w.counter(note).await, 1);
+}
+
+// --- containers ----------------------------------------------------------
+
+async fn a_category(w: &World) -> altaird::store::ids::EntityId {
+    w.create(
+        &w.one,
+        v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+        v1::EntityContent {
+            title: Some("work".into()),
+            ..Default::default()
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn entering_a_container_places_the_entity_at_the_end() {
+    let w = World::new().await;
+    let category = a_category(&w).await;
+
+    let mut placed = Vec::new();
+    for n in 0..3 {
+        let id = w
+            .create(
+                &w.one,
+                v1::entity_content::Specific::Note(v1::NoteContent::default()),
+                v1::EntityContent {
+                    title: Some(format!("note {n}")),
+                    category_id: Some(category.as_uuid().as_bytes().to_vec()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        placed.push(id);
+    }
+
+    for (n, id) in placed.iter().enumerate() {
+        assert_eq!(
+            w.category_position(*id).await,
+            Some(n as i32),
+            "position is assigned by the instance, which appends"
+        );
+    }
+}
+
+#[tokio::test]
+async fn leaving_a_container_forgets_the_position() {
+    let w = World::new().await;
+    let category = a_category(&w).await;
+    let id = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            v1::EntityContent {
+                category_id: Some(category.as_uuid().as_bytes().to_vec()),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert_eq!(w.category_position(id).await, Some(0));
+
+    w.submit(
+        &w.one,
+        edit_entity(
+            id,
+            1,
+            v1::EntityContent {
+                cleared: vec![3],
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+    assert_eq!(w.category_position(id).await, None);
+}
+
+#[tokio::test]
+async fn an_explicit_position_is_refused_while_nothing_reorders() {
+    let w = World::new().await;
+    let category = a_category(&w).await;
+    let ack = w
+        .submit(
+            &w.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    category_id: Some(category.as_uuid().as_bytes().to_vec()),
+                    category_position: Some(0),
+                    specific: Some(v1::entity_content::Specific::Note(
+                        v1::NoteContent::default(),
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+}
+
+#[tokio::test]
+async fn a_container_that_is_not_a_category_is_nothing() {
+    let w = World::new().await;
+    let not_a_category = w.note(&w.one, "not a container").await;
+    let ack = w
+        .submit(
+            &w.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    category_id: Some(not_a_category.as_uuid().as_bytes().to_vec()),
+                    specific: Some(v1::entity_content::Specific::Note(
+                        v1::NoteContent::default(),
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack));
+}
+
+#[tokio::test]
+async fn a_categorys_creation_default_acts_once_and_an_explicit_audience_outranks_it() {
+    let w = World::new().await;
+    let category = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent {
+                title: Some("shared".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    sqlx::query("UPDATE category SET creation_default_audience = $2 WHERE entity_id = $1")
+        .bind(category.as_uuid())
+        .bind(vec![w.two.membership_id()])
+        .execute(&w.db.pool)
+        .await
+        .expect("default");
+
+    let inherited = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            v1::EntityContent {
+                category_id: Some(category.as_uuid().as_bytes().to_vec()),
+                ..Default::default()
+            },
+        )
+        .await;
+    // Member two can act on it, which is the only observation that matters.
+    let ack = w
+        .submit(&w.two, edit_entity(inherited, 1, note_content("theirs")))
+        .await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+
+    let stated = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            v1::EntityContent {
+                category_id: Some(category.as_uuid().as_bytes().to_vec()),
+                cleared: vec![5],
+                ..Default::default()
+            },
+        )
+        .await;
+    let ack = w
+        .submit(&w.two, edit_entity(stated, 1, note_content("theirs")))
+        .await;
+    assert!(
+        is_not_available(&ack),
+        "an explicit audience outranks the category's creation default"
+    );
+}
+
+// --- the batch -----------------------------------------------------------
+
+#[tokio::test]
+async fn a_batch_answers_every_intent_and_a_refusal_does_not_stop_the_next() {
+    let w = World::new().await;
+    let missing = Uuid::new_v4();
+    let first = Uuid::new_v4();
+    let last = Uuid::new_v4();
+
+    let acks = w
+        .write
+        .submit(
+            &w.one,
+            &[
+                v1::Intent {
+                    intent_id: Uuid::new_v4().as_bytes().to_vec(),
+                    action: Some(create_entity(first, note_content("first"))),
+                },
+                v1::Intent {
+                    intent_id: Uuid::new_v4().as_bytes().to_vec(),
+                    action: Some(edit_entity(
+                        altaird::store::ids::EntityId::from_uuid(missing),
+                        1,
+                        note_content("nowhere"),
+                    )),
+                },
+                v1::Intent {
+                    intent_id: Uuid::new_v4().as_bytes().to_vec(),
+                    action: Some(create_entity(last, note_content("last"))),
+                },
+            ],
+        )
+        .await
+        .expect("the store was reachable");
+
+    assert_eq!(acks.len(), 3, "one acknowledgement per intent, in order");
+    assert!(matches!(
+        acks[0].outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    assert!(is_not_available(&acks[1]));
+    assert!(
+        matches!(
+            acks[2].outcome,
+            Some(v1::acknowledgement::Outcome::Applied(_))
+        ),
+        "the intent after a refusal was not applied, so the batch was all or nothing"
+    );
+
+    assert_eq!(
+        w.title(altaird::store::ids::EntityId::from_uuid(last))
+            .await
+            .as_deref(),
+        Some("last")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn concurrent_writes_produce_dense_positions_and_a_total_container_order() {
+    // The claim `changes` makes is that positions are allocated inside the
+    // writing transaction, so commit order and position order are the same and
+    // no position is skipped or shared. It also claims that holding the
+    // sequence row first is what makes `max + 1` safe for a container position
+    // without a second lock. Neither is worth documenting without watching them
+    // hold under real concurrency.
+    let w = std::sync::Arc::new(World::new().await);
+    let category = a_category(&w).await;
+    let before = w.changes().await.len() as i64;
+
+    let mut running = Vec::new();
+    for n in 0..16 {
+        let w = w.clone();
+        running.push(tokio::spawn(async move {
+            w.create(
+                &w.one,
+                v1::entity_content::Specific::Note(v1::NoteContent::default()),
+                v1::EntityContent {
+                    title: Some(format!("note {n}")),
+                    category_id: Some(category.as_uuid().as_bytes().to_vec()),
+                    ..Default::default()
+                },
+            )
+            .await
+        }));
+    }
+    let mut placed = Vec::new();
+    for handle in running {
+        placed.push(handle.await.expect("a create"));
+    }
+
+    let positions: Vec<i64> = w.changes().await.iter().map(|c| c.position).collect();
+    assert_eq!(
+        positions,
+        (1..=before + 16).collect::<Vec<_>>(),
+        "positions must be dense and unique, or a poller cannot tell a hole it \
+         must wait for from one that will never be filled"
+    );
+
+    let mut order: Vec<i32> = Vec::new();
+    for id in &placed {
+        order.push(w.category_position(*id).await.expect("a position"));
+    }
+    order.sort_unstable();
+    assert_eq!(
+        order,
+        (0..16).collect::<Vec<_>>(),
+        "two entities shared a position, so the container's order is not total"
+    );
+}


### PR DESCRIPTION
Wave 2.1, the intent spine. Sequential, load-bearing, and the thing every later wave assumes works.

## Migration two, taken once at the start

Reading 2.1 against the documents found two things the plan did not know, both settled in `docs/altair-scratchpad.md` at the wave boundary and now built.

**`entity_part_counter`** holds, per part of an entity, the counter it last moved at and the member who moved it. Conflict detection asks *which parts moved between two counter values* and nothing in migration one could answer it: the change sequence carries block identities but no field list and no counter, an intent row carries the counter after a write but not what it wrote, and versions are Knowledge-only and declinable. The two shapes rejected — a document column on the entity row, and the changed parts on the change row — are recorded in the migration.

**A relation gains a lifecycle**, the time it was removed, and the act that removed it. The wire can already name a relation in a removal and there was nowhere to hold the result. A relation is never a tombstone: erasing either endpoint removes it outright.

## What the spine is

| Module | Holds |
|---|---|
| `write/parts.rs` | The one place the wire's field number, the store's text name, and the conflict row's spelling agree — the schema's gap (d), pinned by a round-trip test |
| `write/provenance.rs` | The counter, what moved since a base, and that **a stale base is never a rejection** |
| `write/changes.rs` | The change sequence, allocated from the single position row, taken **before** anything an intent writes |
| `write/intent.rs` | Held acknowledgements and idempotent replay, written in the transaction they acknowledge |
| `write/entity.rs` | Create, edit, recreation, remove, erase, restore |
| `write/relation.rs` | The same five, with canonical ordering, duplicate refusal, and type-declared properties **read** rather than branched on |
| `service.rs` | `Submit` served; the other five answer `Unimplemented` |

## Evidence

**218 tests pass** (`cargo test --workspace`), 78 of them new. The suite is the schema's *"checks this file cannot make, which the write path owes"* list turned executable, minus the four lines 2.1 does not own — block recomputation and identity matching, the graduation half of bulk state, ladder position, and the horizon.

Claims that are proved rather than asserted:

- **A stale base is never a rejection**, and conflict is decided per part. Disjoint parts merge silently; the same part retains both values *and still applies*; two people choosing the same value do not conflict, whatever their base said.
- **Writes serialise on one row, and that is the design.** `concurrent_writes_produce_dense_positions_and_a_total_container_order` was watched failing with the sequence lock removed — sixteen concurrent creates into one category then share positions.
- **A refusal on audience is indistinguishable from a refusal on nonexistence**, including the detail and the gRPC status. A submission whose every intent is refused answers `Ok`.
- **A batch is never all or nothing**, asserted over the wire because that is the only place it is observable.
- **Relation types are declarations.** Every type the relation tests declare is one the shipped set has never contained; a branch on `blocks`/`uses`/`references` would fail all of them.
- **Erasure removes every dependent row explicitly**, because the schema's cascades hang off a delete of the entity row and erasure leaves a tombstone.

## Cross-model review

The plan makes this 2.1's done-when. Codex reviewed the branch against the substrate spec, the component model, and the owed-checks list.

**Round one raised four findings; all four verified in code and fixed** (`ecbba27`), each with a test watched failing without its fix:

1. **Concurrent replay answered with a store fault** instead of the acknowledgement already issued. Two submissions of one intent identity both find it absent and both proceed; the loser hit a primary-key violation, so a client retrying a stalled submission — what an outbox does by design — was told the instance was down while it held their answer.
2. **A create leaked whether an invisible identifier exists.** The scoped lookup cannot tell "not there" from "there and not yours"; the bare insert turned the second into a store fault while an unused identifier succeeded. A fault that appears only when something is there is an oracle for whether something is there, arriving through the one channel nobody reads as an answer.
3. **A relation edit could create the duplicate a create refuses**, by clearing the type off one of two relations between the same pair.
4. **A decimal with nanos of a whole unit or more, or opposite signs, was rendered as a different number.** `{ units: 1, nanos: 1_500_000_000 }` became `1.15`. Decimal range is on the owed-checks list.

**Round two: PASS**, no new findings, all four fixes verified with receipts.

**The review job on this PR then found two more** (`d6d5024`), both the same shape — a silent fallback where a sibling path in this branch refuses:

5. **A garbled `created_at` was replaced with the instance's own clock**, while a labelled date's identical parse refused. A client with a broken clock conversion would be told its capture had been accepted carrying a time it never sent. The two callers now share one parser.
6. **An out-of-range `base_counter` was clamped to `i64::MAX`** rather than refused. A base larger than any counter the store can hold reads as *current* against every entity, so a garbled value silently skipped conflict detection — the one mechanism this item exists to build.

## Three structural guards were sharpened

All false alarms the write path is simply the first code to trigger, and each was watched failing on a deliberate violation before and after the change:

- `WritePath::new` contains `Path::`, which the object-store boundary read as reaching around the interface. Now matched at a word boundary.
- `FROM entity_date` and `FROM entity_part_counter` are queries over other tables. Same fix.
- The audience-column and entity-table checks now apply to the instance rather than the whole tree. A test asserting that both paths call one predicate has to be able to read past it; one that could only read through the audience-scoped surface would report success for a predicate that admitted everybody. **The exact-string check is deliberately not scoped this way** and still covers every file.

## What is deliberately not here

Named so they read as decisions rather than omissions:

- **Type-specific content is not applied.** 2.1 creates each type's side-table row with defaults so nothing is half-formed; the fields inside `content.specific` are read for the type tag and nothing else. That is the plan's division, and it is invisible in v0 because no client exists before Wave 4.
- **Three refusals expire**, each with a detail saying why: a file create (2.3), an anchor on a relation (2.2), and an explicit `category_position` (whatever first reorders).
- **Relation edits are unconditional and last-write-wins.** Relations carry no write counter anywhere in the documents — the proto's gap (a). Moot in v0, not moot afterwards, and nothing here pretends otherwise.

## Blast radius

Entirely `crates/altaird`. Nothing outside the instance changes; there is no client to break. Two existing test files changed, both guards, both with their teeth verified. The conformance suite stays red, untouched.
