### PR TITLE
Wave 2.2 slice 1: build the test template once, and name it after its migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 .vscode/
 .idea/
 .DS_Store
+
+# Local-only compose port override for parallel lanes; never committed.
+compose.override.yaml

--- a/crates/altaird/src/testing.rs
+++ b/crates/altaird/src/testing.rs
@@ -13,15 +13,30 @@ use tokio::sync::OnceCell;
 
 static TEMPLATE: OnceCell<String> = OnceCell::const_new();
 
-fn admin_url() -> String {
-    // Nothing reads .env at runtime, so load it here. dotenvy walks up from
-    // the working directory, which is what lets `cargo test` work from a
-    // crate directory as well as from the repo root.
+/// Load `.env` before anything reads the environment.
+///
+/// **Every reader of the environment calls this first, not just the first one
+/// that happened to need it.** `prefix` used to read `ALTAIR_TEST_PREFIX`
+/// without loading, and `ensure_template` calls `prefix` before `admin_url` —
+/// so the template name was computed from an environment `.env` had not
+/// reached yet, and every worktree got the default name however its `.env` was
+/// written. Five lanes then shared one template, and each one starting a run
+/// dropped it with FORCE out from under the others: a suite that had passed
+/// twice would fail with *template database "altair_test_template" does not
+/// exist*, blaming the lane that was already running rather than the one that
+/// had just started.
+///
+/// dotenvy walks up from the working directory, which is what lets `cargo
+/// test` work from a crate directory as well as from the repo root.
+fn load_env() {
     static LOAD: std::sync::Once = std::sync::Once::new();
     LOAD.call_once(|| {
         dotenvy::dotenv().ok();
     });
+}
 
+fn admin_url() -> String {
+    load_env();
     std::env::var("DATABASE_URL")
         .expect("DATABASE_URL is not set. Check .env at the repo root, and that compose is up.")
 }
@@ -29,6 +44,7 @@ fn admin_url() -> String {
 /// Worktrees share one Postgres. Without a prefix, five parallel lanes fight
 /// over one template name.
 fn prefix() -> String {
+    load_env();
     std::env::var("ALTAIR_TEST_PREFIX").unwrap_or_else(|_| "altair_test".into())
 }
 

--- a/crates/altaird/src/testing.rs
+++ b/crates/altaird/src/testing.rs
@@ -53,6 +53,29 @@ fn with_database(url: &str, name: &str) -> String {
     format!("{base}/{name}")
 }
 
+/// A short digest of the migrations this build carries.
+///
+/// **This is what makes reusing a template safe.** The template is created once
+/// and then left alone, so without something in its name tying it to the
+/// migrations it was built from, checking out a revision with a changed or added
+/// migration would go on cloning the *old* schema — and the tests would either
+/// fail for an absent column or, far worse, pass against obsolete constraints
+/// and report green for a revision they never exercised.
+///
+/// Taking it from `MIGRATOR` rather than from the files means it tracks what the
+/// binary will actually apply. A changed migration yields a new name and a new
+/// template; the old one lingers harmlessly until swept, which is the cheap
+/// direction for this to fail in.
+fn migrations_digest() -> String {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    for m in crate::store::MIGRATOR.iter() {
+        m.version.hash(&mut h);
+        m.checksum.hash(&mut h);
+    }
+    format!("{:016x}", h.finish())
+}
+
 /// The advisory-lock key for one prefix's template.
 ///
 /// Any stable mapping from the name to an `i64` does; collisions between two
@@ -93,7 +116,7 @@ fn template_lock_key(name: &str) -> i64 {
 /// Rebuilding it on every run to avoid that was paying a constant cost for a
 /// rare event, and the cost turned out to be the cluster.
 async fn ensure_template() -> String {
-    let name = format!("{}_template", prefix());
+    let name = format!("{}_template_{}", prefix(), migrations_digest());
     let admin = admin_url();
 
     let mut conn = PgConnection::connect(&admin).await.expect("connect");

--- a/crates/altaird/src/testing.rs
+++ b/crates/altaird/src/testing.rs
@@ -53,32 +53,89 @@ fn with_database(url: &str, name: &str) -> String {
     format!("{base}/{name}")
 }
 
+/// The advisory-lock key for one prefix's template.
+///
+/// Any stable mapping from the name to an `i64` does; collisions between two
+/// different prefixes would only make them wait for each other, which is
+/// harmless and vanishingly unlikely.
+fn template_lock_key(name: &str) -> i64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    name.hash(&mut h);
+    h.finish() as i64
+}
+
+/// The migrated template, created once and then left alone.
+///
+/// **It is not dropped and rebuilt every time.** It used to be: every test
+/// binary opened with `DROP DATABASE ... WITH (FORCE)` and a fresh `CREATE`,
+/// which is thirty-odd forced drops per `cargo test --workspace` — and each one
+/// makes Postgres take an immediate checkpoint, while `WITH (FORCE)` terminates
+/// every other connection to it. Several sessions doing that at once drove the
+/// cluster into crash recovery three times in one afternoon, with the symptom
+/// landing on whichever lane happened to be connecting (`57P03`, *the database
+/// system is in recovery mode*) rather than on the run that caused it.
+///
+/// So the template is created only when it is absent. **The advisory lock is
+/// what makes that safe**: without it two binaries starting together both see
+/// nothing, both create, and one fails — or worse, one branches a template the
+/// other has not finished migrating yet.
+///
+/// **A stale template is not a risk in the ordinary case**, because nothing
+/// ever writes to it — tests branch it and write to the branch. It goes stale
+/// only when the migrations themselves change, and the fix is one line:
+///
+/// ```text
+/// docker exec altair-postgres-1 psql -U postgres -d altair \
+///   -c 'DROP DATABASE IF EXISTS "<prefix>_template" WITH (FORCE)'
+/// ```
+///
+/// Rebuilding it on every run to avoid that was paying a constant cost for a
+/// rare event, and the cost turned out to be the cluster.
 async fn ensure_template() -> String {
     let name = format!("{}_template", prefix());
     let admin = admin_url();
 
-    let drop_sql = format!(r#"DROP DATABASE IF EXISTS "{name}" WITH (FORCE)"#);
-    let create_sql = format!(r#"CREATE DATABASE "{name}""#);
-
     let mut conn = PgConnection::connect(&admin).await.expect("connect");
-    conn.execute(sqlx::raw_sql(AssertSqlSafe(drop_sql)))
+
+    // Held until this connection closes, which is after the template is
+    // migrated and ready to branch.
+    sqlx::query("SELECT pg_advisory_lock($1)")
+        .bind(template_lock_key(&name))
+        .execute(&mut conn)
         .await
-        .expect("drop template");
+        .expect("take the template lock");
+
+    let present: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM pg_database WHERE datname = $1")
+        .bind(&name)
+        .fetch_optional(&mut conn)
+        .await
+        .expect("look for the template");
+
+    if present.is_some() {
+        // Somebody else built it. Releasing the lock is closing the connection.
+        conn.close().await.ok();
+        return name;
+    }
+
+    let create_sql = format!(r#"CREATE DATABASE "{name}""#);
     conn.execute(sqlx::raw_sql(AssertSqlSafe(create_sql)))
         .await
         .expect("create template");
-    conn.close().await.ok();
 
     // Migrate over a single connection, then close it. Postgres refuses to
     // branch a template that has any connection open, so a pool here would
     // make every later CREATE DATABASE fail intermittently.
-    let mut conn = PgConnection::connect(&with_database(&admin, &name))
+    let mut migrating = PgConnection::connect(&with_database(&admin, &name))
         .await
         .expect("connect to template");
     crate::store::MIGRATOR
-        .run(&mut conn)
+        .run(&mut migrating)
         .await
         .expect("migrations apply");
+    migrating.close().await.ok();
+
+    // Only now, so nobody branches a half-migrated template.
     conn.close().await.ok();
 
     name


### PR DESCRIPTION
First of nine slices of Wave 2.2, split for review. This one touches only the test harness and is independent of the write path — it can be read, merged, or rejected without reference to any of the others.

## The problem

`ensure_template` opened **every test binary** with `DROP DATABASE ... WITH (FORCE)` and a fresh `CREATE`. That is thirty-odd forced drops per `cargo test --workspace`, each one making Postgres take an immediate checkpoint while `FORCE` terminates every other connection to that template.

With several worktrees running suites at once — which is what `ALTAIR_TEST_PREFIX` exists to support — that drove the cluster into crash recovery **four times in one afternoon**. The symptom landed on whichever lane happened to be connecting (`57P03`, *the database system is in recovery mode*), never on the run that caused it, so it read as a failure in whatever code was being tested at the time.

## Three fixes, in the order they were found

**`.env` was never read when the template name was computed.** `ensure_template` calls `prefix()` before `admin_url()`, and `admin_url` was the only function loading dotenv — so `ALTAIR_TEST_PREFIX` came from an environment `.env` had not reached, and every worktree collapsed onto the same default name however its `.env` was written. The per-test branch databases were named correctly, which is what made it hard to see: the harness looked like it was isolating lanes. Both readers of the environment now load first.

**The template is built once, not once per test binary**, under a `pg_advisory_lock` so two binaries starting together cannot both create it or branch one that is still migrating. Nothing writes to a template — tests branch it and write to the branch — so reusing it is safe.

**The template is named after a digest of the migrations it was built from.** Reuse without that is a cache with no invalidation: check out a revision with a changed or added migration and every test database clones the *old* schema, which either fails for an absent column or, worse, passes against obsolete constraints and reports green for a revision it never exercised. The digest comes from `MIGRATOR`, so it tracks what the binary will actually apply. Superseded templates are left behind rather than dropped, because dropping is the operation this change exists to avoid.

## Verification

- `cargo test --workspace`: 25 targets, 218 tests, 0 failures — Wave 2.1's suite, unchanged.
- `prek run --all-files`: 13 hooks, all passed.
- A full parallel run produces no `57P03` and no missing-database errors, where the previous shape crashed the cluster repeatedly.

## Also here

`.gitignore` gains `compose.override.yaml`, which is how a second Postgres already bound to 5432 is worked around locally.

## What this does not fix

Each *test* still branches and drops its own database, so a full workspace run is still several hundred create/drop pairs. That remaining churn is inherent to the fresh-database-per-test design and is not addressed here. Running with `--test-threads=4` reduces it materially if a machine is under load.
