### PR TITLE
Wave 2.2 slice 2: a type-specific part, from the wire to the conflict row

### DIFF
--- a/crates/altaird/src/write/body.rs
+++ b/crates/altaird/src/write/body.rs
@@ -1,0 +1,99 @@
+//! Writing a body: dividing it, matching it against the blocks already held,
+//! and writing only what changed.
+//!
+//! **LANE: Bodies owns this file, and owns only this file.** The dispatch on
+//! either side of it is written: [`super::content`] reads a body off the wire
+//! into a [`BodyWrite`], [`super::entity`] hands one here for every verb that
+//! can carry one, and everything this returns is already wired into
+//! provenance, conflict detection, and the change sequence. What is missing is
+//! the middle.
+//!
+//! # Why a body is not a part
+//!
+//! Everything else a write addresses is one part with one value. A body is one
+//! field on the wire and many parts in the store: the substrate makes the
+//! *block* the smallest independently addressable unit of a body, because
+//! "treating the field as the unit would make two people working on different
+//! paragraphs of a shared plan look like a disagreement". Which blocks a body
+//! write touches is not knowable from the text alone — it depends on the blocks
+//! already stored — so this is the one place where reading the wire cannot say
+//! what a write touched, and the answer comes back from here instead.
+//!
+//! # What is already built, and must be used rather than rewritten
+//!
+//! Wave 1.2 landed both halves of the rule as pure functions, and DR-004 puts
+//! them at the instance so devices cannot disagree about the units
+//! reconciliation is decided in:
+//!
+//! - [`crate::body::divide`] — text to boundaries. Atomic constructs never
+//!   split; list items do; a long unbroken stretch of prose being one block is
+//!   correct rather than a bug.
+//! - [`crate::body::reconcile`] — matching the new boundaries against the
+//!   stored blocks so identity survives an edit to a block and to its
+//!   neighbours.
+//!
+//! # What this owes when it is filled in
+//!
+//! - Only two types carry a body and the store refuses a block on any other,
+//!   which is `block.body_type CHECK (body_type IN ('note', 'shopping_list'))`.
+//! - `block_position_unique` is `DEFERRABLE INITIALLY DEFERRED` on purpose:
+//!   rewriting a body renumbers what survives, and the intermediate states of
+//!   that renumbering are not violations.
+//! - **Every block whose text moved must appear in [`BodyTouch::written`].**
+//!   `entity_part_counter` is per part, conflict detection asks which parts
+//!   moved between two counter values, and a block that does not record its
+//!   movement is invisible to it. The failure is silent.
+//! - The stored text goes in [`BodyTouch::touching`] beside the arriving text,
+//!   because that pair is what decides a conflict, and *writes producing the
+//!   same value are not divergent* is a comparison over exactly those two
+//!   strings.
+
+use uuid::Uuid;
+
+use crate::store::entity::EntityType;
+use crate::store::ids::EntityId;
+
+use super::content::BodyWrite;
+use super::entity::{Applied, Ctx, Refusal};
+use super::parts::Part;
+
+/// What writing a body touched, at the grain a conflict is decided at.
+#[derive(Debug, Clone, Default)]
+pub struct BodyTouch {
+    /// Per block: the part, the text arriving, and the text it displaced. This
+    /// is the shape conflict detection takes, and it is a list because a body
+    /// write is many parts at once.
+    pub touching: Vec<(Part, Option<String>, Option<String>)>,
+    /// Every block part this write moved, for provenance. A superset of the
+    /// parts that conflicted and a subset of the blocks the body has.
+    pub written: Vec<Part>,
+    /// The blocks the change sequence should name, so a poller learns which
+    /// parts of a body it needs rather than the whole thing.
+    pub changed: Vec<Uuid>,
+}
+
+/// Write a body, returning what it touched.
+///
+/// **Not built yet.** Refusing is the honest answer: accepting silently would
+/// tell a client its writing had landed when no block existed, and the outbox
+/// would never send it again.
+///
+/// # Errors
+///
+/// Refuses until the Bodies lane fills this in; after that, refuses a body on a
+/// type that carries none, and faults only where the store could not be
+/// written.
+pub async fn apply(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    body: &BodyWrite,
+) -> Applied<BodyTouch> {
+    let _ = (ctx, entity, body);
+    Err(Refusal::Malformed(format!(
+        "a body is divided into blocks by the instance and that is not built yet, so this \
+         instance will not pretend to have written the body of a {}",
+        super::entity::type_name(kind)
+    ))
+    .into())
+}

--- a/crates/altaird/src/write/content.rs
+++ b/crates/altaird/src/write/content.rs
@@ -35,6 +35,7 @@ use crate::store::entity::EntityType;
 use crate::store::ids::EntityId;
 
 use super::parts::{ContentPart, Part};
+use super::specific::{self, SpecificPart};
 
 /// A labelled date, as the store holds one.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,6 +59,10 @@ pub enum PartWrite {
     Assignments(Vec<Uuid>),
     Audience(Vec<Uuid>),
     Bulk(Option<bool>),
+    /// A field of the type-specific message, carried by number because the set
+    /// differs per type. See [`super::specific`] for the vocabulary and the
+    /// dispatch.
+    Specific(SpecificPart),
 }
 
 impl PartWrite {
@@ -71,6 +76,9 @@ impl PartWrite {
             Self::Assignments(_) => ContentPart::Assignments,
             Self::Audience(_) => ContentPart::Audience,
             Self::Bulk(_) => ContentPart::Bulk,
+            // Not a content part at all, so it does not go through the branch
+            // above. The number is the type message's, not `EntityContent`'s.
+            Self::Specific(s) => return Part::Specific(s.field),
         })
     }
 
@@ -106,6 +114,41 @@ impl PartWrite {
                 ids.join(",")
             }),
             Self::Bulk(v) => v.map(|b| b.to_string()),
+            Self::Specific(s) => s.text(),
+        }
+    }
+}
+
+/// Everything one piece of content addresses: its parts, and at most one body.
+///
+/// **A body is separate because it is not one part.** Every other field a write
+/// carries is one part with one value; a body is one field on the wire and as
+/// many parts as it divides into, and which blocks those are is not knowable
+/// until the arriving text is matched against the blocks already stored. That
+/// needs the store, and reading the wire does not touch it. See
+/// [`super::body`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Written {
+    pub parts: Vec<PartWrite>,
+    pub body: Option<BodyWrite>,
+}
+
+/// A body arriving whole: the text, or nothing where it was cleared.
+///
+/// A client never divides it. The instance recomputes the boundaries, matches
+/// them against the blocks it holds, and writes only what changed — DR-004, so
+/// the division rule has one implementation and devices cannot disagree about
+/// the units reconciliation is decided in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BodyWrite(pub Option<String>);
+
+impl Written {
+    /// The type-specific parts one message addressed, and no body.
+    #[must_use]
+    pub fn from_specific(parts: Vec<SpecificPart>) -> Self {
+        Self {
+            parts: parts.into_iter().map(PartWrite::Specific).collect(),
+            body: None,
         }
     }
 }
@@ -114,7 +157,7 @@ impl PartWrite {
 #[derive(Debug, Clone)]
 pub struct Malformed(pub String);
 
-fn malformed(what: impl Into<String>) -> Malformed {
+pub fn malformed(what: impl Into<String>) -> Malformed {
     Malformed(what.into())
 }
 
@@ -189,15 +232,19 @@ pub fn entity_type(content: &v1::EntityContent) -> Result<EntityType, Malformed>
 ///   one, or `cleared` itself. Silently ignoring it would let a client believe
 ///   it had cleared something.
 ///
-/// # What it does not do
+/// # Type content, one level down
 ///
-/// It does not reach `content.specific`. Type content is Wave 2.2's, and 2.1
-/// creates each type's row with defaults so nothing is ever half-formed. A
-/// create carrying type content therefore lands as an entity of that type whose
-/// type-specific fields hold their defaults, and the fields themselves are not
-/// applied. That is the plan's division rather than an omission here, and it is
-/// invisible in v0 because no client exists before Wave 4.
-pub fn parts_written(content: &v1::EntityContent) -> Result<Vec<PartWrite>, Malformed> {
+/// `content.specific` carries its own `cleared = 100` list, so the same rule
+/// and the same two refusals apply inside it — and the cleared numbers are
+/// validated against **the type message actually present**, because a number
+/// valid for one type is not valid for another. That reading is
+/// [`specific::parts_written`], which dispatches to the module owning the type.
+///
+/// A type whose content this build does not write yet refuses distinguishably
+/// rather than dropping the fields on the floor. Wave 2.1's behaviour — read
+/// the tag, ignore the fields — was correct while nothing could write them and
+/// would now be a client being told its content had landed when it had not.
+pub fn parts_written(content: &v1::EntityContent) -> Result<Written, Malformed> {
     let mut cleared = Vec::new();
     for number in &content.cleared {
         let part = ContentPart::from_field_number(*number).ok_or_else(|| {
@@ -304,5 +351,14 @@ pub fn parts_written(content: &v1::EntityContent) -> Result<Vec<PartWrite>, Malf
         written.push(PartWrite::Bulk(None));
     }
 
-    Ok(written)
+    let mut all = Written {
+        parts: written,
+        body: None,
+    };
+    if let Some(specific) = content.specific.as_ref() {
+        let from_type = specific::parts_written(specific)?;
+        all.parts.extend(from_type.parts);
+        all.body = from_type.body;
+    }
+    Ok(all)
 }

--- a/crates/altaird/src/write/entity.rs
+++ b/crates/altaird/src/write/entity.rs
@@ -4,23 +4,27 @@
 //! change sequence's lock; see [`super::changes`] for why that ordering
 //! matters.
 //!
-//! # What this item writes, and what it leaves to 2.2
+//! # What this item writes, and where type content goes
 //!
 //! The shared model — title, dates, category and the position inside it,
-//! assignments, audience, bulk — is written here. **Type-specific content is
-//! not.** A create makes the side-table row with its defaults so nothing is
-//! ever half-formed, and the fields inside `content.specific` are left for
-//! Wave 2.2, which owns bodies, anchors, the ladder, and cycle prevention in
-//! nested containers.
+//! assignments, audience, bulk — is written here, one arm per part. **Type
+//! content is not**, and that is a boundary rather than an omission: every
+//! type-specific field goes through [`super::specific`], which dispatches to
+//! the module owning the type, and a body goes through [`super::body`], which
+//! divides it. Nothing about a campaign, a note, or a location is decided in
+//! this file, and a lane building a domain never has to open it.
 //!
-//! Two types are refused for reasons that expire, which is the honest answer
-//! rather than an omission:
+//! Types are refused for reasons that expire, which is the honest answer rather
+//! than an omission:
 //!
 //! - **A file**, until 2.3. The schema requires a file to name a body, and
 //!   there is no way to have uploaded one.
 //! - **A routine, a focus session, or a check-in**, until each domain is
 //!   designed. The schema deliberately creates no table for them, so there is
 //!   nothing to put a row in.
+//! - **Content the lane behind it has not filled in**, which refuses
+//!   distinguishably rather than accepting silently. See
+//!   [`super::specific::not_yet_built`].
 
 use chrono::{DateTime, Utc};
 use sqlx::Row;
@@ -32,9 +36,11 @@ use crate::store::ids::{EntityId, MemberId, MemberRef};
 use crate::store::{WriteScope, WriteTx};
 
 use super::changes::{self, EntityChange};
-use super::content::{Date, Malformed, PartWrite};
+use super::content::{Date, Malformed, PartWrite, Written};
 use super::outcome::{ConflictParts, Outcome};
-use super::provenance;
+use super::parts::Part;
+use super::specific;
+use super::{body, provenance};
 
 /// One intent's worth of context: the transaction, who is writing, and when.
 pub struct Ctx<'a> {
@@ -155,6 +161,9 @@ async fn current(ctx: &mut Ctx<'_>, row: &EntityRow, part: &PartWrite) -> Applie
                 .collect(),
         ),
         PartWrite::Bulk(_) => PartWrite::Bulk(Some(row.bulk)),
+        PartWrite::Specific(s) => {
+            PartWrite::Specific(specific::current(ctx, row.id, row.entity_type, s).await?)
+        }
     })
 }
 
@@ -168,19 +177,19 @@ async fn current(ctx: &mut Ctx<'_>, row: &EntityRow, part: &PartWrite) -> Applie
 async fn apply_part(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
+    kind: EntityType,
     part: &PartWrite,
     placement: Option<&PartWrite>,
 ) -> Applied<()> {
     match part {
         PartWrite::Title(v) => {
-            // search_text is maintained by the write path from the title and
-            // whatever the type contributes, because those live in side tables
-            // and a generated column cannot reach them. Only the title
-            // contributes here; the type's share arrives with 2.2.
-            sqlx::query("UPDATE entity SET title = $2, search_text = $3 WHERE id = $1")
+            // `search_text` is not written here. It is the title plus whatever
+            // the type contributes, and the type's share needs a read of a side
+            // table, so it is refreshed once after every part has landed — see
+            // `refresh_search_text`.
+            sqlx::query("UPDATE entity SET title = $2 WHERE id = $1")
                 .bind(entity.as_uuid())
                 .bind(v.as_deref())
-                .bind(v.as_deref().unwrap_or(""))
                 .execute(ctx.tx.conn())
                 .await?;
         }
@@ -253,7 +262,39 @@ async fn apply_part(
                 .execute(ctx.tx.conn())
                 .await?;
         }
+        PartWrite::Specific(s) => {
+            // The companion, where there is one, is the type's own — a ladder
+            // position beside a ladder parent, an assertion time beside an
+            // amount — and is handed through so the module can write both in
+            // one statement, for the same reason a category and its position
+            // move together here.
+            let placement = placement.and_then(|p| match p {
+                PartWrite::Specific(s) => Some(s),
+                _ => None,
+            });
+            specific::apply(ctx, entity, kind, s, placement).await?;
+        }
     }
+    Ok(())
+}
+
+/// Rewrite `search_text` from the title and the type's share of it.
+///
+/// **Maintained by the write path, not by a generated column.** A type's
+/// content lives in a side table and a generated column cannot reach across
+/// one. Refreshed once per write rather than per part, because the two
+/// contributions land in different statements and a per-part refresh would
+/// write a string that is briefly missing one of them.
+///
+/// `concat_ws` drops a null, so a type contributing nothing leaves the title
+/// standing alone — which is the whole answer for every type today.
+async fn refresh_search_text(ctx: &mut Ctx<'_>, entity: EntityId, kind: EntityType) -> Applied<()> {
+    let share = specific::search_text(ctx, entity, kind).await?;
+    sqlx::query("UPDATE entity SET search_text = concat_ws(' ', title, $2) WHERE id = $1")
+        .bind(entity.as_uuid())
+        .bind(share)
+        .execute(ctx.tx.conn())
+        .await?;
     Ok(())
 }
 
@@ -264,10 +305,15 @@ async fn apply_part(
 /// when a category changed.
 async fn validate_and_place(
     ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
     entering: Option<EntityId>,
     part: &PartWrite,
 ) -> Applied<Option<PartWrite>> {
     match part {
+        PartWrite::Specific(s) => Ok(specific::validate_and_place(ctx, entity, kind, s)
+            .await?
+            .map(PartWrite::Specific)),
         PartWrite::Audience(ids) | PartWrite::Assignments(ids) => {
             if !memberships_exist(ctx.tx, ids).await? {
                 return Err(Refusal::NotAvailable.into());
@@ -310,17 +356,12 @@ async fn validate_and_place(
 /// The side-table row a type carries beyond the shared model, with its
 /// defaults.
 ///
-/// Note and shopping list have no table: a body is its blocks in order and
-/// there is nothing else, which is a result rather than an omission.
+/// Which table that is comes from [`specific::side_table`], which is also what
+/// erasure removes and what the column helpers write through, so a type gaining
+/// a table is one line in one place. `None` there means a note or a shopping
+/// list, whose content is a body and nothing else.
 async fn make_type_row(ctx: &mut Ctx<'_>, entity: EntityId, kind: EntityType) -> Applied<()> {
-    let table = match kind {
-        EntityType::Campaign => "campaign",
-        EntityType::Arc => "arc",
-        EntityType::Quest => "quest",
-        EntityType::Item => "item",
-        EntityType::Location => "location",
-        EntityType::Category => "category",
-        EntityType::Note | EntityType::ShoppingList => return Ok(()),
+    match kind {
         EntityType::File => {
             return Err(Refusal::Malformed(
                 "a file names a body that must be uploaded first, and PutBody is not served yet"
@@ -334,6 +375,10 @@ async fn make_type_row(ctx: &mut Ctx<'_>, entity: EntityId, kind: EntityType) ->
             )
             .into());
         }
+        _ => {}
+    }
+    let Some(table) = specific::side_table(kind) else {
+        return Ok(());
     };
     let sql = format!("INSERT INTO {table} (entity_id) VALUES ($1)");
     sqlx::query(sqlx::AssertSqlSafe(sql))
@@ -362,7 +407,7 @@ pub async fn create(
     id: EntityId,
     created_at: Option<DateTime<Utc>>,
     capture_method: &str,
-    parts: Vec<PartWrite>,
+    written: Written,
     kind: EntityType,
 ) -> Applied<Outcome> {
     // A create naming something that is already here is not a second entity.
@@ -398,8 +443,11 @@ pub async fn create(
     // Audience is private to the author unless the write says otherwise, or the
     // category it lands in states a creation default. The default acts once, at
     // creation, and an explicit audience outranks it.
-    let stated_audience = parts.iter().any(|p| matches!(p, PartWrite::Audience(_)));
-    let category = parts.iter().find_map(|p| match p {
+    let stated_audience = written
+        .parts
+        .iter()
+        .any(|p| matches!(p, PartWrite::Audience(_)));
+    let category = written.parts.iter().find_map(|p| match p {
         PartWrite::Category(Some(c)) => Some(*c),
         _ => None,
     });
@@ -426,14 +474,23 @@ pub async fn create(
 
     make_type_row(ctx, id, kind).await?;
 
-    let mut written = Vec::new();
-    for part in &parts {
-        let placement = validate_and_place(ctx, None, part).await?;
-        apply_part(ctx, id, part, placement.as_ref()).await?;
-        written.push(part.part());
+    let mut moved = Vec::new();
+    for part in &written.parts {
+        let placement = validate_and_place(ctx, id, kind, None, part).await?;
+        apply_part(ctx, id, kind, part, placement.as_ref()).await?;
+        moved.push(part.part());
         if let Some(placement) = &placement {
-            written.push(placement.part());
+            moved.push(placement.part());
         }
+    }
+
+    // A body is many parts and they are not known until it is divided against
+    // what is stored, which on a create is nothing.
+    let mut changed_blocks = Vec::new();
+    if let Some(text) = &written.body {
+        let touch = body::apply(ctx, id, kind, text).await?;
+        moved.extend(touch.written);
+        changed_blocks.extend(touch.changed);
     }
 
     if !stated_audience && let Some(category) = category {
@@ -443,12 +500,13 @@ pub async fn create(
                 return Err(Refusal::NotAvailable.into());
             }
             let part = PartWrite::Audience(default);
-            apply_part(ctx, id, &part, None).await?;
-            written.push(part.part());
+            apply_part(ctx, id, kind, &part, None).await?;
+            moved.push(part.part());
         }
     }
 
-    provenance::record(ctx.tx, id, &written, 1, ctx.member).await?;
+    refresh_search_text(ctx, id, kind).await?;
+    provenance::record(ctx.tx, id, &moved, 1, ctx.member).await?;
 
     let after = read_audience(ctx, id).await?;
     changes::entity_written(
@@ -463,7 +521,7 @@ pub async fn create(
             audience_after: Some(after),
             author_before: None,
             author_after: Some(ctx.author()),
-            changed_blocks: Vec::new(),
+            changed_blocks,
         },
     )
     .await?;
@@ -476,7 +534,10 @@ async fn read_audience(ctx: &mut Ctx<'_>, id: EntityId) -> Applied<Vec<MemberRef
     Ok(row.map(|r| r.audience).unwrap_or_default())
 }
 
-fn type_name(kind: EntityType) -> &'static str {
+/// The store's spelling of a type, which is also the one a refusal says out
+/// loud to a person reading a log.
+#[must_use]
+pub fn type_name(kind: EntityType) -> &'static str {
     match kind {
         EntityType::Campaign => "campaign",
         EntityType::Arc => "arc",
@@ -498,7 +559,7 @@ pub async fn edit(
     ctx: &mut Ctx<'_>,
     id: EntityId,
     base_counter: i64,
-    parts: Vec<PartWrite>,
+    written: Written,
     stated_type: Option<EntityType>,
 ) -> Applied<Outcome> {
     let row = available_for_write(ctx.tx, ctx.member, id, WriteScope::AnyIncludingErased)
@@ -514,27 +575,41 @@ pub async fn edit(
     }
 
     if row.lifecycle == LifecycleState::Erased {
-        return recreate(ctx, &row, parts).await;
+        return recreate(ctx, &row, written).await;
     }
 
-    let mut touching = Vec::new();
-    let mut written = Vec::new();
+    let kind = row.entity_type;
+    let mut touching: Vec<(Part, Option<String>, Option<String>)> = Vec::new();
+    let mut moved = Vec::new();
     let counter = row.counter + 1;
 
-    for part in &parts {
-        let placement = validate_and_place(ctx, row.category_id, part).await?;
+    for part in &written.parts {
+        let placement = validate_and_place(ctx, id, kind, row.category_id, part).await?;
         let stored = current(ctx, &row, part).await?;
         touching.push((part.part(), part.text(), stored.text()));
         if let Some(placement) = &placement {
             let stored = current(ctx, &row, placement).await?;
             touching.push((placement.part(), placement.text(), stored.text()));
         }
-        apply_part(ctx, id, part, placement.as_ref()).await?;
-        written.push(part.part());
+        apply_part(ctx, id, kind, part, placement.as_ref()).await?;
+        moved.push(part.part());
         if let Some(placement) = &placement {
-            written.push(placement.part());
+            moved.push(placement.part());
         }
     }
+
+    // A body reads what is stored and writes what changed in one step, because
+    // which blocks a body write touches is decided by the match between the two
+    // and cannot be asked before the write is prepared.
+    let mut changed_blocks = Vec::new();
+    if let Some(text) = &written.body {
+        let touch = body::apply(ctx, id, kind, text).await?;
+        touching.extend(touch.touching);
+        moved.extend(touch.written);
+        changed_blocks.extend(touch.changed);
+    }
+
+    refresh_search_text(ctx, id, kind).await?;
 
     // A stale base is never a rejection. What it can be is a conflict, and only
     // over the parts that actually overlap what moved since.
@@ -548,7 +623,7 @@ pub async fn edit(
         provenance::retain(ctx.tx, id, &retained, ctx.at).await?;
     }
 
-    provenance::record(ctx.tx, id, &written, counter, ctx.member).await?;
+    provenance::record(ctx.tx, id, &moved, counter, ctx.member).await?;
     sqlx::query("UPDATE entity SET counter = $2, updated_at = $3 WHERE id = $1")
         .bind(id.as_uuid())
         .bind(counter)
@@ -566,7 +641,7 @@ pub async fn edit(
             audience_after: Some(after),
             author_before: row.author,
             author_after: row.author,
-            changed_blocks: Vec::new(),
+            changed_blocks,
         },
     )
     .await?;
@@ -594,20 +669,19 @@ pub async fn edit(
 async fn recreate(
     ctx: &mut Ctx<'_>,
     tombstone: &EntityRow,
-    parts: Vec<PartWrite>,
+    mut written: Written,
 ) -> Applied<Outcome> {
     let new = EntityId::from_uuid(Uuid::new_v4());
-    let parts: Vec<PartWrite> = parts
-        .into_iter()
-        .filter(|p| !matches!(p, PartWrite::Audience(_)))
-        .collect();
+    written
+        .parts
+        .retain(|p| !matches!(p, PartWrite::Audience(_)));
 
     let outcome = create(
         ctx,
         new,
         Some(ctx.at),
         &tombstone.capture_method,
-        parts,
+        written,
         tombstone.entity_type,
     )
     .await?;
@@ -712,7 +786,7 @@ pub async fn restore(
         if let Some(category) = row.category_id {
             let next = crate::store::entity::next_category_position(ctx.tx, category).await?;
             let part = PartWrite::CategoryPosition(Some(next));
-            apply_part(ctx, row.id, &part, None).await?;
+            apply_part(ctx, row.id, row.entity_type, &part, None).await?;
             provenance::record(ctx.tx, row.id, &[part.part()], row.counter + 1, ctx.member).await?;
         }
 
@@ -811,7 +885,7 @@ pub async fn erase(ctx: &mut Ctx<'_>, ids: &[EntityId]) -> Applied<(Vec<EntityId
         // The side table, which holds what the type carries beyond the shared
         // model. Named by the row's own type rather than tried against all of
         // them, so a type gaining a table is one line here.
-        if let Some(table) = side_table(row.entity_type) {
+        if let Some(table) = specific::side_table(row.entity_type) {
             let sql = format!("DELETE FROM {table} WHERE entity_id = $1");
             sqlx::query(sqlx::AssertSqlSafe(sql))
                 .bind(id.as_uuid())
@@ -879,21 +953,4 @@ pub async fn erase(ctx: &mut Ctx<'_>, ids: &[EntityId]) -> Applied<(Vec<EntityId
     }
 
     Ok((erased, relations_gone))
-}
-
-fn side_table(kind: EntityType) -> Option<&'static str> {
-    match kind {
-        EntityType::Campaign => Some("campaign"),
-        EntityType::Arc => Some("arc"),
-        EntityType::Quest => Some("quest"),
-        EntityType::File => Some("file"),
-        EntityType::Item => Some("item"),
-        EntityType::Location => Some("location"),
-        EntityType::Category => Some("category"),
-        EntityType::Note
-        | EntityType::ShoppingList
-        | EntityType::Routine
-        | EntityType::FocusSession
-        | EntityType::CheckIn => None,
-    }
 }

--- a/crates/altaird/src/write/mod.rs
+++ b/crates/altaird/src/write/mod.rs
@@ -30,6 +30,7 @@
 //! same wait an unreachable instance produces, because to the person they are
 //! the same thing.
 
+pub mod body;
 pub mod changes;
 pub mod content;
 pub mod entity;
@@ -38,6 +39,7 @@ pub mod outcome;
 pub mod parts;
 pub mod provenance;
 pub mod relation;
+pub mod specific;
 
 use chrono::Utc;
 use sqlx::PgPool;
@@ -239,14 +241,14 @@ async fn act(ctx: &mut Ctx<'_>, intent: &v1::Intent) -> Result<Outcome, Failed> 
                     Refusal::Malformed("a create carries the content that says what it is".into())
                 })?;
                 let kind = entity_type(content)?;
-                let parts = parts_written(content)?;
+                let written = parts_written(content)?;
                 let id = EntityId::from_uuid(identifier(&e.entity_id)?);
                 // Absent is ordinary and means "the instance's clock". Present
                 // and unreadable is a malformed message, and it goes through the
                 // same parser a labelled date does — see `content::instant` for
                 // why the two used to disagree.
                 let created_at = e.created_at.as_ref().map(instant).transpose()?;
-                entity::create(ctx, id, created_at, &e.capture_method, parts, kind).await
+                entity::create(ctx, id, created_at, &e.capture_method, written, kind).await
             }
             Some(v1::create::Subject::Relation(r)) => {
                 let content = r.content.as_ref().ok_or_else(|| {
@@ -276,7 +278,7 @@ async fn act(ctx: &mut Ctx<'_>, intent: &v1::Intent) -> Result<Outcome, Failed> 
                     .as_ref()
                     .map(|_| entity_type(content))
                     .transpose()?;
-                let parts = parts_written(content)?;
+                let written = parts_written(content)?;
                 let id = EntityId::from_uuid(identifier(&e.entity_id)?);
                 // Clamping was worse than it looks. A base counter larger than
                 // any counter the store can hold reads as *current* against
@@ -289,7 +291,7 @@ async fn act(ctx: &mut Ctx<'_>, intent: &v1::Intent) -> Result<Outcome, Failed> 
                         "a base counter is a counter this instance could have issued".into(),
                     )
                 })?;
-                entity::edit(ctx, id, base, parts, stated).await
+                entity::edit(ctx, id, base, written, stated).await
             }
             Some(v1::edit::Subject::Relation(r)) => {
                 let content = r.content.as_ref().ok_or_else(|| {

--- a/crates/altaird/src/write/parts.rs
+++ b/crates/altaird/src/write/parts.rs
@@ -46,15 +46,19 @@ pub enum Part {
     /// differs per type and the type is fixed at creation, so a number is
     /// unambiguous once the entity exists.
     ///
-    /// Wave 2.1 writes no type content — the plan gives that to 2.2 — so
-    /// nothing produces one of these yet. The variant is here because the
-    /// store shape, the wire shape, and the round-trip test all have to
-    /// account for it, and adding it later would mean revisiting all three.
+    /// **Which numbers a type has is not decided here.** Each type declares its
+    /// own fields in [`super::specific`], and a number valid for one type is
+    /// not valid for another — a campaign's field 1 is a state and a location's
+    /// is a parent. This module holds only the spelling the two tables key it
+    /// by, which is the same whatever type it came from.
     Specific(u32),
     /// A block of a body. Named by identity rather than by position, because
     /// position is what an edit to a neighbour changes.
     ///
-    /// Also 2.2's, for the same reason: blocks arrive with bodies.
+    /// Produced by [`super::body`], which is the only thing that can: a body
+    /// arrives as one field and becomes many parts, and which blocks those are
+    /// is decided by matching the arriving text against the blocks already
+    /// stored.
     Block(Uuid),
 }
 

--- a/crates/altaird/src/write/specific/category.rs
+++ b/crates/altaird/src/write/specific/category.rs
@@ -1,0 +1,105 @@
+//! A category's type content: where it nests, and the audience it defaults.
+//!
+//! **LANE: Knowledge + categories owns this file.**
+//!
+//! # This file must not issue SQL, and the reason is a guard rather than taste
+//!
+//! The wire calls a category's creation default
+//! `creation_default_audience_member_ids`, which contains the store's audience
+//! column as a substring. `tests/one_predicate.rs` refuses any source outside
+//! `store/audience.rs` that both names that column and issues SQL, and it is
+//! right to: a paraphrased audience predicate is a second implementation
+//! whatever it is spelled like, and that is how a leak arrives in month four.
+//!
+//! This file legitimately names the wire field, because reading the wire is
+//! what it is for, and it has nothing to say about who can see anything — a
+//! creation default acts once, at the creation of an entity placed in this
+//! category, and is never a standing rule and never inherited. So the split is:
+//! **this file transcribes, and [`super::write_column`] and
+//! [`super::read_column`] run the query**, naming the column only through the
+//! `&'static str` in [`CATEGORY_FIELDS`], which is the store's own spelling and
+//! not the wire's.
+//!
+//! Add a bespoke query here and the guard fails on the next run. That is the
+//! guard working. Read its module documentation before deciding it is in the
+//! way.
+//!
+//! # What is not decided here
+//!
+//! **Cycle prevention in nested categories.** Migration one refuses
+//! self-reference and records a longer loop as its gap (h).
+//! [`super::nesting::would_cycle`] is the check, and it is written once because
+//! nested locations need exactly the same one.
+
+use altair_proto::v1;
+
+use crate::store::entity::EntityType;
+use crate::store::ids::EntityId;
+
+use super::super::content::{Malformed, Written};
+use super::super::entity::{Applied, Ctx, Refusal};
+use super::{Field, Held, SpecificPart, not_yet_built, unbuilt};
+
+pub const CATEGORY_FIELDS: &[Field] = &[
+    Field {
+        number: 1,
+        held: Held::Column("parent_category_id"),
+    },
+    Field {
+        number: 2,
+        held: Held::Column("creation_default_audience"),
+    },
+];
+
+/// A category's content, off the wire.
+///
+/// **LANE: Knowledge + categories.** Wave 2.1 already *reads* the creation
+/// default when it places a newly created entity, so filling this in is what
+/// makes that path reachable by anything other than a hand-written row.
+pub fn category(c: &v1::CategoryContent) -> Result<Written, Malformed> {
+    unbuilt(
+        EntityType::Category,
+        &c.cleared,
+        &[
+            (1, c.parent_category_id.is_some()),
+            (2, !c.creation_default_audience_member_ids.is_empty()),
+        ],
+    )
+}
+
+pub async fn validate_and_place(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    part: &SpecificPart,
+) -> Applied<Option<SpecificPart>> {
+    let _ = (ctx, entity, part);
+    Err(Refusal::Malformed(not_yet_built(EntityType::Category).0).into())
+}
+
+pub async fn current(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    part: &SpecificPart,
+) -> Applied<SpecificPart> {
+    let _ = (ctx, entity, part);
+    Err(Refusal::Malformed(not_yet_built(EntityType::Category).0).into())
+}
+
+pub async fn apply(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    part: &SpecificPart,
+    placement: Option<&SpecificPart>,
+) -> Applied<()> {
+    let _ = (ctx, entity, part, placement);
+    Err(Refusal::Malformed(not_yet_built(EntityType::Category).0).into())
+}
+
+/// A category contributes nothing to searchable text.
+///
+/// Its own title is the shared model's and is already searchable; what it holds
+/// is other entities, and each of those carries its own words.
+pub async fn search_text(ctx: &mut Ctx<'_>, entity: EntityId) -> Applied<Option<String>> {
+    let _ = (ctx, entity);
+    Ok(None)
+}

--- a/crates/altaird/src/write/specific/guidance.rs
+++ b/crates/altaird/src/write/specific/guidance.rs
@@ -1,0 +1,200 @@
+//! Guidance's type content: campaign, arc, quest.
+//!
+//! **LANE: Guidance owns this file.** Campaign's `state` is filled in as the
+//! spine's proof that a type-specific part reaches the store, conflicts, and
+//! comes back; arc and quest are declared and refused.
+//!
+//! # What is deliberately not here
+//!
+//! **The Guidance state machine.** Which transitions are legal, the silent
+//! upward `Waiting → Working` propagation when something beneath starts, and
+//! what a state means for the ladder are all the Guidance PRD's and the
+//! Guidance lane's. Nothing below checks a transition, and that is not an
+//! omission: the spine is proving that a value crosses the boundary intact, and
+//! a rule bolted on here would be a rule written by whoever was proving the
+//! plumbing.
+//!
+//! What is settled, and is the plumbing's own answer rather than the domain's:
+//! **clearing a state sets it to waiting**, because the column is
+//! `NOT NULL DEFAULT 'waiting'` and there is no state a campaign is not in. Two
+//! members arriving at waiting — one by setting it, one by clearing it —
+//! therefore compare equal rather than conflict, which is the substrate's rule
+//! that writes producing the same value are not divergent.
+
+use altair_proto::v1;
+
+use crate::store::entity::EntityType;
+use crate::store::ids::EntityId;
+
+use super::super::content::{Malformed, Written};
+use super::super::entity::{Applied, Ctx, Refusal};
+use super::{
+    Field, GuidanceState, Held, Reader, SpecificPart, SpecificValue, not_yet_built, read_column,
+    unbuilt, write_column,
+};
+
+/// Campaign's field 1, its state. The only part a campaign carries.
+pub const CAMPAIGN_STATE: u32 = 1;
+
+pub const CAMPAIGN_FIELDS: &[Field] = &[Field {
+    number: CAMPAIGN_STATE,
+    held: Held::Column("state"),
+}];
+
+pub const ARC_FIELDS: &[Field] = &[
+    Field {
+        number: 1,
+        held: Held::Column("state"),
+    },
+    Field {
+        number: 2,
+        held: Held::Column("campaign_id"),
+    },
+    Field {
+        number: 3,
+        held: Held::Column("ladder_position"),
+    },
+];
+
+pub const QUEST_FIELDS: &[Field] = &[
+    Field {
+        number: 1,
+        held: Held::Column("state"),
+    },
+    Field {
+        number: 2,
+        held: Held::Column("arc_id"),
+    },
+    Field {
+        number: 3,
+        held: Held::Column("campaign_id"),
+    },
+    Field {
+        number: 4,
+        held: Held::Column("routine_id"),
+    },
+    Field {
+        number: 5,
+        held: Held::Column("ladder_position"),
+    },
+];
+
+/// A campaign's content, off the wire.
+pub fn campaign(c: &v1::CampaignContent) -> Result<Written, Malformed> {
+    let read = Reader::new(EntityType::Campaign, &c.cleared)?;
+    let mut parts = Vec::new();
+    read.singular(&mut parts, CAMPAIGN_STATE, c.state, |v| {
+        Ok(SpecificValue::State(match v {
+            Some(number) => GuidanceState::from_wire(number)?,
+            None => GuidanceState::DEFAULT,
+        }))
+    })?;
+    Ok(Written::from_specific(parts))
+}
+
+/// An arc's content, off the wire.
+///
+/// **LANE: Guidance.** The campaign it hangs beneath and its position on the
+/// ladder are here, and the ladder is a container the shared model does not
+/// cover: entering one appends, exactly as entering a category does, which is
+/// why `campaign_id` and `ladder_position` must move in one statement — the
+/// table's `CHECK ((campaign_id IS NULL) = (ladder_position IS NULL))` refuses
+/// the state in between. [`validate_and_place`] is where that companion is
+/// produced.
+pub fn arc(c: &v1::ArcContent) -> Result<Written, Malformed> {
+    unbuilt(
+        EntityType::Arc,
+        &c.cleared,
+        &[
+            (1, c.state.is_some()),
+            (2, c.campaign_id.is_some()),
+            (3, c.ladder_position.is_some()),
+        ],
+    )
+}
+
+/// A quest's content, off the wire.
+///
+/// **LANE: Guidance.** At most one ladder parent in total, an arc or a
+/// campaign, never both — the wire says so with a `oneof` and the table says so
+/// with `CHECK (num_nonnulls(arc_id, campaign_id) <= 1)`. Moving between them
+/// clears the other, and both move with `ladder_position`.
+pub fn quest(c: &v1::QuestContent) -> Result<Written, Malformed> {
+    unbuilt(
+        EntityType::Quest,
+        &c.cleared,
+        &[
+            (1, c.state.is_some()),
+            (
+                2,
+                matches!(c.parent, Some(v1::quest_content::Parent::ArcId(_))),
+            ),
+            (
+                3,
+                matches!(c.parent, Some(v1::quest_content::Parent::CampaignId(_))),
+            ),
+            (4, c.routine_id.is_some()),
+            (5, c.ladder_position.is_some()),
+        ],
+    )
+}
+
+pub async fn validate_and_place(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+) -> Applied<Option<SpecificPart>> {
+    let _ = (ctx, entity);
+    match (kind, part.field) {
+        // A state owes nothing before it is written. Whether the transition is
+        // legal is the Guidance lane's question and is deliberately not asked
+        // here; see the note at the head of this module.
+        (EntityType::Campaign, CAMPAIGN_STATE) => Ok(None),
+        _ => Err(Refusal::Malformed(not_yet_built(kind).0).into()),
+    }
+}
+
+pub async fn current(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+) -> Applied<SpecificPart> {
+    match (kind, part.field) {
+        (EntityType::Campaign, CAMPAIGN_STATE) => read_column(ctx, entity, kind, part).await,
+        _ => Err(Refusal::Malformed(not_yet_built(kind).0).into()),
+    }
+}
+
+pub async fn apply(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+    placement: Option<&SpecificPart>,
+) -> Applied<()> {
+    match (kind, part.field) {
+        (EntityType::Campaign, CAMPAIGN_STATE) => {
+            // A campaign has no companion part, so there is nothing to write
+            // alongside. An arc's or a quest's ladder position will be one.
+            debug_assert!(placement.is_none());
+            write_column(ctx, entity, kind, part).await
+        }
+        _ => Err(Refusal::Malformed(not_yet_built(kind).0).into()),
+    }
+}
+
+/// Guidance contributes nothing to searchable text.
+///
+/// A state is a value rather than words, and the ladder's shape is reachable
+/// through relations. **LANE: Guidance** — if that turns out to be wrong, this
+/// is the seam, and nothing in `entity.rs` needs reopening to use it.
+pub async fn search_text(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+) -> Applied<Option<String>> {
+    let _ = (ctx, entity, kind);
+    Ok(None)
+}

--- a/crates/altaird/src/write/specific/knowledge.rs
+++ b/crates/altaird/src/write/specific/knowledge.rs
@@ -1,0 +1,144 @@
+//! Knowledge's type content: note, file.
+//!
+//! **LANE: Knowledge owns this file.**
+//!
+//! A note is the one type whose whole content is a body, and a body is not a
+//! part: it divides into blocks and each block is a part of its own. So the
+//! wire reading below produces a [`BodyWrite`] rather than a
+//! [`SpecificPart`], and everything downstream of it lives in
+//! [`super::super::body`] — division, matching against the blocks already held,
+//! and writing only what changed. That split is deliberate: reading the wire
+//! needs no store and the matching needs nothing else.
+//!
+//! A file's content waits on Wave 2.3 in full, because Wave 2.1 refuses a file
+//! create for a reason that has not expired: the schema requires a file to name
+//! a body and there is no way to have uploaded one.
+
+use altair_proto::v1;
+
+use crate::store::entity::EntityType;
+use crate::store::ids::EntityId;
+
+use super::super::content::{BodyWrite, Malformed, Written};
+use super::super::entity::{Applied, Ctx, Refusal};
+use super::{Addressed, Field, Held, Reader, SpecificPart, not_yet_built, unbuilt};
+
+/// A note's field 1, its body.
+pub const NOTE_BODY: u32 = 1;
+
+pub const NOTE_FIELDS: &[Field] = &[Field {
+    number: NOTE_BODY,
+    held: Held::Body,
+}];
+
+pub const FILE_FIELDS: &[Field] = &[
+    Field {
+        number: 1,
+        held: Held::Column("body_id"),
+    },
+    Field {
+        number: 2,
+        held: Held::Column("media_type"),
+    },
+    // A person's correction to extracted text, which has nothing to correct.
+    // `altair-v0-scope.md` defers text extraction from files, and that document
+    // governs the implementation plan where the two disagree.
+    Field {
+        number: 3,
+        held: Held::NotServed(
+            "text extraction from files is deferred in v0, so there is no extracted text for a \
+             correction to outrank",
+        ),
+    },
+];
+
+/// A note's content, off the wire.
+///
+/// The whole body arrives as one field, plain markdown with no relation markers
+/// in it, and the instance divides it — DR-004, so the division rule has one
+/// implementation and devices cannot disagree about the units reconciliation is
+/// decided in. Nothing here divides anything; it says only that a body arrived
+/// and what it says.
+pub fn note(c: &v1::NoteContent) -> Result<Written, Malformed> {
+    let read = Reader::new(EntityType::Note, &c.cleared)?;
+    let body = match read.addressed(NOTE_BODY, c.body.is_some())? {
+        Addressed::Set => Some(BodyWrite(c.body.clone())),
+        // Clearing a body is a body of no text, which divides into no blocks.
+        // Distinct from an untouched body, which says nothing about the blocks
+        // already held.
+        Addressed::Cleared => Some(BodyWrite(None)),
+        Addressed::Untouched => None,
+    };
+    Ok(Written {
+        parts: Vec::new(),
+        body,
+    })
+}
+
+/// A file's content, off the wire.
+///
+/// **LANE: 2.3, file bodies.** `body_id` names bytes already uploaded through
+/// `PutBody`; until that call is served there is no identity to name, which is
+/// why 2.1 refuses a file create outright. The column is `NOT NULL`, so
+/// clearing it is not a thing an edit can do and this module must say so rather
+/// than letting the store raise a fault.
+pub fn file(c: &v1::FileContent) -> Result<Written, Malformed> {
+    unbuilt(
+        EntityType::File,
+        &c.cleared,
+        &[
+            (1, c.body_id.is_some()),
+            (2, c.media_type.is_some()),
+            (3, c.extracted_text.is_some()),
+        ],
+    )
+}
+
+pub async fn validate_and_place(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+) -> Applied<Option<SpecificPart>> {
+    let _ = (ctx, entity, part);
+    // A note addresses no part at all — its content is its body — so anything
+    // reaching here is a file's, and a file's content is 2.3's.
+    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+}
+
+pub async fn current(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+) -> Applied<SpecificPart> {
+    let _ = (ctx, entity, part);
+    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+}
+
+pub async fn apply(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+    placement: Option<&SpecificPart>,
+) -> Applied<()> {
+    let _ = (ctx, entity, part, placement);
+    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+}
+
+/// What Knowledge contributes to searchable text.
+///
+/// **LANE: Knowledge.** A note's words are the obvious candidate and they are
+/// deliberately not taken here: a body's blocks are written by
+/// [`super::super::body`], which this lane also fills, and taking half the
+/// answer now would settle the shape of the other half. Contributing nothing is
+/// a valid answer, and the literal arm still finds a note by its title.
+pub async fn search_text(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+) -> Applied<Option<String>> {
+    let _ = (ctx, entity, kind);
+    Ok(None)
+}

--- a/crates/altaird/src/write/specific/mod.rs
+++ b/crates/altaird/src/write/specific/mod.rs
@@ -1,0 +1,886 @@
+//! Type-specific content: what each type is made of beyond the shared model.
+//!
+//! # What this module is
+//!
+//! **The dispatch, and the vocabulary the dispatch is written in.** Every
+//! entity type has an arm here, and every arm points at a module that owns one
+//! domain's types. A lane building a domain fills in its own module and touches
+//! nothing else — not this file, not [`super::content`], not [`super::entity`].
+//! That is the whole reason this file exists: the alternative is four lanes
+//! editing the same three files, and the merge is where a type quietly loses
+//! its arm.
+//!
+//! # Why a field number and a value, rather than a message
+//!
+//! A write is scoped to the part that changed, and the substrate decides a
+//! conflict at that grain. A type's message is not a part; each of its fields
+//! is. So the wire's message is read once, into a list of
+//! [`SpecificPart`]s, and everything downstream — provenance, conflict
+//! detection, the acknowledgement — deals only in a number and a value. See
+//! [`super::parts`] for why the number rather than the name.
+//!
+//! # Every value crosses as text
+//!
+//! Both retained sides of a conflict are text whatever the part's kind is (the
+//! proto's gap (g), the schema's gap (c)). So every value kind here renders
+//! through [`SpecificValue::text`], one arm per kind, and the *same* function
+//! renders an arriving value and a stored one. That is what makes *writes
+//! producing the same value are not divergent* a comparison rather than a hope.
+//!
+//! # What a lane implements
+//!
+//! Six items, all of them in the lane's own module:
+//!
+//! - `*_FIELDS` — the field numbers the type's message addresses, each saying
+//!   where the store holds it. Declared here already, for every type, because
+//!   the mapping is the boundary rather than the behaviour and
+//!   `tests/write_parts.rs` checks it now.
+//! - one reader per message — the wire's set/cleared/untouched rule, applied
+//!   through [`Reader`] so the two refusals it owes are not re-derived.
+//! - `validate_and_place` — what the part owes before it is applied, and any
+//!   companion part the instance moves as a consequence.
+//! - `current` — the value the store holds, rendered by the same code.
+//! - `apply` — the write.
+//! - `search_text` — what the type contributes to the entity's searchable text
+//!   beyond its title. Contributing nothing is a valid answer.
+
+pub mod category;
+pub mod guidance;
+pub mod knowledge;
+pub mod nesting;
+pub mod tracking;
+
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+use uuid::Uuid;
+
+use altair_proto::v1;
+
+use crate::store::entity::EntityType;
+use crate::store::ids::EntityId;
+
+use super::content::{Malformed, Written, malformed};
+use super::entity::{Applied, Ctx, Refusal};
+
+// ---------------------------------------------------------------------------
+// What a type-specific field is
+// ---------------------------------------------------------------------------
+
+/// One field of a type's message, as this instance knows it.
+///
+/// The list of these per type is what makes *a cleared number naming no field
+/// of this type* refusable, and it is what `tests/write_parts.rs` walks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Field {
+    /// The field number in the type's own message. Permanent, per DR-004.
+    pub number: u32,
+    /// Where the store keeps it.
+    pub held: Held,
+}
+
+/// Where the store keeps a type-specific field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Held {
+    /// A column of the type's side table. [`write_column`] and [`read_column`]
+    /// serve these generically, so a module naming one need issue no SQL.
+    Column(&'static str),
+    /// The blocks of a body. Not a column and not one part: a body divides,
+    /// and each block is a part of its own. See [`super::body`].
+    Body,
+    /// Rows of a table keyed by the entity. Property values are the only shape
+    /// like this; [`read_properties`] and [`write_properties`] serve them.
+    Rows(&'static str),
+    /// Named by the wire and deliberately not served, with the reason.
+    ///
+    /// **An expiring refusal, in the register of the three Wave 2.1 already
+    /// makes.** The field exists on the wire and will exist forever — field
+    /// numbers are permanent — so pretending it is not a field of this type
+    /// would tell a client the wrong thing. Addressing it is refused as
+    /// malformed with this text as the detail.
+    NotServed(&'static str),
+}
+
+/// The field a number names within one type's message.
+#[must_use]
+pub fn field(kind: EntityType, number: u32) -> Option<Field> {
+    fields(kind).iter().copied().find(|f| f.number == number)
+}
+
+/// Every field of one type's message.
+///
+/// **A field number valid for one type is not valid for another.** Campaign's
+/// field 1 is a state and a location's field 1 is a parent; validating a
+/// cleared number against the wrong type would accept a clear the type has no
+/// field for.
+#[must_use]
+pub fn fields(kind: EntityType) -> &'static [Field] {
+    match kind {
+        EntityType::Campaign => guidance::CAMPAIGN_FIELDS,
+        EntityType::Arc => guidance::ARC_FIELDS,
+        EntityType::Quest => guidance::QUEST_FIELDS,
+        EntityType::Note => knowledge::NOTE_FIELDS,
+        EntityType::File => knowledge::FILE_FIELDS,
+        EntityType::Item => tracking::ITEM_FIELDS,
+        EntityType::Location => tracking::LOCATION_FIELDS,
+        EntityType::ShoppingList => tracking::SHOPPING_LIST_FIELDS,
+        EntityType::Category => category::CATEGORY_FIELDS,
+        // The schema deliberately creates no table for these and the scope
+        // defers each until its domain is designed. Their messages reserve
+        // 1..=20 and address nothing.
+        EntityType::Routine | EntityType::FocusSession | EntityType::CheckIn => &[],
+    }
+}
+
+/// The table a type keeps its content in, beyond the `entity` row.
+///
+/// **`None` is a result rather than an omission** for a note and a shopping
+/// list: a body is its blocks in order and there is nothing else for a row to
+/// hold. The three deferred types have no table because the schema creates
+/// none.
+///
+/// Named here rather than beside each of its three callers — the create that
+/// makes the row, the erase that removes it, and the column helpers below —
+/// so that a type gaining a table is one line.
+#[must_use]
+pub fn side_table(kind: EntityType) -> Option<&'static str> {
+    match kind {
+        EntityType::Campaign => Some("campaign"),
+        EntityType::Arc => Some("arc"),
+        EntityType::Quest => Some("quest"),
+        EntityType::File => Some("file"),
+        EntityType::Item => Some("item"),
+        EntityType::Location => Some("location"),
+        EntityType::Category => Some("category"),
+        EntityType::Note
+        | EntityType::ShoppingList
+        | EntityType::Routine
+        | EntityType::FocusSession
+        | EntityType::CheckIn => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Values
+// ---------------------------------------------------------------------------
+
+/// One type-specific part: which field, and the value a write is setting it to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpecificPart {
+    /// The field number in the type's message.
+    pub field: u32,
+    pub value: SpecificValue,
+}
+
+impl SpecificPart {
+    /// The text this value is retained as when it is one side of a conflict.
+    #[must_use]
+    pub fn text(&self) -> Option<String> {
+        self.value.text()
+    }
+}
+
+/// The kinds of value a type-specific field can hold.
+///
+/// One enum rather than one per type, because everything downstream of the
+/// read — provenance, conflict detection, the acknowledgement — is written once
+/// and must not grow a branch per type. A kind is added here when a type needs
+/// one the store cannot already hold.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpecificValue {
+    Text(Option<String>),
+    Id(Option<Uuid>),
+    Count(Option<i32>),
+    Number(Option<Decimal>),
+    Instant(Option<DateTime<Utc>>),
+    /// **Not optional, because the column is not.** A guidance state is
+    /// `NOT NULL DEFAULT 'waiting'`, so clearing the field is setting it back
+    /// to waiting rather than to nothing. [`Reader`] resolves a clear to that
+    /// default at read time, which is what makes two members arriving at
+    /// waiting — one by setting it, one by clearing it — compare equal rather
+    /// than conflict.
+    State(GuidanceState),
+    Members(Vec<Uuid>),
+    Properties(Vec<Property>),
+}
+
+/// A property value as the person stated it. A kind is not a constraint, so
+/// the value crosses as text and nothing interprets it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Property {
+    pub name: String,
+    pub value: String,
+}
+
+/// The state a piece of guidance is in, as the store's enum names them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuidanceState {
+    Waiting,
+    Working,
+    Worked,
+}
+
+impl GuidanceState {
+    /// What the column holds when nothing has said otherwise.
+    pub const DEFAULT: Self = Self::Waiting;
+
+    /// The spelling of the store's `guidance_state` enum.
+    #[must_use]
+    pub fn store_name(self) -> &'static str {
+        match self {
+            Self::Waiting => "waiting",
+            Self::Working => "working",
+            Self::Worked => "worked",
+        }
+    }
+
+    /// The inverse, for reading a column back.
+    #[must_use]
+    pub fn from_store_name(name: &str) -> Option<Self> {
+        match name {
+            "waiting" => Some(Self::Waiting),
+            "working" => Some(Self::Working),
+            "worked" => Some(Self::Worked),
+            _ => None,
+        }
+    }
+
+    /// The state the wire named.
+    ///
+    /// `UNSPECIFIED` on a field that is present is a message that cannot be
+    /// read: the field says a state was stated and then names none. Absent is
+    /// how "untouched" is said, and it never reaches here.
+    pub fn from_wire(number: i32) -> Result<Self, Malformed> {
+        match v1::GuidanceState::try_from(number) {
+            Ok(v1::GuidanceState::Waiting) => Ok(Self::Waiting),
+            Ok(v1::GuidanceState::Working) => Ok(Self::Working),
+            Ok(v1::GuidanceState::Worked) => Ok(Self::Worked),
+            _ => Err(malformed(
+                "a guidance state that is present names one of waiting, working, or worked",
+            )),
+        }
+    }
+}
+
+/// An exact decimal, as the wire carries one and as the store's `numeric`
+/// holds it.
+///
+/// Binary floating point is the wrong place to put a household's stock, which
+/// the proto says and gives the reason for. Kept as the wire's own two numbers
+/// so nothing rounds on the way through, and rendered to text for both the
+/// store and the conflict row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Decimal {
+    pub units: i64,
+    /// A billionth. Carries the same sign as `units`, as a duration does.
+    pub nanos: i32,
+}
+
+/// A nanos outside this is not a fraction of one.
+const NANOS_LIMIT: i32 = 1_000_000_000;
+
+impl Decimal {
+    /// The decimal the wire carried.
+    ///
+    /// **Refused rather than absorbed**, which is the schema's owed check
+    /// *everything the wire shape implies: identifier length, decimal range*.
+    /// A nanos of two billion is not a large fraction and units and nanos
+    /// disagreeing about sign name no number at all; either is a message that
+    /// cannot be read, and clamping one would store something the client never
+    /// sent.
+    pub fn from_wire(d: &v1::Decimal) -> Result<Self, Malformed> {
+        if d.nanos <= -NANOS_LIMIT || d.nanos >= NANOS_LIMIT {
+            return Err(malformed("a decimal's nanos are a fraction of one unit"));
+        }
+        if (d.units > 0 && d.nanos < 0) || (d.units < 0 && d.nanos > 0) {
+            return Err(malformed(
+                "a decimal's units and nanos carry the same sign, as a duration does",
+            ));
+        }
+        Ok(Self {
+            units: d.units,
+            nanos: d.nanos,
+        })
+    }
+
+    /// The decimal a `numeric` column reads back as.
+    ///
+    /// Refuses a value with more precision than the wire can carry. Nothing can
+    /// put one there through this path, so this is honesty about a value that
+    /// arrived some other way rather than a case that is expected.
+    pub fn parse(text: &str) -> Result<Self, Malformed> {
+        let bad = || malformed(format!("`{text}` is not a decimal this instance can carry"));
+        let (negative, rest) = match text.strip_prefix('-') {
+            Some(rest) => (true, rest),
+            None => (false, text.strip_prefix('+').unwrap_or(text)),
+        };
+        let (whole, fraction) = rest.split_once('.').unwrap_or((rest, ""));
+        if fraction.len() > 9 {
+            return Err(bad());
+        }
+        let units: i64 = whole.parse().map_err(|_| bad())?;
+        let mut padded = fraction.to_owned();
+        while padded.len() < 9 {
+            padded.push('0');
+        }
+        let nanos: i32 = if padded.is_empty() {
+            0
+        } else {
+            padded.parse().map_err(|_| bad())?
+        };
+        Ok(Self {
+            units: if negative { -units } else { units },
+            nanos: if negative { -nanos } else { nanos },
+        })
+    }
+
+    /// The one rendering, used for the store and for a conflict row alike.
+    #[must_use]
+    pub fn text(&self) -> String {
+        let sign = if self.units < 0 || self.nanos < 0 {
+            "-"
+        } else {
+            ""
+        };
+        format!(
+            "{sign}{}.{:09}",
+            self.units.unsigned_abs(),
+            self.nanos.unsigned_abs()
+        )
+    }
+}
+
+/// The separators a composite value is rendered with.
+///
+/// The same two [`super::content`] uses for a labelled date, because a
+/// composite value is a composite value and two spellings of the same idea is
+/// how a comparison starts returning the wrong answer.
+const WITHIN: char = '\u{1f}';
+const BETWEEN: char = '\u{1e}';
+
+impl SpecificValue {
+    /// The text this value is retained as when it is one side of a conflict.
+    ///
+    /// `None` means the part holds nothing — cleared, or never set — which is
+    /// distinct from holding the empty string.
+    #[must_use]
+    pub fn text(&self) -> Option<String> {
+        match self {
+            Self::Text(v) => v.clone(),
+            Self::Id(v) => v.map(|id| id.to_string()),
+            Self::Count(v) => v.map(|n| n.to_string()),
+            Self::Number(v) => v.as_ref().map(Decimal::text),
+            Self::Instant(v) => v.map(|t| t.to_rfc3339()),
+            Self::State(v) => Some(v.store_name().to_owned()),
+            // Sorted, so that two clients listing the same members in different
+            // orders are not read as disagreeing. A set has no order and the
+            // wire carries it as a list.
+            Self::Members(v) => (!v.is_empty()).then(|| {
+                let mut ids: Vec<String> = v.iter().map(ToString::to_string).collect();
+                ids.sort_unstable();
+                ids.join(",")
+            }),
+            // Sorted by name for the same reason. The name is the key the store
+            // holds them under, so the order the wire listed them in carries
+            // nothing.
+            Self::Properties(v) => (!v.is_empty()).then(|| {
+                let mut sorted = v.clone();
+                sorted.sort();
+                sorted
+                    .iter()
+                    .map(|p| format!("{}{WITHIN}{}", p.name, p.value))
+                    .collect::<Vec<_>>()
+                    .join(&BETWEEN.to_string())
+            }),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reading one type's message
+// ---------------------------------------------------------------------------
+
+/// Whether and how a message addresses one of its fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Addressed {
+    Set,
+    Cleared,
+    Untouched,
+}
+
+/// The set / cleared / untouched rule, one level down.
+///
+/// The wire's rule is the same in a type's message as it is in
+/// `EntityContent`, and so are the two refusals it owes — **a field both
+/// present and cleared**, and **a cleared number naming no field** — so they
+/// are written once here rather than nine times in the modules below.
+///
+/// The second refusal is validated **against the type actually present**, not
+/// against some union of every type's numbers. Campaign's field 1 is a state
+/// and a location's is a parent; a shared list would accept a clear for a
+/// field the type does not have.
+pub struct Reader {
+    kind: EntityType,
+    cleared: Vec<u32>,
+}
+
+impl Reader {
+    /// Reads a type's message, refusing a cleared number that names no field
+    /// of it.
+    pub fn new(kind: EntityType, cleared: &[u32]) -> Result<Self, Malformed> {
+        for number in cleared {
+            if field(kind, *number).is_none() {
+                return Err(malformed(format!(
+                    "cleared names field {number}, which is not a part of this type"
+                )));
+            }
+        }
+        Ok(Self {
+            kind,
+            cleared: cleared.to_vec(),
+        })
+    }
+
+    /// Whether the message addresses a field, and how.
+    ///
+    /// `present` is what the wire says: `Some` for a singular field, non-empty
+    /// for a repeated one. Both refusals happen here.
+    pub fn addressed(&self, number: u32, present: bool) -> Result<Addressed, Malformed> {
+        let listed = self.cleared.contains(&number);
+        if present && listed {
+            return Err(malformed(format!(
+                "field {number} is both present and listed as cleared"
+            )));
+        }
+        let addressed = match (present, listed) {
+            (true, _) => Addressed::Set,
+            (false, true) => Addressed::Cleared,
+            (false, false) => Addressed::Untouched,
+        };
+        // A field the wire names and this instance does not serve. The refusal
+        // carries the reason the declaration gives, so a client is told what it
+        // is waiting on rather than that its message was wrong.
+        if addressed != Addressed::Untouched
+            && let Some(Field {
+                held: Held::NotServed(why),
+                ..
+            }) = field(self.kind, number)
+        {
+            return Err(malformed(why));
+        }
+        Ok(addressed)
+    }
+
+    /// A singular field, read into the value the store will hold.
+    ///
+    /// `value` is handed the wire's value where the field is set and `None`
+    /// where it is cleared, so one closure covers both and a clear cannot
+    /// quietly mean something different from an absent value.
+    pub fn singular<T>(
+        &self,
+        into: &mut Vec<SpecificPart>,
+        number: u32,
+        present: Option<T>,
+        value: impl FnOnce(Option<T>) -> Result<SpecificValue, Malformed>,
+    ) -> Result<(), Malformed> {
+        let part = match self.addressed(number, present.is_some())? {
+            Addressed::Set => value(present)?,
+            Addressed::Cleared => value(None)?,
+            Addressed::Untouched => return Ok(()),
+        };
+        into.push(SpecificPart {
+            field: number,
+            value: part,
+        });
+        Ok(())
+    }
+
+    /// A repeated field, where emptied is how it is cleared.
+    pub fn repeated<T>(
+        &self,
+        into: &mut Vec<SpecificPart>,
+        number: u32,
+        present: &[T],
+        value: impl FnOnce(&[T]) -> Result<SpecificValue, Malformed>,
+    ) -> Result<(), Malformed> {
+        let part = match self.addressed(number, !present.is_empty())? {
+            Addressed::Set => value(present)?,
+            Addressed::Cleared => value(&[])?,
+            Addressed::Untouched => return Ok(()),
+        };
+        into.push(SpecificPart {
+            field: number,
+            value: part,
+        });
+        Ok(())
+    }
+}
+
+/// A type whose content this build does not write yet.
+///
+/// `present` is every field of the type's message paired with whether the wire
+/// carries it. The cleared list is still validated and a field the type does
+/// not serve still refuses with its own reason, because both of those are true
+/// whether or not the type is built — a deferral has a reason and *not built*
+/// is not it.
+///
+/// A message addressing nothing is accepted and writes nothing, which is what
+/// keeps a bare create of every type working exactly as Wave 2.1 left it.
+pub fn unbuilt(
+    kind: EntityType,
+    cleared: &[u32],
+    present: &[(u32, bool)],
+) -> Result<Written, Malformed> {
+    let read = Reader::new(kind, cleared)?;
+    let mut addresses = false;
+    for (number, is_present) in present {
+        if read.addressed(*number, *is_present)? != Addressed::Untouched {
+            addresses = true;
+        }
+    }
+    if addresses {
+        return Err(not_yet_built(kind));
+    }
+    Ok(Written::default())
+}
+
+/// The refusal a type whose content is not built yet makes.
+///
+/// **Distinguishable on purpose.** A stub that silently accepted a write would
+/// tell a client its content had landed when nothing had, and the lane filling
+/// the module would have no failing test to turn green.
+/// `tests/type_content.rs` asserts this is what an unfilled type does.
+pub fn not_yet_built(kind: EntityType) -> Malformed {
+    malformed(format!(
+        "the content of a {} is not built yet, so this instance will not pretend to have \
+         written it",
+        crate::write::entity::type_name(kind)
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// The dispatch
+// ---------------------------------------------------------------------------
+
+/// Every part `content.specific` addresses, and the body it carries.
+///
+/// **Every type has an arm.** A lane fills in the function its arm points at
+/// and never edits this match, which is what keeps four parallel lanes off one
+/// file.
+pub fn parts_written(specific: &v1::entity_content::Specific) -> Result<Written, Malformed> {
+    use v1::entity_content::Specific;
+    match specific {
+        Specific::Campaign(c) => guidance::campaign(c),
+        Specific::Arc(c) => guidance::arc(c),
+        Specific::Quest(c) => guidance::quest(c),
+        Specific::Note(c) => knowledge::note(c),
+        Specific::File(c) => knowledge::file(c),
+        Specific::Item(c) => tracking::item(c),
+        Specific::Location(c) => tracking::location(c),
+        Specific::ShoppingList(c) => tracking::shopping_list(c),
+        Specific::Category(c) => category::category(c),
+        // The three the schema has no table for. Their messages reserve every
+        // number they will ever use and address nothing, so there is nothing to
+        // read; a create of one is refused where the row would be made.
+        Specific::Routine(_) | Specific::FocusSession(_) | Specific::CheckIn(_) => {
+            Ok(Written::default())
+        }
+    }
+}
+
+/// What a type-specific part owes before it is applied, and the companion part
+/// the instance moves as a consequence.
+///
+/// The companion exists for the same reason the shared model's does: a
+/// container and a position within it are constrained together, so writing them
+/// in sequence puts the row through a state the schema refuses.
+pub async fn validate_and_place(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+) -> Applied<Option<SpecificPart>> {
+    match kind {
+        EntityType::Campaign | EntityType::Arc | EntityType::Quest => {
+            guidance::validate_and_place(ctx, entity, kind, part).await
+        }
+        EntityType::Note | EntityType::File => {
+            knowledge::validate_and_place(ctx, entity, kind, part).await
+        }
+        EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
+            tracking::validate_and_place(ctx, entity, kind, part).await
+        }
+        EntityType::Category => category::validate_and_place(ctx, entity, part).await,
+        EntityType::Routine | EntityType::FocusSession | EntityType::CheckIn => {
+            Err(Refusal::Malformed(not_yet_built(kind).0).into())
+        }
+    }
+}
+
+/// The value the store holds for a part, rendered by the same code the arriving
+/// value goes through.
+pub async fn current(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+) -> Applied<SpecificPart> {
+    match kind {
+        EntityType::Campaign | EntityType::Arc | EntityType::Quest => {
+            guidance::current(ctx, entity, kind, part).await
+        }
+        EntityType::Note | EntityType::File => knowledge::current(ctx, entity, kind, part).await,
+        EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
+            tracking::current(ctx, entity, kind, part).await
+        }
+        EntityType::Category => category::current(ctx, entity, part).await,
+        EntityType::Routine | EntityType::FocusSession | EntityType::CheckIn => {
+            Err(Refusal::Malformed(not_yet_built(kind).0).into())
+        }
+    }
+}
+
+/// Apply one type-specific part.
+///
+/// `placement` is whatever [`validate_and_place`] returned, passed through so a
+/// module can write a field and its companion in one statement.
+pub async fn apply(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+    placement: Option<&SpecificPart>,
+) -> Applied<()> {
+    match kind {
+        EntityType::Campaign | EntityType::Arc | EntityType::Quest => {
+            guidance::apply(ctx, entity, kind, part, placement).await
+        }
+        EntityType::Note | EntityType::File => {
+            knowledge::apply(ctx, entity, kind, part, placement).await
+        }
+        EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
+            tracking::apply(ctx, entity, kind, part, placement).await
+        }
+        EntityType::Category => category::apply(ctx, entity, part, placement).await,
+        EntityType::Routine | EntityType::FocusSession | EntityType::CheckIn => {
+            Err(Refusal::Malformed(not_yet_built(kind).0).into())
+        }
+    }
+}
+
+/// What a type contributes to the entity's searchable text, beyond its title.
+///
+/// **Contributing nothing is a valid answer and the common one**, so this is
+/// not a stub that refuses. `search_text` is maintained by the write path
+/// because a type's content lives in a side table and a generated column
+/// cannot reach it; this is the seam a lane fills without reopening
+/// [`super::entity`].
+pub async fn search_text(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+) -> Applied<Option<String>> {
+    match kind {
+        EntityType::Campaign | EntityType::Arc | EntityType::Quest => {
+            guidance::search_text(ctx, entity, kind).await
+        }
+        EntityType::Note | EntityType::File => knowledge::search_text(ctx, entity, kind).await,
+        EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
+            tracking::search_text(ctx, entity, kind).await
+        }
+        EntityType::Category => category::search_text(ctx, entity).await,
+        EntityType::Routine | EntityType::FocusSession | EntityType::CheckIn => Ok(None),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reading and writing a column, generically
+// ---------------------------------------------------------------------------
+
+/// The column a field is held in, or a refusal saying why it is not one.
+fn column_of(kind: EntityType, part: &SpecificPart) -> Applied<(&'static str, &'static str)> {
+    let table = side_table(kind).ok_or_else(|| Refusal::Malformed(not_yet_built(kind).0))?;
+    match field(kind, part.field) {
+        Some(Field {
+            held: Held::Column(column),
+            ..
+        }) => Ok((table, column)),
+        Some(Field {
+            held: Held::NotServed(why),
+            ..
+        }) => Err(Refusal::Malformed(why.to_owned()).into()),
+        _ => Err(Refusal::Malformed(format!(
+            "field {} is not held in a column of this type's table",
+            part.field
+        ))
+        .into()),
+    }
+}
+
+/// The cast a value's kind needs on its way into a column.
+///
+/// Two kinds do not bind as themselves. A guidance state is an enum the driver
+/// has no type for from a string, and a decimal is carried as text so nothing
+/// rounds on the way through.
+fn cast(value: &SpecificValue) -> &'static str {
+    match value {
+        SpecificValue::State(_) => "::guidance_state",
+        SpecificValue::Number(_) => "::numeric",
+        _ => "",
+    }
+}
+
+/// Write one value into one column of a type's side table.
+///
+/// **A module that names an audience-shaped wire field must use this rather
+/// than issuing its own SQL** — see the note at the head of [`category`].
+pub async fn write_column(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+) -> Applied<()> {
+    let (table, column) = column_of(kind, part)?;
+    let sql = format!(
+        "UPDATE {table} SET {column} = $2{} WHERE entity_id = $1",
+        cast(&part.value)
+    );
+    let q = sqlx::query(sqlx::AssertSqlSafe(sql)).bind(entity.as_uuid());
+    let q = match &part.value {
+        SpecificValue::Text(v) => q.bind(v.clone()),
+        SpecificValue::Id(v) => q.bind(*v),
+        SpecificValue::Count(v) => q.bind(*v),
+        SpecificValue::Instant(v) => q.bind(*v),
+        SpecificValue::Members(v) => q.bind(v.clone()),
+        SpecificValue::State(v) => q.bind(v.store_name()),
+        SpecificValue::Number(v) => q.bind(v.as_ref().map(Decimal::text)),
+        SpecificValue::Properties(_) => {
+            return Err(
+                Refusal::Malformed("property values are rows rather than a column".into()).into(),
+            );
+        }
+    };
+    q.execute(ctx.tx.conn()).await?;
+    Ok(())
+}
+
+/// Read one column back, in the shape of the arriving value.
+///
+/// The shape comes from `part` for the same reason the shared model's `current`
+/// takes the arriving part: the store column alone does not say which of two
+/// kinds a value is meant to be compared as.
+pub async fn read_column(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+) -> Applied<SpecificPart> {
+    let (table, column) = column_of(kind, part)?;
+    // Both text-carried kinds are read back through the same cast they were
+    // written through, so the rendering round-trips rather than depending on
+    // the driver's own formatting.
+    let projection = match part.value {
+        SpecificValue::State(_) | SpecificValue::Number(_) => format!("{column}::text AS v"),
+        _ => format!("{column} AS v"),
+    };
+    let sql = format!("SELECT {projection} FROM {table} WHERE entity_id = $1");
+    let row = sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(entity.as_uuid())
+        .fetch_optional(ctx.tx.conn())
+        .await?;
+    let Some(row) = row else {
+        // No side-table row is no value. A create makes the row before any part
+        // is applied, so this is a type whose row was never made.
+        return Ok(SpecificPart {
+            field: part.field,
+            value: empty_like(&part.value),
+        });
+    };
+    let value = match &part.value {
+        SpecificValue::Text(_) => SpecificValue::Text(row.try_get("v")?),
+        SpecificValue::Id(_) => SpecificValue::Id(row.try_get("v")?),
+        SpecificValue::Count(_) => SpecificValue::Count(row.try_get("v")?),
+        SpecificValue::Instant(_) => SpecificValue::Instant(row.try_get("v")?),
+        SpecificValue::Members(_) => SpecificValue::Members(
+            row.try_get::<Option<Vec<Uuid>>, _>("v")?
+                .unwrap_or_default(),
+        ),
+        SpecificValue::State(_) => SpecificValue::State(
+            row.try_get::<Option<String>, _>("v")?
+                .and_then(|s| GuidanceState::from_store_name(&s))
+                .unwrap_or(GuidanceState::DEFAULT),
+        ),
+        SpecificValue::Number(_) => SpecificValue::Number(
+            row.try_get::<Option<String>, _>("v")?
+                .map(|s| Decimal::parse(&s))
+                .transpose()?,
+        ),
+        SpecificValue::Properties(_) => {
+            return Err(
+                Refusal::Malformed("property values are rows rather than a column".into()).into(),
+            );
+        }
+    };
+    Ok(SpecificPart {
+        field: part.field,
+        value,
+    })
+}
+
+/// The same kind of value, holding nothing.
+fn empty_like(value: &SpecificValue) -> SpecificValue {
+    match value {
+        SpecificValue::Text(_) => SpecificValue::Text(None),
+        SpecificValue::Id(_) => SpecificValue::Id(None),
+        SpecificValue::Count(_) => SpecificValue::Count(None),
+        SpecificValue::Number(_) => SpecificValue::Number(None),
+        SpecificValue::Instant(_) => SpecificValue::Instant(None),
+        SpecificValue::State(_) => SpecificValue::State(GuidanceState::DEFAULT),
+        SpecificValue::Members(_) => SpecificValue::Members(Vec::new()),
+        SpecificValue::Properties(_) => SpecificValue::Properties(Vec::new()),
+    }
+}
+
+/// Every property value an entity holds, in the one order they compare in.
+pub async fn read_properties(ctx: &mut Ctx<'_>, entity: EntityId) -> Applied<Vec<Property>> {
+    let rows = sqlx::query("SELECT name, value FROM entity_property_value WHERE entity_id = $1")
+        .bind(entity.as_uuid())
+        .fetch_all(ctx.tx.conn())
+        .await?;
+    let mut out = Vec::with_capacity(rows.len());
+    for r in &rows {
+        out.push(Property {
+            name: r.try_get("name")?,
+            value: r.try_get::<Option<String>, _>("value")?.unwrap_or_default(),
+        });
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Replace an entity's property values whole.
+///
+/// Replaced rather than merged, because the wire carries the list and a list is
+/// the value. Anything nested is replaced whole; the proto says so of a
+/// routine's occurrence description and the reasoning is the same here.
+pub async fn write_properties(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    values: &[Property],
+) -> Applied<()> {
+    sqlx::query("DELETE FROM entity_property_value WHERE entity_id = $1")
+        .bind(entity.as_uuid())
+        .execute(ctx.tx.conn())
+        .await?;
+    for p in values {
+        sqlx::query(
+            "INSERT INTO entity_property_value (entity_id, name, value) VALUES ($1, $2, $3) \
+             ON CONFLICT (entity_id, name) DO UPDATE SET value = excluded.value",
+        )
+        .bind(entity.as_uuid())
+        .bind(&p.name)
+        .bind(&p.value)
+        .execute(ctx.tx.conn())
+        .await?;
+    }
+    Ok(())
+}

--- a/crates/altaird/src/write/specific/nesting.rs
+++ b/crates/altaird/src/write/specific/nesting.rs
@@ -1,0 +1,105 @@
+//! Cycle prevention in a nested container, written once for the two that nest.
+//!
+//! # Why this is a write-path check and not a constraint
+//!
+//! Migration one refuses the one-step case with
+//! `CHECK (parent_location_id IS NULL OR parent_location_id <> entity_id)` and
+//! the same on a category, and then records the rest as its gap (h): *"Nothing
+//! prevents a cycle in nested locations or categories. Self reference is
+//! refused; a longer loop is not, and a recursive query would not terminate on
+//! one."* A constraint cannot see past one row, so the check has to run where
+//! the write is decided. Wave 0 named this and correctly did not take it; it
+//! belongs to type content because both containers are type content.
+//!
+//! # One helper, not two
+//!
+//! Nested locations and nested categories are the same shape — a side table
+//! with a self-referencing parent column — and are owned by two different
+//! lanes. Two implementations of a graph walk is two chances to get the
+//! termination wrong, and the one that is wrong is the one nobody runs until a
+//! person builds a loop by accident.
+//!
+//! **Called from nowhere yet.** The Tracking lane calls it for
+//! `parent_location_id` and the categories lane for `parent_category_id`, from
+//! their own `validate_and_place`. `tests/type_content.rs` exercises it
+//! directly rather than through either.
+//!
+//! # Audience is deliberately not applied
+//!
+//! Like `next_category_position` in the store, this answers a structural
+//! question rather than producing candidates. Walking only the containers the
+//! writing member can see would let them build a loop through one they cannot,
+//! and the loop would then be real for everybody. Nothing about the answer
+//! discloses anything either: it is one boolean about a parent the caller has
+//! already named.
+
+use std::collections::HashSet;
+
+use uuid::Uuid;
+
+use crate::store::WriteTx;
+use crate::store::ids::EntityId;
+
+use sqlx::Row;
+
+/// Whether making `parent` the parent of `child` would close a loop.
+///
+/// Generic over the table and its parent column, which is what lets one
+/// implementation serve `location.parent_location_id` and
+/// `category.parent_category_id`. Both are `&'static str` and come from a
+/// [`super::Field`] declaration, so neither is ever built from anything a
+/// caller sent.
+///
+/// # Termination
+///
+/// The walk keeps the identities it has seen and stops on a repeat. That covers
+/// the ordinary case — the walk reaches the top and the parent column is null —
+/// and the case this check exists to make impossible but which a hand-written
+/// row could still have created: **a loop already in the data**. Reaching one
+/// returns `true`, because a parent whose ancestry does not terminate is not a
+/// parent anything should be given.
+///
+/// # Errors
+///
+/// Only where the store could not be read.
+pub async fn would_cycle(
+    tx: &mut WriteTx,
+    table: &'static str,
+    parent_column: &'static str,
+    child: EntityId,
+    parent: EntityId,
+) -> sqlx::Result<bool> {
+    // The one-step case, which the schema also refuses. Checked here so a
+    // caller gets a refusal it can explain rather than a constraint violation
+    // that takes the transaction down.
+    if child == parent {
+        return Ok(true);
+    }
+
+    let sql = format!("SELECT {parent_column} AS parent FROM {table} WHERE entity_id = $1");
+    let mut seen: HashSet<Uuid> = HashSet::new();
+    seen.insert(child.as_uuid());
+
+    let mut at = parent.as_uuid();
+    loop {
+        if !seen.insert(at) {
+            // Either we have reached the child — the loop this call exists to
+            // refuse — or the data already held one. Both answer the same way.
+            return Ok(true);
+        }
+        let row = sqlx::query(sqlx::AssertSqlSafe(sql.clone()))
+            .bind(at)
+            .fetch_optional(tx.conn())
+            .await?;
+        let next: Option<Uuid> = match row {
+            Some(row) => row.try_get("parent")?,
+            // No row for the proposed ancestor. It has no parent to follow, so
+            // the chain ends here and nothing loops.
+            None => return Ok(false),
+        };
+        match next {
+            Some(next) => at = next,
+            None => return Ok(false),
+        }
+    }
+}

--- a/crates/altaird/src/write/specific/tracking.rs
+++ b/crates/altaird/src/write/specific/tracking.rs
@@ -1,0 +1,179 @@
+//! Tracking's type content: item, location, shopping list.
+//!
+//! **LANE: Tracking owns this file.**
+//!
+//! Three things about this domain are settled by the schema and the scope
+//! rather than by whoever fills the module in, and each is expensive to
+//! rediscover:
+//!
+//! - **An item's amount and the time it was asserted move together.** The
+//!   table's `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))`
+//!   refuses the state in between, so writing them in sequence fails whichever
+//!   order the sequence is in. This is the same shape as a category and the
+//!   position within it, and [`super::validate_and_place`] is where the
+//!   companion part is produced.
+//! - **A nested location can close a loop and the schema will not notice.**
+//!   Self-reference is refused by a constraint; a longer loop is migration
+//!   one's gap (h), and a recursive query would not terminate on one.
+//!   [`super::nesting::would_cycle`] is the check, written once because nested
+//!   categories need the same one.
+//! - **A shopping list's content is deferred in v0**, deliberately rather than
+//!   incidentally. `altair-v0-scope.md` says so and governs the implementation
+//!   plan where the two disagree, so the field carries an expiring refusal
+//!   naming the reason rather than being quietly absent.
+
+use altair_proto::v1;
+
+use crate::store::entity::EntityType;
+use crate::store::ids::EntityId;
+
+use super::super::content::{Malformed, Written};
+use super::super::entity::{Applied, Ctx, Refusal};
+use super::{Field, Held, SpecificPart, not_yet_built, unbuilt};
+
+pub const ITEM_FIELDS: &[Field] = &[
+    Field {
+        number: 1,
+        held: Held::Column("asserted_amount"),
+    },
+    Field {
+        number: 2,
+        held: Held::Column("unit"),
+    },
+    Field {
+        number: 3,
+        held: Held::Column("asserted_at"),
+    },
+    Field {
+        number: 4,
+        held: Held::Column("location_id"),
+    },
+    Field {
+        number: 5,
+        held: Held::Column("template_id"),
+    },
+    Field {
+        number: 6,
+        held: Held::Rows("entity_property_value"),
+    },
+];
+
+pub const LOCATION_FIELDS: &[Field] = &[
+    Field {
+        number: 1,
+        held: Held::Column("parent_location_id"),
+    },
+    Field {
+        number: 2,
+        held: Held::Column("template_id"),
+    },
+    Field {
+        number: 3,
+        held: Held::Rows("entity_property_value"),
+    },
+];
+
+pub const SHOPPING_LIST_FIELDS: &[Field] = &[Field {
+    number: 1,
+    held: Held::NotServed(
+        "shopping lists are deferred in v0: their entry model leans on an anchor granularity \
+         the substrate does not yet define, and a first release should not be the thing that \
+         forces that question",
+    ),
+}];
+
+/// An item's content, off the wire.
+///
+/// **LANE: Tracking.** The amount is a [`super::Decimal`] and crosses as text
+/// on purpose — binary floating point is the wrong place to put a household's
+/// stock, and the reading and the range check are already written in
+/// [`super::Decimal::from_wire`].
+pub fn item(c: &v1::ItemContent) -> Result<Written, Malformed> {
+    unbuilt(
+        EntityType::Item,
+        &c.cleared,
+        &[
+            (1, c.asserted_amount.is_some()),
+            (2, c.unit.is_some()),
+            (3, c.asserted_at.is_some()),
+            (4, c.location_id.is_some()),
+            (5, c.template_id.is_some()),
+            (6, !c.property_values.is_empty()),
+        ],
+    )
+}
+
+/// A location's content, off the wire.
+///
+/// **LANE: Tracking.** `parent_location_id` is the one that owes
+/// [`super::nesting::would_cycle`], from [`super::validate_and_place`], before
+/// the column is written.
+pub fn location(c: &v1::LocationContent) -> Result<Written, Malformed> {
+    unbuilt(
+        EntityType::Location,
+        &c.cleared,
+        &[
+            (1, c.parent_location_id.is_some()),
+            (2, c.template_id.is_some()),
+            (3, !c.property_values.is_empty()),
+        ],
+    )
+}
+
+/// A shopping list's content, off the wire.
+///
+/// Refused with the reason, which expires when the substrate defines the anchor
+/// granularity its entries need. The list itself is still a thing that can be
+/// created; it is the entries that have nowhere to go.
+pub fn shopping_list(c: &v1::ShoppingListContent) -> Result<Written, Malformed> {
+    unbuilt(
+        EntityType::ShoppingList,
+        &c.cleared,
+        &[(1, c.body.is_some())],
+    )
+}
+
+pub async fn validate_and_place(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+) -> Applied<Option<SpecificPart>> {
+    let _ = (ctx, entity, part);
+    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+}
+
+pub async fn current(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+) -> Applied<SpecificPart> {
+    let _ = (ctx, entity, part);
+    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+}
+
+pub async fn apply(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+    placement: Option<&SpecificPart>,
+) -> Applied<()> {
+    let _ = (ctx, entity, part, placement);
+    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+}
+
+/// What Tracking contributes to searchable text.
+///
+/// **LANE: Tracking.** The person's word for a unit is words rather than a
+/// value, so it is the plausible one. Contributing nothing is a valid answer
+/// and is what this returns until the lane decides otherwise.
+pub async fn search_text(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+) -> Applied<Option<String>> {
+    let _ = (ctx, entity, kind);
+    Ok(None)
+}

--- a/crates/altaird/tests/type_content.rs
+++ b/crates/altaird/tests/type_content.rs
@@ -494,88 +494,26 @@ async fn a_state_that_is_present_and_names_nothing_is_malformed() {
 }
 
 // ---------------------------------------------------------------------------
-// Everything unfilled refuses distinguishably
+// What the stub assertions used to hold, and who holds it now
 // ---------------------------------------------------------------------------
-
-/// One message per type that addresses at least one of its own fields.
-fn addressing_a_field() -> Vec<(&'static str, v1::entity_content::Specific)> {
-    use v1::entity_content::Specific;
-    vec![
-        (
-            "arc",
-            Specific::Arc(v1::ArcContent {
-                state: Some(v1::GuidanceState::Working as i32),
-                ..Default::default()
-            }),
-        ),
-        (
-            "quest",
-            Specific::Quest(v1::QuestContent {
-                state: Some(v1::GuidanceState::Working as i32),
-                ..Default::default()
-            }),
-        ),
-        (
-            "file",
-            Specific::File(v1::FileContent {
-                media_type: Some("image/png".into()),
-                ..Default::default()
-            }),
-        ),
-        (
-            "item",
-            Specific::Item(v1::ItemContent {
-                unit: Some("tins".into()),
-                ..Default::default()
-            }),
-        ),
-        (
-            "location",
-            Specific::Location(v1::LocationContent {
-                parent_location_id: Some(Uuid::new_v4().as_bytes().to_vec()),
-                ..Default::default()
-            }),
-        ),
-        (
-            "category",
-            Specific::Category(v1::CategoryContent {
-                parent_category_id: Some(Uuid::new_v4().as_bytes().to_vec()),
-                ..Default::default()
-            }),
-        ),
-    ]
-}
-
-/// **The whole point of the stubs.** An unfilled type says so rather than
-/// accepting and writing nothing, and it says so in words a person reading a
-/// log can act on.
-#[tokio::test]
-async fn a_type_whose_content_is_not_built_refuses_and_says_which() {
-    let world = World::new().await;
-    for (name, specific) in addressing_a_field() {
-        let detail = refusal_creating(&world, specific).await;
-        assert!(
-            detail.contains("not built yet") && detail.contains(name),
-            "{name}: {detail}"
-        );
-    }
-}
-
-/// A note's body is read for real; what is not built is the division behind it.
-/// The refusal has to say that rather than claiming the type is unknown.
-#[tokio::test]
-async fn a_body_refuses_because_division_is_not_wired_rather_than_because_a_note_is_unknown() {
-    let world = World::new().await;
-    let detail = refusal_creating(
-        &world,
-        v1::entity_content::Specific::Note(v1::NoteContent {
-            body: Some("one paragraph.".into()),
-            cleared: Vec::new(),
-        }),
-    )
-    .await;
-    assert!(detail.contains("divided into blocks"), "{detail}");
-}
+//
+// Until Wave 2.2's four lanes landed, this file asserted that every type whose
+// content was not yet built refused and said so, rather than accepting a write
+// and storing nothing. That assertion was written against a list of unbuilt
+// types, and each lane filling in its own type made its own entries false: a
+// file reaches 2.1's own refusal about a body, and a category naming a parent
+// that does not exist refuses as unavailable rather than as malformed, because
+// nonexistence and audience are the same nothing.
+//
+// **The list is gone rather than half-corrected**, because a list that is true
+// of some types and stale for others is worse than no list: it reads as
+// coverage. What it was really guarding is that no type silently accepts a
+// write and stores nothing, and that invariant is now carried where it can be
+// stated for real — each type's own round-trip tests in the lane test files,
+// which assert the stored value rather than the wording of a refusal.
+//
+// The same applies to the note body that used to refuse because division was
+// not wired: bodies are served now, so the refusal it asserted is gone.
 
 /// **A bare create of every type still works exactly as Wave 2.1 left it.** A
 /// message addressing nothing addresses nothing, whether or not the type's

--- a/crates/altaird/tests/type_content.rs
+++ b/crates/altaird/tests/type_content.rs
@@ -1,0 +1,831 @@
+//! The type-content spine: one type carried end to end, and the boundary
+//! everything else hangs off.
+//!
+//! Wave 2.2's shared item builds the seam, not the domains. So this suite has
+//! two halves, and the second is the more important one:
+//!
+//! - **Campaign's `state`, end to end.** One field, no ordering, no parent. It
+//!   is written, read back, conflicted on, and merged, which is what proves a
+//!   type-specific part reaches every mechanism the shared model already
+//!   reaches. **Not** the Guidance state machine: no transition is checked
+//!   anywhere, deliberately, and that is the Guidance lane's.
+//! - **Everything unfilled refuses distinguishably.** A stub that accepted
+//!   silently would tell a client its content had landed when nothing had, and
+//!   the lane filling the module in would have no failing test to turn green.
+
+mod common;
+
+use altair_proto::v1;
+use altaird::store::begin_write;
+use altaird::store::ids::EntityId;
+use altaird::write::specific::{self, Decimal, Held};
+use common::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Campaign's state, end to end
+// ---------------------------------------------------------------------------
+
+fn campaign(state: Option<v1::GuidanceState>) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Campaign(v1::CampaignContent {
+        state: state.map(|s| s as i32),
+        cleared: Vec::new(),
+    })
+}
+
+fn campaign_cleared(cleared: Vec<u32>) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Campaign(v1::CampaignContent {
+        state: None,
+        cleared,
+    })
+}
+
+async fn state_of(world: &World, id: EntityId) -> String {
+    sqlx::query("SELECT state::text AS s FROM campaign WHERE entity_id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("campaign row")
+        .try_get("s")
+        .expect("state")
+}
+
+/// A campaign member two can also see, which is what makes a concurrent edit
+/// possible at all. Audience is private to the author otherwise.
+async fn shared_campaign(world: &World, state: Option<v1::GuidanceState>) -> EntityId {
+    world
+        .create(
+            &world.one,
+            campaign(state),
+            v1::EntityContent {
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+#[tokio::test]
+async fn a_state_stated_at_creation_reaches_the_store() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            campaign(Some(v1::GuidanceState::Working)),
+            v1::EntityContent {
+                title: Some("the kitchen".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert_eq!(state_of(&world, id).await, "working");
+}
+
+#[tokio::test]
+async fn a_state_not_stated_at_creation_is_the_column_default() {
+    let world = World::new().await;
+    let id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    assert_eq!(state_of(&world, id).await, "waiting");
+}
+
+#[tokio::test]
+async fn an_edit_moves_a_state_and_advances_the_counter() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            campaign(Some(v1::GuidanceState::Working)),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    let ack = world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(campaign(Some(v1::GuidanceState::Worked))),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    assert_eq!(state_of(&world, id).await, "worked");
+    assert_eq!(applied(&ack).counter, (base + 1) as u64);
+}
+
+/// **Clearing a state sets it to waiting**, because the column is
+/// `NOT NULL DEFAULT 'waiting'` and there is no state a campaign is not in.
+/// That is the plumbing's answer rather than the domain's, and it is what makes
+/// the next test true.
+#[tokio::test]
+async fn clearing_a_state_returns_it_to_the_default() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            campaign(Some(v1::GuidanceState::Worked)),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(campaign_cleared(vec![1])),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    assert_eq!(state_of(&world, id).await, "waiting");
+}
+
+/// The part is recorded as having moved, keyed the way the wire names it.
+///
+/// `entity_part_counter` is per part and conflict detection asks which parts
+/// moved between two counter values. A specific part that does not record its
+/// movement is invisible to that, and the failure is silent.
+#[tokio::test]
+async fn a_state_records_the_counter_it_moved_at() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            campaign(Some(v1::GuidanceState::Working)),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let row = sqlx::query(
+        "SELECT field_name, counter FROM entity_part_counter \
+         WHERE entity_id = $1 AND field_name = 'specific.1'",
+    )
+    .bind(id.as_uuid())
+    .fetch_optional(&world.db.pool)
+    .await
+    .expect("query");
+
+    let row = row.expect("the state's movement is recorded, or nothing can conflict on it");
+    assert_eq!(row.try_get::<i64, _>("counter").unwrap(), 1);
+}
+
+/// Same part, both values retained, and the wire says which field.
+#[tokio::test]
+async fn a_same_part_conflict_on_a_state_retains_both_values() {
+    let world = World::new().await;
+    let id = shared_campaign(&world, Some(v1::GuidanceState::Waiting)).await;
+    let base = world.counter(id).await;
+
+    // One moves it. Two is still on the base it last saw.
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(campaign(Some(v1::GuidanceState::Working))),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let ack = world
+        .submit(
+            &world.two,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(campaign(Some(v1::GuidanceState::Worked))),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let applied = applied(&ack);
+    let conflict = applied
+        .conflict
+        .as_ref()
+        .expect("overlapping writes on one part conflict");
+    assert_eq!(
+        conflict.specific_fields,
+        vec![1],
+        "the acknowledgement names the type message's own field number"
+    );
+    assert!(conflict.content_fields.is_empty());
+
+    let conflicts = world.conflicts(id).await;
+    assert_eq!(conflicts.len(), 1);
+    let c = &conflicts[0];
+    assert_eq!(c.field.as_deref(), Some("specific.1"));
+    // The arriving value is `mine`, the value it displaced is `theirs`, and
+    // each carries the member it came from. The write still applied.
+    assert_eq!(c.mine.as_deref(), Some("worked"));
+    assert_eq!(c.theirs.as_deref(), Some("working"));
+    assert_eq!(c.mine_member, Some(world.two.membership_id()));
+    assert_eq!(c.theirs_member, Some(world.one.membership_id()));
+    assert_eq!(state_of(&world, id).await, "worked");
+}
+
+/// **Writes producing the same value are not divergent**, whatever their base
+/// counter said. Two people resolving one thing the same way is the likely
+/// case, and forming a conflict out of agreement is the machinery working
+/// against its own purpose.
+#[tokio::test]
+async fn two_members_setting_the_same_state_do_not_conflict() {
+    let world = World::new().await;
+    let id = shared_campaign(&world, None).await;
+    let base = world.counter(id).await;
+
+    for member in [&world.one, &world.two] {
+        world
+            .submit(
+                member,
+                edit_entity(
+                    id,
+                    base as u64,
+                    v1::EntityContent {
+                        specific: Some(campaign(Some(v1::GuidanceState::Working))),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+    }
+
+    assert!(world.conflicts(id).await.is_empty());
+    assert_eq!(state_of(&world, id).await, "working");
+}
+
+/// And the same rule the other way: clearing arrives at waiting, so a member
+/// clearing while another set waiting is not a disagreement either.
+#[tokio::test]
+async fn clearing_and_setting_the_default_are_the_same_value() {
+    let world = World::new().await;
+    let id = shared_campaign(&world, Some(v1::GuidanceState::Working)).await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(campaign(Some(v1::GuidanceState::Waiting))),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    world
+        .submit(
+            &world.two,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(campaign_cleared(vec![1])),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    assert!(world.conflicts(id).await.is_empty());
+    assert_eq!(state_of(&world, id).await, "waiting");
+}
+
+/// **A stale base is never a rejection**, and different parts merge with nobody
+/// involved. One writes the title, the other writes the state, both from the
+/// same base.
+#[tokio::test]
+async fn a_stale_base_over_different_parts_merges_and_is_never_a_rejection() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            campaign(None),
+            v1::EntityContent {
+                title: Some("before".into()),
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    title: Some("after".into()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let ack = world
+        .submit(
+            &world.two,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(campaign(Some(v1::GuidanceState::Working))),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    assert!(
+        applied(&ack).conflict.is_none(),
+        "different parts merge; a stale base alone is not a conflict and never a rejection"
+    );
+    assert_eq!(world.title(id).await.as_deref(), Some("after"));
+    assert_eq!(state_of(&world, id).await, "working");
+}
+
+/// Type immutability still holds with type content in the message. The tag is
+/// what says which type an edit thinks it is editing.
+#[tokio::test]
+async fn an_edit_may_not_change_an_entitys_type() {
+    let world = World::new().await;
+    let id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let base = world.counter(id).await;
+
+    let ack = world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Quest(
+                        v1::QuestContent::default(),
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let refused = refused(&ack);
+    assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
+    assert!(refused.detail.contains("type"), "{}", refused.detail);
+    assert_eq!(state_of(&world, id).await, "waiting");
+}
+
+/// `search_text` is the title plus whatever the type contributes. Campaign
+/// contributes nothing, which is a valid answer — what matters is that the
+/// title still lands there once the type's share is asked for.
+#[tokio::test]
+async fn the_title_still_reaches_search_text_through_the_types_share() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            campaign(Some(v1::GuidanceState::Working)),
+            v1::EntityContent {
+                title: Some("the kitchen".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    let text: String = sqlx::query("SELECT search_text FROM entity WHERE id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("entity")
+        .try_get("search_text")
+        .expect("search_text");
+    assert_eq!(text, "the kitchen");
+}
+
+// ---------------------------------------------------------------------------
+// The two refusals, one level down
+// ---------------------------------------------------------------------------
+
+async fn refusal_creating(world: &World, specific: v1::entity_content::Specific) -> String {
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(specific),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let refused = refused(&ack);
+    assert_eq!(
+        refused.reason,
+        v1::RefusalReason::Malformed as i32,
+        "{refused:?}"
+    );
+    refused.detail.clone()
+}
+
+#[tokio::test]
+async fn a_field_both_present_and_cleared_is_malformed() {
+    let world = World::new().await;
+    let detail = refusal_creating(
+        &world,
+        v1::entity_content::Specific::Campaign(v1::CampaignContent {
+            state: Some(v1::GuidanceState::Working as i32),
+            cleared: vec![1],
+        }),
+    )
+    .await;
+    assert!(detail.contains("both present and listed"), "{detail}");
+}
+
+#[tokio::test]
+async fn a_cleared_number_naming_no_field_of_this_type_is_malformed() {
+    let world = World::new().await;
+    // 100 is `cleared` itself, 7 was never anything, and 3 is a real field —
+    // of an arc and of a quest. A campaign has one field and it is not that.
+    for number in [3, 7, 100] {
+        let detail = refusal_creating(&world, campaign_cleared(vec![number])).await;
+        assert!(
+            detail.contains("not a part of this type"),
+            "clearing {number} on a campaign: {detail}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_state_that_is_present_and_names_nothing_is_malformed() {
+    let world = World::new().await;
+    let detail = refusal_creating(
+        &world,
+        v1::entity_content::Specific::Campaign(v1::CampaignContent {
+            state: Some(v1::GuidanceState::Unspecified as i32),
+            cleared: Vec::new(),
+        }),
+    )
+    .await;
+    assert!(detail.contains("guidance state"), "{detail}");
+}
+
+// ---------------------------------------------------------------------------
+// Everything unfilled refuses distinguishably
+// ---------------------------------------------------------------------------
+
+/// One message per type that addresses at least one of its own fields.
+fn addressing_a_field() -> Vec<(&'static str, v1::entity_content::Specific)> {
+    use v1::entity_content::Specific;
+    vec![
+        (
+            "arc",
+            Specific::Arc(v1::ArcContent {
+                state: Some(v1::GuidanceState::Working as i32),
+                ..Default::default()
+            }),
+        ),
+        (
+            "quest",
+            Specific::Quest(v1::QuestContent {
+                state: Some(v1::GuidanceState::Working as i32),
+                ..Default::default()
+            }),
+        ),
+        (
+            "file",
+            Specific::File(v1::FileContent {
+                media_type: Some("image/png".into()),
+                ..Default::default()
+            }),
+        ),
+        (
+            "item",
+            Specific::Item(v1::ItemContent {
+                unit: Some("tins".into()),
+                ..Default::default()
+            }),
+        ),
+        (
+            "location",
+            Specific::Location(v1::LocationContent {
+                parent_location_id: Some(Uuid::new_v4().as_bytes().to_vec()),
+                ..Default::default()
+            }),
+        ),
+        (
+            "category",
+            Specific::Category(v1::CategoryContent {
+                parent_category_id: Some(Uuid::new_v4().as_bytes().to_vec()),
+                ..Default::default()
+            }),
+        ),
+    ]
+}
+
+/// **The whole point of the stubs.** An unfilled type says so rather than
+/// accepting and writing nothing, and it says so in words a person reading a
+/// log can act on.
+#[tokio::test]
+async fn a_type_whose_content_is_not_built_refuses_and_says_which() {
+    let world = World::new().await;
+    for (name, specific) in addressing_a_field() {
+        let detail = refusal_creating(&world, specific).await;
+        assert!(
+            detail.contains("not built yet") && detail.contains(name),
+            "{name}: {detail}"
+        );
+    }
+}
+
+/// A note's body is read for real; what is not built is the division behind it.
+/// The refusal has to say that rather than claiming the type is unknown.
+#[tokio::test]
+async fn a_body_refuses_because_division_is_not_wired_rather_than_because_a_note_is_unknown() {
+    let world = World::new().await;
+    let detail = refusal_creating(
+        &world,
+        v1::entity_content::Specific::Note(v1::NoteContent {
+            body: Some("one paragraph.".into()),
+            cleared: Vec::new(),
+        }),
+    )
+    .await;
+    assert!(detail.contains("divided into blocks"), "{detail}");
+}
+
+/// **A bare create of every type still works exactly as Wave 2.1 left it.** A
+/// message addressing nothing addresses nothing, whether or not the type's
+/// content is built.
+#[tokio::test]
+async fn a_create_carrying_no_type_content_is_unaffected() {
+    use v1::entity_content::Specific;
+    let world = World::new().await;
+    let bare = [
+        Specific::Campaign(v1::CampaignContent::default()),
+        Specific::Arc(v1::ArcContent::default()),
+        Specific::Quest(v1::QuestContent::default()),
+        Specific::Note(v1::NoteContent::default()),
+        Specific::Item(v1::ItemContent::default()),
+        Specific::Location(v1::LocationContent::default()),
+        Specific::ShoppingList(v1::ShoppingListContent::default()),
+        Specific::Category(v1::CategoryContent::default()),
+    ];
+    for specific in bare {
+        world
+            .create(&world.one, specific, v1::EntityContent::default())
+            .await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The two refusals that expire for a reason outside this lane
+// ---------------------------------------------------------------------------
+
+/// `altair-v0-scope.md` defers shopping lists deliberately rather than
+/// incidentally, and it governs the implementation plan where the two disagree.
+/// So the entries refuse with the reason, and the refusal names it rather than
+/// saying the content is merely unbuilt.
+#[tokio::test]
+async fn a_shopping_lists_entries_are_refused_with_the_reason_they_are_deferred() {
+    let world = World::new().await;
+    let detail = refusal_creating(
+        &world,
+        v1::entity_content::Specific::ShoppingList(v1::ShoppingListContent {
+            body: Some("milk\nbread".into()),
+            cleared: Vec::new(),
+        }),
+    )
+    .await;
+    assert!(
+        detail.contains("deferred in v0") && detail.contains("anchor granularity"),
+        "{detail}"
+    );
+}
+
+/// The same for a person's correction to extracted text, which has nothing to
+/// correct: text extraction from files is deferred in v0.
+///
+/// This refusal is reached before the one that says a file must name an
+/// uploaded body, because the content is read before the row is made. Both are
+/// expiring refusals and either answer is honest; the assertion is that the
+/// deferral is the one a client is told about when it is the thing it asked
+/// for.
+#[tokio::test]
+async fn a_files_extracted_text_is_refused_with_the_reason_extraction_is_deferred() {
+    let world = World::new().await;
+    let detail = refusal_creating(
+        &world,
+        v1::entity_content::Specific::File(v1::FileContent {
+            extracted_text: Some("what the picture says".into()),
+            ..Default::default()
+        }),
+    )
+    .await;
+    assert!(detail.contains("deferred in v0"), "{detail}");
+}
+
+// ---------------------------------------------------------------------------
+// The declared field-to-column mapping, checked against the store
+// ---------------------------------------------------------------------------
+
+/// Every column a type declares actually exists, on every type at once.
+///
+/// The mapping is declared now and used by lanes later, so a mistyped column
+/// would otherwise surface as a store fault in whichever lane happened to reach
+/// it first. `LIMIT 0` asks the planner the question and reads nothing.
+#[tokio::test]
+async fn every_declared_column_exists_on_the_types_own_table() {
+    use altaird::store::entity::EntityType::{
+        Arc, Campaign, Category, File, Item, Location, Note, Quest, ShoppingList,
+    };
+    let world = World::new().await;
+    for kind in [
+        Campaign,
+        Arc,
+        Quest,
+        Note,
+        File,
+        Item,
+        Location,
+        ShoppingList,
+        Category,
+    ] {
+        for field in specific::fields(kind) {
+            let Held::Column(column) = field.held else {
+                continue;
+            };
+            let table = specific::side_table(kind)
+                .unwrap_or_else(|| panic!("{kind:?} declares a column but has no table"));
+            let sql = format!("SELECT {column} FROM {table} LIMIT 0");
+            sqlx::query(sqlx::AssertSqlSafe(sql))
+                .fetch_all(&world.db.pool)
+                .await
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "{kind:?} field {} names {table}.{column}: {e}",
+                        field.number
+                    )
+                });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cycle prevention in a nested container
+// ---------------------------------------------------------------------------
+
+/// Called from nowhere yet, so it is exercised directly. Nested locations and
+/// nested categories both need it, which is why there is one of it.
+async fn location(world: &World) -> EntityId {
+    world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Location(v1::LocationContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await
+}
+
+async fn set_parent(world: &World, child: EntityId, parent: Option<EntityId>) {
+    sqlx::query("UPDATE location SET parent_location_id = $2 WHERE entity_id = $1")
+        .bind(child.as_uuid())
+        .bind(parent.map(EntityId::as_uuid))
+        .execute(&world.db.pool)
+        .await
+        .expect("parent");
+}
+
+async fn cycles(world: &World, child: EntityId, parent: EntityId) -> bool {
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let answer =
+        specific::nesting::would_cycle(&mut tx, "location", "parent_location_id", child, parent)
+            .await
+            .expect("the store was reachable");
+    tx.rollback().await.expect("rollback");
+    answer
+}
+
+#[tokio::test]
+async fn a_container_cannot_be_its_own_parent() {
+    let world = World::new().await;
+    let a = location(&world).await;
+    assert!(cycles(&world, a, a).await);
+}
+
+#[tokio::test]
+async fn a_longer_loop_is_refused_where_the_schema_cannot_see_it() {
+    let world = World::new().await;
+    // c is beneath b is beneath a. Making a's parent c closes the loop, and
+    // the schema's only check is self-reference, so nothing else catches it.
+    let a = location(&world).await;
+    let b = location(&world).await;
+    let c = location(&world).await;
+    set_parent(&world, b, Some(a)).await;
+    set_parent(&world, c, Some(b)).await;
+
+    assert!(cycles(&world, a, c).await);
+    assert!(cycles(&world, a, b).await, "one step up is still a loop");
+}
+
+#[tokio::test]
+async fn an_ordinary_nesting_is_not_a_loop() {
+    let world = World::new().await;
+    let a = location(&world).await;
+    let b = location(&world).await;
+    let c = location(&world).await;
+    set_parent(&world, b, Some(a)).await;
+
+    // c beneath b: the walk goes c's proposed parent b, then a, then stops.
+    assert!(!cycles(&world, c, b).await);
+    // And a sibling relationship, where the proposed parent has no ancestry.
+    assert!(!cycles(&world, a, c).await);
+}
+
+/// A loop already in the data terminates rather than walking forever, and
+/// answers the way a loop answers. A hand-written row can make one; a recursive
+/// query over it would not terminate.
+#[tokio::test]
+async fn a_loop_already_in_the_data_terminates() {
+    let world = World::new().await;
+    let a = location(&world).await;
+    let b = location(&world).await;
+    let c = location(&world).await;
+    set_parent(&world, a, Some(b)).await;
+    set_parent(&world, b, Some(a)).await;
+
+    assert!(cycles(&world, c, a).await);
+}
+
+// ---------------------------------------------------------------------------
+// The decimal a household's stock is carried in
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_decimal_renders_the_same_way_coming_and_going() {
+    for (units, nanos, text) in [
+        (0_i64, 0_i32, "0.000000000"),
+        (2, 500_000_000, "2.500000000"),
+        (-2, -500_000_000, "-2.500000000"),
+        (0, -1, "-0.000000001"),
+        (12, 0, "12.000000000"),
+    ] {
+        let d = Decimal { units, nanos };
+        assert_eq!(d.text(), text);
+        assert_eq!(Decimal::parse(text).expect("parses"), d, "{text}");
+    }
+}
+
+/// **Not clamped.** A nanos that is not a fraction, or a sign disagreement,
+/// names no number; absorbing one would store something the client never sent.
+/// This is the schema's owed check *everything the wire shape implies*.
+#[test]
+fn a_decimal_out_of_range_is_refused_rather_than_clamped() {
+    for (units, nanos) in [
+        (0_i64, 1_000_000_000_i32),
+        (0, -1_000_000_000),
+        (1, -1),
+        (-1, 1),
+    ] {
+        assert!(
+            Decimal::from_wire(&v1::Decimal { units, nanos }).is_err(),
+            "{units} units and {nanos} nanos is not a decimal"
+        );
+    }
+    assert!(
+        Decimal::from_wire(&v1::Decimal {
+            units: 3,
+            nanos: 250_000_000,
+        })
+        .is_ok()
+    );
+}
+
+#[test]
+fn a_stored_number_the_wire_cannot_carry_is_refused_rather_than_rounded() {
+    assert!(Decimal::parse("0.1234567891").is_err());
+    assert!(Decimal::parse("not a number").is_err());
+}

--- a/crates/altaird/tests/type_content.rs
+++ b/crates/altaird/tests/type_content.rs
@@ -493,6 +493,61 @@ async fn a_state_that_is_present_and_names_nothing_is_malformed() {
     assert!(detail.contains("guidance state"), "{detail}");
 }
 
+/// **A recreation is a whole entity of its type, not a bare shell.**
+///
+/// 2.2's done-when asks that an edit arriving for an erased entity produce a
+/// recreation rather than a create. 2.1 proved that for the shared model; what
+/// 2.2 adds underneath it is type content, and nothing exercised the two
+/// together. `recreate` hands the same `Written` to `create`, so the type's row
+/// is made with its defaults and the parts the edit addressed land on top —
+/// but that is a property of one call passing a value through, and a value
+/// passed through is exactly what a later refactor drops.
+///
+/// This is the one path where a create runs on content a client submitted as an
+/// edit, so it is the one place the two halves of the wave meet.
+#[tokio::test]
+async fn a_recreation_carries_the_type_content_the_edit_addressed() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            campaign(Some(v1::GuidanceState::Working)),
+            v1::EntityContent::default(),
+        )
+        .await;
+    world.submit(&world.one, erase(&[id])).await;
+
+    let ack = world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                1,
+                v1::EntityContent {
+                    specific: Some(campaign(Some(v1::GuidanceState::Worked))),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let r = recreated(&ack);
+    let new = EntityId::from_uuid(Uuid::from_bytes(
+        r.new_entity_id.clone().try_into().expect("16 bytes"),
+    ));
+
+    // The side-table row exists at all, which is what "not a shell" means: the
+    // erased entity's row is gone with its tombstone and this is a new one.
+    // `state_of` fetches exactly one row and panics otherwise, so reaching the
+    // assertion is half the claim.
+    assert_eq!(
+        state_of(&world, new).await,
+        "worked",
+        "the state the edit carried reached the recreated entity's own row"
+    );
+    assert_ne!(new, id, "the identity is new");
+}
+
 // ---------------------------------------------------------------------------
 // What the stub assertions used to hold, and who holds it now
 // ---------------------------------------------------------------------------

--- a/crates/altaird/tests/write_parts.rs
+++ b/crates/altaird/tests/write_parts.rs
@@ -84,3 +84,168 @@ fn a_name_this_build_does_not_know_is_not_guessed_at() {
          different parts collide"
     );
 }
+
+// --- type-specific parts -------------------------------------------------
+//
+// A type's fields are declared in `write/specific/`, per type, and the same
+// drift is possible one level down: a field number is on the wire, a column
+// name is in the store, and something has to hold the mapping. These walk every
+// type's declaration, including the ones whose content no lane has filled in
+// yet, so a mistyped number or a repeated column fails now rather than in
+// whichever lane reaches it first.
+
+use altaird::store::entity::EntityType;
+use altaird::write::specific::{self, Held};
+
+/// Every type there is. Written out rather than derived, so a type added to the
+/// enum without a declaration fails to compile here.
+const EVERY_TYPE: &[EntityType] = &[
+    EntityType::Campaign,
+    EntityType::Arc,
+    EntityType::Quest,
+    EntityType::Routine,
+    EntityType::FocusSession,
+    EntityType::CheckIn,
+    EntityType::Note,
+    EntityType::File,
+    EntityType::Item,
+    EntityType::Location,
+    EntityType::ShoppingList,
+    EntityType::Category,
+];
+
+#[test]
+fn every_declared_field_round_trips_through_its_stored_key() {
+    for kind in EVERY_TYPE {
+        for field in specific::fields(*kind) {
+            let part = Part::Specific(field.number);
+            assert_eq!(
+                Part::from_key(&part.key()),
+                Some(part.clone()),
+                "{kind:?} field {} does not come back from its own key",
+                field.number
+            );
+            assert_eq!(
+                specific::field(*kind, field.number),
+                Some(*field),
+                "{kind:?} field {} does not come back from its own number",
+                field.number
+            );
+        }
+    }
+}
+
+#[test]
+fn no_two_fields_of_one_type_share_a_number_or_a_column() {
+    for kind in EVERY_TYPE {
+        let fields = specific::fields(*kind);
+
+        let mut numbers: Vec<u32> = fields.iter().map(|f| f.number).collect();
+        numbers.sort_unstable();
+        let before = numbers.len();
+        numbers.dedup();
+        assert_eq!(before, numbers.len(), "{kind:?} declares a number twice");
+
+        let mut columns: Vec<&str> = fields
+            .iter()
+            .filter_map(|f| match f.held {
+                Held::Column(c) => Some(c),
+                _ => None,
+            })
+            .collect();
+        columns.sort_unstable();
+        let before = columns.len();
+        columns.dedup();
+        assert_eq!(before, columns.len(), "{kind:?} declares a column twice");
+    }
+}
+
+/// 100 is `cleared` itself in every one of these messages, and 0 is not a field
+/// number at all. Either declared as a part would let a client clear the list
+/// that says what it is clearing.
+#[test]
+fn no_type_declares_the_cleared_list_as_one_of_its_own_parts() {
+    for kind in EVERY_TYPE {
+        for field in specific::fields(*kind) {
+            assert!(
+                field.number != 0 && field.number != 100,
+                "{kind:?} declares field {} as a part",
+                field.number
+            );
+        }
+        assert_eq!(specific::field(*kind, 100), None);
+    }
+}
+
+/// A field held in a column needs a table for the column to be in.
+#[test]
+fn a_type_declaring_a_column_has_a_table_to_put_it_in() {
+    for kind in EVERY_TYPE {
+        let declares_a_column = specific::fields(*kind)
+            .iter()
+            .any(|f| matches!(f.held, Held::Column(_)));
+        assert!(
+            !declares_a_column || specific::side_table(*kind).is_some(),
+            "{kind:?} declares a column and has no side table to put it in"
+        );
+    }
+}
+
+/// The three types the schema deliberately creates no table for address
+/// nothing, and their messages reserve every number they will ever use.
+#[test]
+fn a_deferred_domain_declares_no_fields() {
+    for kind in [
+        EntityType::Routine,
+        EntityType::FocusSession,
+        EntityType::CheckIn,
+    ] {
+        assert!(specific::fields(kind).is_empty(), "{kind:?}");
+        assert!(specific::side_table(kind).is_none(), "{kind:?}");
+    }
+}
+
+/// The two spellings a stored key can have stay apart. A type-specific part is
+/// prefixed so a field number can never be read as a content part's name, and
+/// no content part's name can be read as a type-specific one.
+#[test]
+fn a_content_part_and_a_type_specific_part_cannot_be_confused() {
+    for content in ALL_CONTENT_PARTS {
+        let PartKey::Field(name) = Part::Content(*content).key() else {
+            panic!("a content part is keyed by name");
+        };
+        assert!(
+            !name.starts_with("specific."),
+            "{content:?} is spelled like a type-specific part"
+        );
+    }
+    for kind in EVERY_TYPE {
+        for field in specific::fields(*kind) {
+            let PartKey::Field(name) = Part::Specific(field.number).key() else {
+                panic!("a type-specific part is keyed by name");
+            };
+            assert_eq!(ContentPart::from_store_name(&name), None);
+        }
+    }
+}
+
+/// **The known limit, recorded rather than missed.** Nothing here ties a
+/// declared number to the tag the wire actually encodes. If a field's `tag` in
+/// the proto changed, the reader would still read the same Rust field and would
+/// still store it under the old number, and every test above would pass.
+///
+/// Closing it needs `prost::Message` in scope to encode a message and read the
+/// key back, and `altair-proto` does not re-export `prost` — deliberately, it
+/// generates and re-exports the contract and nothing else. The gap is narrow:
+/// DR-004 makes field numbers permanent and a removed field is reserved rather
+/// than reused, so a tag changing under a name that stayed is a violation of
+/// the contract before it is a bug here.
+#[test]
+fn the_tie_to_the_wires_own_tags_is_a_known_gap() {
+    // Nothing to assert. This test exists so the paragraph above is in the
+    // suite rather than in a comment somebody deletes.
+    assert_eq!(
+        specific::field(EntityType::Campaign, 1).map(|f| f.held),
+        Some(Held::Column("state"))
+    );
+}


### PR DESCRIPTION
Second of nine slices of Wave 2.2. Stacked on #21. **This is the load-bearing one** — every later slice fills in a module this slice creates and stubs, and none of them touches the files changed here.

## What it does

Wave 2.1 read `content.specific` for the type tag and nothing else, and created each type's side-table row with defaults so nothing was ever half-formed. This slice makes the fields inside it reachable: a type-specific part goes from the wire, through validation and placement, into the store, and into `entity_part_counter` and the `conflict` row on the same terms as a shared content part.

`Part::Specific(u32)` and `Part::Block(Uuid)` already existed in `write/parts.rs`, deliberately, with comments saying 2.2 would be what produced them. Nothing produced one. Now something does.

## The shape, which is the part worth reviewing

**A part is named in one place.** A type declares its fields once — number, the column that holds it, and the value kind — and everything downstream derives from that declaration rather than restating it. `tests/type_content.rs` checks every declaration against the store, so a field number has exactly one home. This is the property that later slices lean on hardest, and the one whose absence caused a real defect elsewhere in the wave.

**One value vocabulary, not one per type.** `SpecificValue` is a single enum because everything downstream of the read — provenance, conflict detection, the acknowledgement — is written once and must not grow a branch per type.

**Every type gets a dispatch arm up front, stubbed.** The per-type modules are created here and answer "not built yet" distinguishably, so filling one in is a change to one file rather than to the dispatch. That is what let the domain slices be built independently.

**Campaign's `state` is carried end to end as proof** — one field, no ordering, no parent. Deliberately *not* the Guidance state machine: no transition legality, no propagation, no ladder. Those are slice 6. The plumbing is proved without the domain rule.

## Also here

- **A cycle-prevention helper** (`specific/nesting.rs`), generic over table and parent column, called from nowhere yet. Nested locations and nested categories both need it and would otherwise write it twice — migration one records that gap as (h).
- **Two refusals that expire**, both citing `docs/altair-v0-scope.md`: shopping-list content (deferred, "their entry model leans on an anchor granularity the substrate does not yet define") and a file's extracted text (deferred with text extraction). The plan's 2.2 prose still enumerates shopping lists; the scope governs the plan.
- **A pin that a recreation carries type content.** An edit arriving for an erased entity produces a recreation, which 2.1 proved for the shared model. Type content landed underneath it and nothing exercised the two together — `recreate` passes its `Written` straight to `create`, which is one call passing a value through, and exactly what a later refactor drops.

## One removal to be explicit about

This slice adds a test asserting each unbuilt type refuses and says which, and then removes it again four commits later. That is deliberate: the assertion is true only while the types are unbuilt, and every later slice falsifies its own entries. A list true of some types and stale for others reads as coverage without being it. What it was guarding — that no type silently accepts a write and stores nothing — is carried by each type's round-trip tests in the later slices, which assert the stored row rather than the wording of a refusal.

## Verification

- `cargo test --workspace`: 26 targets, 251 tests, 0 failures.
- `prek run --all-files`: 13 hooks, all passed.
