### PR TITLE
Wave 2.2 slice 4: give an item its amount, and a location somewhere to sit

### DIFF
--- a/crates/altaird/src/write/entity.rs
+++ b/crates/altaird/src/write/entity.rs
@@ -592,12 +592,37 @@ pub async fn edit(
         let placement = validate_and_place(ctx, id, kind, row.category_id, part).await?;
         let stored = current(ctx, &row, part).await?;
         touching.push((part.part(), part.text(), stored.text()));
-        if let Some(placement) = &placement {
-            let stored = current(ctx, &row, placement).await?;
-            touching.push((placement.part(), placement.text(), stored.text()));
-        }
         apply_part(ctx, id, kind, part, placement.as_ref()).await?;
         moved.push(part.part());
+        // **A placement moves, and does not conflict.** It goes into `moved` —
+        // it did move, and which member moved it is a fact provenance owes an
+        // answer to — but deliberately not into `touching`, which is what the
+        // write *addressed*. The client addressed the part beside it; the
+        // instance chose this one.
+        //
+        // The distinction is load-bearing rather than tidy, because a placement
+        // is a part the client is refused permission to state — an explicit
+        // `category_position` and an `asserted_at` are both malformed. A
+        // conflict is something a person is shown and asked to settle, and
+        // settling one means restating the part. So a conflict on a placement
+        // is one nothing can clear.
+        //
+        // It would also be a conflict carrying no information. A placement
+        // moves only when the part it accompanies moves, so it overlaps what
+        // moved since exactly when that part does, and there are only two
+        // outcomes: the two writes disagree about the amount, and the amount
+        // already conflicts with the time beside it saying nothing further; or
+        // the two writes agree — *both counted four tins* — and the amount
+        // rightly does not conflict while two `Utc::now()` readings a
+        // millisecond apart never compare equal and would raise a conflict out
+        // of agreement. That second case is the machinery working against its
+        // own purpose, on the one field a person could otherwise have acted on.
+        //
+        // **Not a claim that these parts can never conflict.** Reordering is
+        // not served yet; when it is, a write that names a position addresses
+        // it, and it enters `touching` through the loop above like any other
+        // part and conflicts normally. The rule is about what a write said, not
+        // about which parts are special.
         if let Some(placement) = &placement {
             moved.push(placement.part());
         }

--- a/crates/altaird/src/write/entity.rs
+++ b/crates/altaird/src/write/entity.rs
@@ -213,16 +213,38 @@ async fn apply_part(
             }
         }
         PartWrite::Category(v) => {
-            let position = match placement {
-                Some(PartWrite::CategoryPosition(p)) => *p,
-                _ => None,
-            };
-            sqlx::query("UPDATE entity SET category_id = $2, category_position = $3 WHERE id = $1")
-                .bind(entity.as_uuid())
-                .bind(v.map(EntityId::as_uuid))
-                .bind(position)
-                .execute(ctx.tx.conn())
-                .await?;
+            match placement {
+                // Entering a container, or leaving one. The instance decided a
+                // position either way, and the two columns move in one
+                // statement because the schema refuses the state between them.
+                Some(PartWrite::CategoryPosition(p)) => {
+                    sqlx::query(
+                        "UPDATE entity SET category_id = $2, category_position = $3 \
+                         WHERE id = $1",
+                    )
+                    .bind(entity.as_uuid())
+                    .bind(v.map(EntityId::as_uuid))
+                    .bind(*p)
+                    .execute(ctx.tx.conn())
+                    .await?;
+                }
+                // **Naming the container it is already in leaves it where it
+                // sits.** A client that resends the whole of `EntityContent` on
+                // every edit — which is the ordinary shape of a client, not an
+                // odd one — states the category each time without meaning to
+                // move anything. Writing a null position here would be the
+                // schema's `(category_id IS NULL) = (category_position IS
+                // NULL)` violated, so this was not a silent reordering waiting
+                // to happen; it was the whole transaction failing on the second
+                // edit that mentioned a category.
+                _ => {
+                    sqlx::query("UPDATE entity SET category_id = $2 WHERE id = $1")
+                        .bind(entity.as_uuid())
+                        .bind(v.map(EntityId::as_uuid))
+                        .execute(ctx.tx.conn())
+                        .await?;
+                }
+            }
         }
         PartWrite::CategoryPosition(v) => {
             sqlx::query("UPDATE entity SET category_position = $2 WHERE id = $1")

--- a/crates/altaird/src/write/specific/tracking.rs
+++ b/crates/altaird/src/write/specific/tracking.rs
@@ -10,8 +10,8 @@
 //!   table's `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))`
 //!   refuses the state in between, so writing them in sequence fails whichever
 //!   order the sequence is in. This is the same shape as a category and the
-//!   position within it, and [`super::validate_and_place`] is where the
-//!   companion part is produced.
+//!   position within it, and [`validate_and_place`] is where the companion part
+//!   is produced.
 //! - **A nested location can close a loop and the schema will not notice.**
 //!   Self-reference is refused by a constraint; a longer loop is migration
 //!   one's gap (h), and a recursive query would not terminate on one.
@@ -21,103 +21,254 @@
 //!   incidentally. `altair-v0-scope.md` says so and governs the implementation
 //!   plan where the two disagree, so the field carries an expiring refusal
 //!   naming the reason rather than being quietly absent.
+//!
+//! # Templates are in force, and that is a reading rather than an assumption
+//!
+//! Migration one records the ambiguity as its gap (i), at lines 935–938: the
+//! scope names Tracking's core as *items, nested locations and quantity*, which
+//! reads as an enumeration, while also saying anything not named as deferred is
+//! in force — and templates are not named as deferred. **The schema resolved
+//! this on the second reading and created the tables**, so this module follows
+//! the schema: `template_id` on both types is served, and property values are
+//! written. The reasoning is recorded here so the next reader finds it rather
+//! than re-arguing it.
+//!
+//! What a template contributes is names, never content
+//! (`proto/altair/v1/altair.proto:465`). So nothing here reads
+//! `template_property`: a value is stored under the name it was given, keyed by
+//! that name and not by a reference to the template's property, because
+//! detaching a template keeps every value with the names it had then
+//! (`0001_initial.sql:518-519`, `docs/altair-tracking-prd.md:100`). Detaching is
+//! therefore clearing one column and touching nothing else, which is what makes
+//! it *never destructive* without any code here saying so.
+//!
+//! **A property kind is not a constraint.** No lengths, no ranges, nothing
+//! required. Every value crosses as text and nothing here interprets it.
+//!
+//! # What is deliberately not here
+//!
+//! **Availability.** It is the asserted amount minus what live quantified
+//! relations commit, it is derived, and it is never stored
+//! (`0001_initial.sql:336-337`, `docs/altair-tracking-prd.md:172`). There is no
+//! column for it and this module computes none.
+//!
+//! **An item's name.** It is the shared model's `title` under this domain's
+//! word for it, and not a property of its own
+//! (`docs/altair-tracking-prd.md:78`). Duplicating it here would give two places
+//! to look and two things to keep in step.
+//!
+//! **Anything that would make a field required.** No field is required on
+//! either path: *an item with a name and nothing else is a complete item*. Every
+//! column below is nullable and has no default, and nothing here supplies one.
+
+use sqlx::Row;
+use uuid::Uuid;
 
 use altair_proto::v1;
 
-use crate::store::entity::EntityType;
+use crate::store::WriteScope;
+use crate::store::entity::{EntityType, available_for_write};
 use crate::store::ids::EntityId;
 
-use super::super::content::{Malformed, Written};
-use super::super::entity::{Applied, Ctx, Refusal};
-use super::{Field, Held, SpecificPart, not_yet_built, unbuilt};
+use super::super::content::{Malformed, Written, identifier, instant, malformed};
+use super::super::entity::{Applied, Ctx, Failed, Refusal, type_name};
+use super::{
+    Decimal, Field, Held, Property, Reader, SpecificPart, SpecificValue, nesting, read_column,
+    read_properties, unbuilt, write_column, write_properties,
+};
+
+// ---------------------------------------------------------------------------
+// The fields, and the columns spelled once
+// ---------------------------------------------------------------------------
+
+/// The columns a statement in this file names directly.
+///
+/// Every other column reaches the store through [`super::write_column`], which
+/// takes the name from the [`Field`] declaration and issues the SQL itself.
+/// These cannot: the amount and its timestamp move in one statement, and the
+/// unit is read back for searchable text. Naming them through a constant used
+/// by both the declaration and the statement is what stops the two drifting,
+/// because `tests/type_content.rs` only checks the declaration.
+const ASSERTED_AMOUNT: &str = "asserted_amount";
+const ASSERTED_AT: &str = "asserted_at";
+const UNIT: &str = "unit";
+
+/// The store's spelling of a location's parent column, named once.
+///
+/// [`nesting::would_cycle`] is generic over the column so that one walk serves
+/// nested locations and nested categories, and it takes a `&'static str` so that
+/// nothing a caller sent can ever reach it. This is that string, and it is the
+/// same one [`LOCATION_FIELDS`] declares. The categories lane names its own the
+/// same way, deliberately: two callers of one walk feeding it two different
+/// ways is how the walk ends up running against a column one of them renamed.
+const PARENT_LOCATION: &str = "parent_location_id";
+
+/// The side table a type keeps its content in.
+///
+/// Taken from [`super::side_table`] rather than written out, so the three
+/// statements in this file that name a table cannot disagree with the one place
+/// that decides which table a type has. The `None` arm is unreachable for the
+/// types that reach it — both have a table — and is an answer rather than a
+/// panic for the same reason everything else here refuses rather than asserts.
+fn table_of(kind: EntityType) -> Applied<&'static str> {
+    super::side_table(kind).ok_or_else(|| {
+        Refusal::Malformed(format!("a {} has no table of its own", type_name(kind))).into()
+    })
+}
+
+pub const ITEM_AMOUNT: u32 = 1;
+pub const ITEM_UNIT: u32 = 2;
+pub const ITEM_ASSERTED_AT: u32 = 3;
+pub const ITEM_LOCATION: u32 = 4;
+pub const ITEM_TEMPLATE: u32 = 5;
+pub const ITEM_PROPERTIES: u32 = 6;
 
 pub const ITEM_FIELDS: &[Field] = &[
     Field {
-        number: 1,
-        held: Held::Column("asserted_amount"),
+        number: ITEM_AMOUNT,
+        held: Held::Column(ASSERTED_AMOUNT),
     },
     Field {
-        number: 2,
-        held: Held::Column("unit"),
+        number: ITEM_UNIT,
+        held: Held::Column(UNIT),
     },
     Field {
-        number: 3,
-        held: Held::Column("asserted_at"),
+        number: ITEM_ASSERTED_AT,
+        held: Held::Column(ASSERTED_AT),
     },
     Field {
-        number: 4,
+        number: ITEM_LOCATION,
         held: Held::Column("location_id"),
     },
     Field {
-        number: 5,
+        number: ITEM_TEMPLATE,
         held: Held::Column("template_id"),
     },
     Field {
-        number: 6,
+        number: ITEM_PROPERTIES,
         held: Held::Rows("entity_property_value"),
     },
 ];
+
+pub const LOCATION_PARENT: u32 = 1;
+pub const LOCATION_TEMPLATE: u32 = 2;
+pub const LOCATION_PROPERTIES: u32 = 3;
 
 pub const LOCATION_FIELDS: &[Field] = &[
     Field {
-        number: 1,
-        held: Held::Column("parent_location_id"),
+        number: LOCATION_PARENT,
+        held: Held::Column(PARENT_LOCATION),
     },
     Field {
-        number: 2,
+        number: LOCATION_TEMPLATE,
         held: Held::Column("template_id"),
     },
     Field {
-        number: 3,
+        number: LOCATION_PROPERTIES,
         held: Held::Rows("entity_property_value"),
     },
 ];
 
+/// Why a shopping list's entries are refused, said once.
+const SHOPPING_LIST_DEFERRED: &str = "shopping lists are deferred in v0: their entry model leans on an anchor granularity \
+     the substrate does not yet define, and a first release should not be the thing that \
+     forces that question";
+
 pub const SHOPPING_LIST_FIELDS: &[Field] = &[Field {
     number: 1,
-    held: Held::NotServed(
-        "shopping lists are deferred in v0: their entry model leans on an anchor granularity \
-         the substrate does not yet define, and a first release should not be the thing that \
-         forces that question",
-    ),
+    held: Held::NotServed(SHOPPING_LIST_DEFERRED),
 }];
+
+/// Why an item's assertion time is not a field a client states.
+///
+/// **An expiring refusal, in the register of the three Wave 2.1 makes.** The
+/// field exists on the wire and will exist forever — field numbers are
+/// permanent — so this says what a client is waiting on rather than that its
+/// message was wrong.
+///
+/// The instance assigns it, for the same reason it assigns a category position:
+/// the column is constrained against another column, so the two move in one
+/// statement, and [`validate_and_place`] can see only one part at a time. A
+/// client free to state the time independently could put the row through the
+/// state `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))` refuses —
+/// by clearing the amount and stating a time in one message, or by stating a
+/// time on an item that has no amount — and the answer would be a constraint
+/// violation that takes the transaction down rather than a refusal anybody can
+/// act on.
+///
+/// **It expires when a device's own assertion time can cross.** A count taken
+/// offline at nine and replayed at six should read nine, not six. Today no
+/// client exists to have taken one, and the outbox that will carry it is Wave
+/// 4.1's; when it lands this becomes a companion carrying the stated instant
+/// rather than a refusal, and the pairing below is already where it goes.
+const ASSERTED_AT_IS_THE_INSTANCES: &str = "the time an amount was asserted is the amount's own and moves with it, so the instance \
+     sets it when the amount is written; stating it separately is not served yet";
+
+// ---------------------------------------------------------------------------
+// Reading the wire
+// ---------------------------------------------------------------------------
 
 /// An item's content, off the wire.
 ///
-/// **LANE: Tracking.** The amount is a [`super::Decimal`] and crosses as text
-/// on purpose — binary floating point is the wrong place to put a household's
+/// **LANE: Tracking.** The amount is a [`Decimal`] and crosses as text on
+/// purpose — binary floating point is the wrong place to put a household's
 /// stock, and the reading and the range check are already written in
-/// [`super::Decimal::from_wire`].
+/// [`Decimal::from_wire`], which refuses rather than clamps.
 pub fn item(c: &v1::ItemContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::Item,
-        &c.cleared,
-        &[
-            (1, c.asserted_amount.is_some()),
-            (2, c.unit.is_some()),
-            (3, c.asserted_at.is_some()),
-            (4, c.location_id.is_some()),
-            (5, c.template_id.is_some()),
-            (6, !c.property_values.is_empty()),
-        ],
-    )
+    let read = Reader::new(EntityType::Item, &c.cleared)?;
+    let mut parts = Vec::new();
+
+    read.singular(&mut parts, ITEM_AMOUNT, c.asserted_amount.as_ref(), |v| {
+        Ok(SpecificValue::Number(
+            v.map(Decimal::from_wire).transpose()?,
+        ))
+    })?;
+    read.singular(&mut parts, ITEM_UNIT, c.unit.as_deref(), |v| {
+        Ok(SpecificValue::Text(v.map(str::to_owned)))
+    })?;
+    read.singular(&mut parts, ITEM_ASSERTED_AT, c.asserted_at.as_ref(), |v| {
+        Ok(SpecificValue::Instant(v.map(instant).transpose()?))
+    })?;
+    read.singular(&mut parts, ITEM_LOCATION, c.location_id.as_deref(), |v| {
+        Ok(SpecificValue::Id(v.map(identifier).transpose()?))
+    })?;
+    read.singular(&mut parts, ITEM_TEMPLATE, c.template_id.as_deref(), |v| {
+        Ok(SpecificValue::Id(v.map(identifier).transpose()?))
+    })?;
+    read.repeated(&mut parts, ITEM_PROPERTIES, &c.property_values, |v| {
+        Ok(SpecificValue::Properties(properties(v)?))
+    })?;
+
+    Ok(Written::from_specific(parts))
 }
 
 /// A location's content, off the wire.
 ///
 /// **LANE: Tracking.** `parent_location_id` is the one that owes
-/// [`super::nesting::would_cycle`], from [`super::validate_and_place`], before
-/// the column is written.
+/// [`super::nesting::would_cycle`], from [`validate_and_place`], before the
+/// column is written. Nesting exists and is never required; nothing here bounds
+/// the depth, and a flat set of locations is complete rather than degraded.
 pub fn location(c: &v1::LocationContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::Location,
-        &c.cleared,
-        &[
-            (1, c.parent_location_id.is_some()),
-            (2, c.template_id.is_some()),
-            (3, !c.property_values.is_empty()),
-        ],
-    )
+    let read = Reader::new(EntityType::Location, &c.cleared)?;
+    let mut parts = Vec::new();
+
+    read.singular(
+        &mut parts,
+        LOCATION_PARENT,
+        c.parent_location_id.as_deref(),
+        |v| Ok(SpecificValue::Id(v.map(identifier).transpose()?)),
+    )?;
+    read.singular(
+        &mut parts,
+        LOCATION_TEMPLATE,
+        c.template_id.as_deref(),
+        |v| Ok(SpecificValue::Id(v.map(identifier).transpose()?)),
+    )?;
+    read.repeated(&mut parts, LOCATION_PROPERTIES, &c.property_values, |v| {
+        Ok(SpecificValue::Properties(properties(v)?))
+    })?;
+
+    Ok(Written::from_specific(parts))
 }
 
 /// A shopping list's content, off the wire.
@@ -133,15 +284,181 @@ pub fn shopping_list(c: &v1::ShoppingListContent) -> Result<Written, Malformed> 
     )
 }
 
+/// The property values one message carries.
+///
+/// **A kind is not a constraint**, so nothing here consults what a template says
+/// a property holds, and no value is interpreted, measured, or refused for its
+/// content. The two refusals below are about the message rather than about the
+/// person's answer:
+///
+/// - **A name twice.** The store keys a value by name, so two values under one
+///   name are two instructions with no reading that honours both — the same
+///   class as a field both present and cleared. The store's own upsert would
+///   silently keep whichever came last.
+/// - **A name that is nothing.** The name is the key. A value filed under no
+///   name could never be found again, and the primary key would happily hold it.
+fn properties(values: &[v1::PropertyValue]) -> Result<Vec<Property>, Malformed> {
+    let mut out: Vec<Property> = Vec::with_capacity(values.len());
+    for v in values {
+        if v.name.is_empty() {
+            return Err(malformed(
+                "a property value is keyed by its name, and this one carries none",
+            ));
+        }
+        if out.iter().any(|p| p.name == v.name) {
+            return Err(malformed(format!(
+                "the property `{}` is given a value twice, and a value is keyed by its name",
+                v.name
+            )));
+        }
+        out.push(Property {
+            name: v.name.clone(),
+            value: v.value.clone(),
+        });
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// What a part owes before it is applied
+// ---------------------------------------------------------------------------
+
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<Option<SpecificPart>> {
-    let _ = (ctx, entity, part);
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    match (kind, part.field) {
+        // **The companion.** An amount and the time it was asserted are
+        // constrained against each other, so they move in one statement and the
+        // instance supplies the time. Asserting an amount stamps now; clearing
+        // one clears the stamp with it, because a time an amount was asserted at
+        // is not something an item with no amount has.
+        //
+        // Re-stating the same amount is a real act — *I looked again, still
+        // three* — and it moves the stamp while leaving the amount where it was.
+        // That is what makes freshness recordable at all, given that a count is
+        // only as good as the last time somebody looked.
+        (EntityType::Item, ITEM_AMOUNT) => {
+            let asserted = matches!(part.value, SpecificValue::Number(Some(_)));
+            Ok(Some(SpecificPart {
+                field: ITEM_ASSERTED_AT,
+                value: SpecificValue::Instant(asserted.then_some(ctx.at)),
+            }))
+        }
+
+        // **Not a general modified time.** Renaming an item or correcting its
+        // notes does not confirm what is on the shelf, so nothing but the amount
+        // moves this, and a client may not move it by hand.
+        (EntityType::Item, ITEM_ASSERTED_AT) => {
+            Err(Refusal::Malformed(ASSERTED_AT_IS_THE_INSTANCES.into()).into())
+        }
+
+        // A location has to be one this member can see, and it has to be a
+        // location — the column is a typed foreign key, so pointing at something
+        // else is a refusal rather than a cast.
+        (EntityType::Item, ITEM_LOCATION) => {
+            if let SpecificValue::Id(Some(id)) = part.value {
+                must_be(ctx, EntityId::from_uuid(id), EntityType::Location).await?;
+            }
+            Ok(None)
+        }
+
+        (EntityType::Location, LOCATION_PARENT) => {
+            if let SpecificValue::Id(Some(id)) = part.value {
+                let parent = EntityId::from_uuid(id);
+                // Availability answers first, and it answers before anything
+                // about ancestry is read. A parent this member cannot see and a
+                // parent that does not exist are the same nothing; the cycle
+                // refusal below says more than nothing, so it must not be
+                // reachable for a parent the member was never entitled to know
+                // about.
+                must_be(ctx, parent, EntityType::Location).await?;
+                let table = table_of(kind)?;
+                if nesting::would_cycle(ctx.tx, table, PARENT_LOCATION, entity, parent).await? {
+                    return Err(Refusal::Malformed(
+                        "a location cannot be nested inside itself, directly or through what \
+                         it already contains"
+                            .into(),
+                    )
+                    .into());
+                }
+            }
+            Ok(None)
+        }
+
+        // A template is not an entity and carries no audience: one shared set
+        // reaches items and locations, and following one is the person's own
+        // act. What it owes is existence, checked here so a missing one is a
+        // refusal rather than a foreign-key violation that takes the whole
+        // transaction down.
+        (EntityType::Item, ITEM_TEMPLATE) | (EntityType::Location, LOCATION_TEMPLATE) => {
+            if let SpecificValue::Id(Some(id)) = part.value {
+                template_exists(ctx, id).await?;
+            }
+            Ok(None)
+        }
+
+        // Words the person wrote. Nothing to check that reading them did not
+        // already check.
+        (EntityType::Item, ITEM_UNIT | ITEM_PROPERTIES)
+        | (EntityType::Location, LOCATION_PROPERTIES) => Ok(None),
+
+        (EntityType::ShoppingList, _) => {
+            Err(Refusal::Malformed(SHOPPING_LIST_DEFERRED.into()).into())
+        }
+        _ => Err(unaddressable(kind, part.field)),
+    }
 }
+
+/// An entity this member may act on, and of the type the column requires.
+///
+/// **The three refusals are one.** A location the member cannot see, a location
+/// that does not exist, and an identifier naming something that is not a
+/// location all answer the same nothing — otherwise the refusal would report the
+/// type of a thing the member was never entitled to know existed.
+async fn must_be(ctx: &mut Ctx<'_>, id: EntityId, kind: EntityType) -> Applied<()> {
+    let found = available_for_write(ctx.tx, ctx.member, id, WriteScope::Active)
+        .await?
+        .ok_or(Refusal::NotAvailable)?;
+    if found.entity_type != kind {
+        return Err(Refusal::NotAvailable.into());
+    }
+    Ok(())
+}
+
+/// A template the household has declared.
+///
+/// Not audience-scoped, because a template is not an entity and carries no
+/// audience: it is one shared set reaching items and locations, and remembering
+/// which set a template lives in is exactly the recall this product refuses to
+/// ask for.
+async fn template_exists(ctx: &mut Ctx<'_>, id: Uuid) -> Applied<()> {
+    let found = sqlx::query("SELECT id FROM template WHERE id = $1")
+        .bind(id)
+        .fetch_optional(ctx.tx.conn())
+        .await?;
+    found.ok_or(Refusal::NotAvailable)?;
+    Ok(())
+}
+
+/// A field number the type does not have.
+///
+/// Unreachable through the wire — [`Reader`] validates a number against the type
+/// before a part exists — so this is honesty about a part built some other way
+/// rather than a case that is expected.
+fn unaddressable(kind: EntityType, number: u32) -> Failed {
+    Refusal::Malformed(format!(
+        "field {number} is not a part of a {}",
+        type_name(kind)
+    ))
+    .into()
+}
+
+// ---------------------------------------------------------------------------
+// Reading back, and writing
+// ---------------------------------------------------------------------------
 
 pub async fn current(
     ctx: &mut Ctx<'_>,
@@ -149,8 +466,32 @@ pub async fn current(
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<SpecificPart> {
-    let _ = (ctx, entity, part);
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    match (kind, part.field) {
+        // Rows rather than a column, so the generic column reader cannot serve
+        // them. The order is the one they compare in, which `read_properties`
+        // already puts them in.
+        (EntityType::Item, ITEM_PROPERTIES) | (EntityType::Location, LOCATION_PROPERTIES) => {
+            Ok(SpecificPart {
+                field: part.field,
+                value: SpecificValue::Properties(read_properties(ctx, entity).await?),
+            })
+        }
+        // Everything else is one column, read back through the same rendering
+        // the arriving value goes through. `ITEM_ASSERTED_AT` is here because
+        // the companion is compared like any other part even though no client
+        // may state it.
+        (
+            EntityType::Item,
+            ITEM_AMOUNT | ITEM_UNIT | ITEM_ASSERTED_AT | ITEM_LOCATION | ITEM_TEMPLATE,
+        )
+        | (EntityType::Location, LOCATION_PARENT | LOCATION_TEMPLATE) => {
+            read_column(ctx, entity, kind, part).await
+        }
+        (EntityType::ShoppingList, _) => {
+            Err(Refusal::Malformed(SHOPPING_LIST_DEFERRED.into()).into())
+        }
+        _ => Err(unaddressable(kind, part.field)),
+    }
 }
 
 pub async fn apply(
@@ -160,20 +501,123 @@ pub async fn apply(
     part: &SpecificPart,
     placement: Option<&SpecificPart>,
 ) -> Applied<()> {
-    let _ = (ctx, entity, part, placement);
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    match (kind, part.field) {
+        // **One statement, both columns.** The table refuses the state in
+        // between, so writing them in sequence fails whichever order the
+        // sequence is in.
+        (EntityType::Item, ITEM_AMOUNT) => {
+            let Some(SpecificPart {
+                field: ITEM_ASSERTED_AT,
+                value: SpecificValue::Instant(at),
+            }) = placement
+            else {
+                // Unreachable: `validate_and_place` always produces the
+                // companion for this part. Refused rather than written alone,
+                // because the alternative is a statement the table rejects with
+                // a message nobody can act on.
+                return Err(Refusal::Malformed(
+                    "an amount is written with the time it was asserted, and this write \
+                     carries no time"
+                        .into(),
+                )
+                .into());
+            };
+            let SpecificValue::Number(amount) = &part.value else {
+                return Err(unaddressable(kind, part.field));
+            };
+            // Bound as text and cast, so nothing rounds on the way through —
+            // the same route `write_column` takes for a number.
+            let table = table_of(kind)?;
+            let sql = format!(
+                "UPDATE {table} SET {ASSERTED_AMOUNT} = $2::numeric, {ASSERTED_AT} = $3 \
+                 WHERE entity_id = $1"
+            );
+            sqlx::query(sqlx::AssertSqlSafe(sql))
+                .bind(entity.as_uuid())
+                .bind(amount.as_ref().map(Decimal::text))
+                .bind(*at)
+                .execute(ctx.tx.conn())
+                .await?;
+            Ok(())
+        }
+
+        (EntityType::Item, ITEM_PROPERTIES) | (EntityType::Location, LOCATION_PROPERTIES) => {
+            let SpecificValue::Properties(values) = &part.value else {
+                return Err(unaddressable(kind, part.field));
+            };
+            debug_assert!(placement.is_none());
+            write_properties(ctx, entity, values).await
+        }
+
+        (EntityType::Item, ITEM_UNIT | ITEM_LOCATION | ITEM_TEMPLATE)
+        | (EntityType::Location, LOCATION_PARENT | LOCATION_TEMPLATE) => {
+            debug_assert!(placement.is_none());
+            write_column(ctx, entity, kind, part).await
+        }
+
+        // Refused before it could reach here; see `ASSERTED_AT_IS_THE_INSTANCES`.
+        (EntityType::Item, ITEM_ASSERTED_AT) => {
+            Err(Refusal::Malformed(ASSERTED_AT_IS_THE_INSTANCES.into()).into())
+        }
+        (EntityType::ShoppingList, _) => {
+            Err(Refusal::Malformed(SHOPPING_LIST_DEFERRED.into()).into())
+        }
+        _ => Err(unaddressable(kind, part.field)),
+    }
 }
+
+// ---------------------------------------------------------------------------
+// Searchable text
+// ---------------------------------------------------------------------------
 
 /// What Tracking contributes to searchable text.
 ///
-/// **LANE: Tracking.** The person's word for a unit is words rather than a
-/// value, so it is the plausible one. Contributing nothing is a valid answer
-/// and is what this returns until the lane decides otherwise.
+/// **LANE: Tracking.** The person's own words, and only those. A unit is what
+/// they call it — *tins*, *rolls*, *bottle* — and a property is a name they
+/// chose with a value they typed. Those are the words somebody reaches for when
+/// looking for the thing, and the literal arm is a permanent arm rather than a
+/// fallback, which is what makes a just-captured item findable by them before
+/// any derivation runs.
+///
+/// **Not here:** the amount, the assertion time, and the identifiers of a
+/// location or a template. A number and an instant are values rather than words,
+/// nothing ever reads an identifier (DR-007), and a location's own title is
+/// already searchable on the location.
+///
+/// Availability is not here either, and not because it is awkward: it is
+/// derived and never stored, and putting a derived figure into a person's search
+/// text would make the index disagree with itself the moment a relation moved.
 pub async fn search_text(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
 ) -> Applied<Option<String>> {
-    let _ = (ctx, entity, kind);
-    Ok(None)
+    let mut words: Vec<String> = Vec::new();
+
+    if kind == EntityType::Item {
+        let table = table_of(kind)?;
+        let sql = format!("SELECT {UNIT} AS u FROM {table} WHERE entity_id = $1");
+        let row = sqlx::query(sqlx::AssertSqlSafe(sql))
+            .bind(entity.as_uuid())
+            .fetch_optional(ctx.tx.conn())
+            .await?;
+        if let Some(row) = row
+            && let Some(unit) = row.try_get::<Option<String>, _>("u")?
+        {
+            words.push(unit);
+        }
+    }
+
+    // A shopping list holds no property values and has no side-table row to read
+    // them from. The query would answer empty, but asking it would say this
+    // module thought it might not.
+    if matches!(kind, EntityType::Item | EntityType::Location) {
+        for p in read_properties(ctx, entity).await? {
+            words.push(p.name);
+            words.push(p.value);
+        }
+    }
+
+    words.retain(|w| !w.trim().is_empty());
+    Ok((!words.is_empty()).then(|| words.join(" ")))
 }

--- a/crates/altaird/src/write/specific/tracking.rs
+++ b/crates/altaird/src/write/specific/tracking.rs
@@ -340,6 +340,13 @@ pub async fn validate_and_place(
         // three* — and it moves the stamp while leaving the amount where it was.
         // That is what makes freshness recordable at all, given that a count is
         // only as good as the last time somebody looked.
+        //
+        // Which is why two people counting the same shelf at once, and
+        // agreeing, must not surface a conflict on the stamp: their two
+        // `ctx.at` readings genuinely differ and would never compare equal.
+        // Nothing here has to arrange that — a placement is not a part the
+        // write addressed, so it does not reach conflict detection at all. The
+        // rule and the reasoning are in `write::entity::edit`.
         (EntityType::Item, ITEM_AMOUNT) => {
             let asserted = matches!(part.value, SpecificValue::Number(Some(_)));
             Ok(Some(SpecificPart {

--- a/crates/altaird/tests/type_content_tracking.rs
+++ b/crates/altaird/tests/type_content_tracking.rs
@@ -102,6 +102,18 @@ async fn item_row(world: &World, id: EntityId) -> ItemRow {
     }
 }
 
+/// The container an entity is in and where it sits inside it, which the schema
+/// requires to be both present or both absent.
+async fn category_of(world: &World, id: EntityId) -> (Option<Uuid>, Option<i32>) {
+    let r =
+        sqlx::query("SELECT category_id AS c, category_position AS p FROM entity WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_one(&world.db.pool)
+            .await
+            .expect("entity row");
+    (r.try_get("c").unwrap(), r.try_get("p").unwrap())
+}
+
 async fn location_row(world: &World, id: EntityId) -> (Option<Uuid>, Option<Uuid>) {
     let r = sqlx::query(
         "SELECT parent_location_id AS p, template_id AS t FROM location WHERE entity_id = $1",
@@ -1565,6 +1577,55 @@ async fn two_members_filing_one_item_onto_two_shelves_conflict_only_over_the_she
         "the instance's own append raised a conflict the client cannot settle: {:?}",
         named()
     );
+}
+
+/// **Naming the container an entity is already in is not a move.** A client that
+/// resends the whole of `EntityContent` on every edit states the category each
+/// time, and the instance must leave the position it assigned alone rather than
+/// clear it — the schema's `(category_id IS NULL) = (category_position IS NULL)`
+/// makes clearing it the whole transaction failing, not a quiet reordering.
+#[tokio::test]
+async fn restating_the_category_an_item_is_already_in_keeps_its_position() {
+    let world = World::new().await;
+    let id = shared_item(&world, v1::ItemContent::default()).await;
+    let shelf = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent {
+                title: Some("the cupboard".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    let mut placed = None;
+    for _ in 0..2 {
+        let base = world.counter(id).await;
+        world
+            .submit(
+                &world.one,
+                edit_entity(
+                    id,
+                    base as u64,
+                    v1::EntityContent {
+                        category_id: Some(id_bytes(shelf)),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        let (category, position) = category_of(&world, id).await;
+        assert_eq!(category, Some(shelf.as_uuid()));
+        let position = position.expect("the item is in a container and sits nowhere in it");
+        match placed {
+            None => placed = Some(position),
+            Some(first) => assert_eq!(
+                position, first,
+                "restating the container moved the item within it"
+            ),
+        }
+    }
 }
 
 /// **A stale base is never a rejection**, and different parts merge with nobody

--- a/crates/altaird/tests/type_content_tracking.rs
+++ b/crates/altaird/tests/type_content_tracking.rs
@@ -1,0 +1,1580 @@
+//! Tracking's type content: an item, a location, and what a template does not
+//! own.
+//!
+//! **LANE: Tracking.** The spine's own suite is `type_content.rs` and proves a
+//! type-specific part reaches every mechanism the shared model reaches. This one
+//! proves the three things about this domain that a plausible implementation
+//! gets wrong:
+//!
+//! - **An amount and the time it was asserted move in one statement.** The
+//!   table refuses the state in between, so a sequence of two writes fails
+//!   whichever order it is in.
+//! - **The assertion time is the amount's own.** An unrelated edit must not
+//!   advance it, or a count from March looks fresh — which the PRD says is worse
+//!   than showing nothing.
+//! - **A loop in nested locations is refused where the schema cannot see it.**
+//!   Self-reference passes for free and proves nothing; two hops and three are
+//!   the cases that matter.
+//!
+//! And two the scope decides rather than this lane: property values survive a
+//! template being detached, keyed by the names they had, and a shopping list's
+//! entries are still refused with the reason they are deferred.
+
+mod common;
+
+use altair_proto::v1;
+use altaird::store::ids::EntityId;
+use common::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Building the two messages
+// ---------------------------------------------------------------------------
+
+fn item(c: v1::ItemContent) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Item(c)
+}
+
+fn location(c: v1::LocationContent) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Location(c)
+}
+
+fn decimal(units: i64, nanos: i32) -> v1::Decimal {
+    v1::Decimal { units, nanos }
+}
+
+fn property(name: &str, value: &str) -> v1::PropertyValue {
+    v1::PropertyValue {
+        name: name.into(),
+        value: value.into(),
+    }
+}
+
+fn id_bytes(id: EntityId) -> Vec<u8> {
+    id.as_uuid().as_bytes().to_vec()
+}
+
+/// An edit carrying one type message and nothing else.
+fn edit_specific(
+    id: EntityId,
+    base: i64,
+    specific: v1::entity_content::Specific,
+) -> v1::intent::Action {
+    edit_entity(
+        id,
+        base as u64,
+        v1::EntityContent {
+            specific: Some(specific),
+            ..Default::default()
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Reading the store back
+// ---------------------------------------------------------------------------
+
+/// One item row, as text, so a numeric keeps the precision it was written with.
+struct ItemRow {
+    amount: Option<String>,
+    unit: Option<String>,
+    asserted_at: Option<chrono::DateTime<chrono::Utc>>,
+    location: Option<Uuid>,
+    template: Option<Uuid>,
+}
+
+async fn item_row(world: &World, id: EntityId) -> ItemRow {
+    let r = sqlx::query(
+        "SELECT asserted_amount::text AS amount, unit, asserted_at, location_id, template_id \
+         FROM item WHERE entity_id = $1",
+    )
+    .bind(id.as_uuid())
+    .fetch_one(&world.db.pool)
+    .await
+    .expect("item row");
+    ItemRow {
+        amount: r.try_get("amount").unwrap(),
+        unit: r.try_get("unit").unwrap(),
+        asserted_at: r.try_get("asserted_at").unwrap(),
+        location: r.try_get("location_id").unwrap(),
+        template: r.try_get("template_id").unwrap(),
+    }
+}
+
+async fn location_row(world: &World, id: EntityId) -> (Option<Uuid>, Option<Uuid>) {
+    let r = sqlx::query(
+        "SELECT parent_location_id AS p, template_id AS t FROM location WHERE entity_id = $1",
+    )
+    .bind(id.as_uuid())
+    .fetch_one(&world.db.pool)
+    .await
+    .expect("location row");
+    (r.try_get("p").unwrap(), r.try_get("t").unwrap())
+}
+
+/// Every property value on an entity, by name.
+async fn properties_of(world: &World, id: EntityId) -> Vec<(String, Option<String>)> {
+    sqlx::query("SELECT name, value FROM entity_property_value WHERE entity_id = $1 ORDER BY name")
+        .bind(id.as_uuid())
+        .fetch_all(&world.db.pool)
+        .await
+        .expect("property values")
+        .iter()
+        .map(|r| (r.try_get("name").unwrap(), r.try_get("value").unwrap()))
+        .collect()
+}
+
+async fn search_text(world: &World, id: EntityId) -> String {
+    sqlx::query("SELECT search_text AS s FROM entity WHERE id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("entity")
+        .try_get("s")
+        .expect("search_text")
+}
+
+/// The counters `entity_part_counter` recorded, by part name.
+async fn moved_parts(world: &World, id: EntityId) -> Vec<(String, i64)> {
+    sqlx::query(
+        "SELECT field_name, counter FROM entity_part_counter \
+         WHERE entity_id = $1 AND field_name IS NOT NULL ORDER BY field_name",
+    )
+    .bind(id.as_uuid())
+    .fetch_all(&world.db.pool)
+    .await
+    .expect("part counters")
+    .iter()
+    .map(|r| {
+        (
+            r.try_get("field_name").unwrap(),
+            r.try_get("counter").unwrap(),
+        )
+    })
+    .collect()
+}
+
+/// A template with the property names it contributes.
+///
+/// Declared by hand: nothing on the wire creates a template yet, and a template
+/// contributes names rather than content, so what matters below is only that the
+/// row exists to be followed and detached.
+async fn declare_template(world: &World, name: &str, properties: &[(&str, &str)]) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO template (id, name, created_at) VALUES ($1, $2, now())")
+        .bind(id)
+        .bind(name)
+        .execute(&world.db.pool)
+        .await
+        .expect("template");
+    for (ordinal, (property, kind)) in properties.iter().enumerate() {
+        sqlx::query(
+            "INSERT INTO template_property (template_id, name, kind, ordinal) \
+             VALUES ($1, $2, $3::property_kind, $4)",
+        )
+        .bind(id)
+        .bind(property)
+        .bind(kind)
+        .bind(ordinal as i32)
+        .execute(&world.db.pool)
+        .await
+        .expect("template property");
+    }
+    id
+}
+
+async fn a_location(world: &World, member: &altaird::auth::Member, title: &str) -> EntityId {
+    world
+        .create(
+            member,
+            location(v1::LocationContent::default()),
+            v1::EntityContent {
+                title: Some(title.into()),
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// An item's fields, there and back
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn every_item_field_reaches_the_store_on_creation() {
+    let world = World::new().await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    let template = declare_template(&world, "filament", &[("diameter", "text")]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 250_000_000)),
+                unit: Some("rolls".into()),
+                location_id: Some(id_bytes(shelf)),
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("diameter", "1.75mm"), property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("black filament".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("3.250000000"));
+    assert_eq!(row.unit.as_deref(), Some("rolls"));
+    assert_eq!(row.location, Some(shelf.as_uuid()));
+    assert_eq!(row.template, Some(template));
+    assert!(row.asserted_at.is_some());
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![
+            ("diameter".to_owned(), Some("1.75mm".to_owned())),
+            ("material".to_owned(), Some("PLA".to_owned())),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn every_item_field_moves_on_an_edit() {
+    let world = World::new().await;
+    let first = a_location(&world, &world.one, "the shelf").await;
+    let second = a_location(&world, &world.one, "the garage").await;
+    let template = declare_template(&world, "filament", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(1, 0)),
+                unit: Some("roll".into()),
+                location_id: Some(id_bytes(first)),
+                property_values: vec![property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    asserted_amount: Some(decimal(12, 500_000_000)),
+                    unit: Some("rolls".into()),
+                    location_id: Some(id_bytes(second)),
+                    template_id: Some(template.as_bytes().to_vec()),
+                    property_values: vec![property("material", "PETG")],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("12.500000000"));
+    assert_eq!(row.unit.as_deref(), Some("rolls"));
+    assert_eq!(row.location, Some(second.as_uuid()));
+    assert_eq!(row.template, Some(template));
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![("material".to_owned(), Some("PETG".to_owned()))]
+    );
+}
+
+/// Clearing empties every one of them, and the store holds nothing rather than
+/// an empty string.
+#[tokio::test]
+async fn clearing_every_item_field_empties_it() {
+    let world = World::new().await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    let template = declare_template(&world, "filament", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                unit: Some("rolls".into()),
+                location_id: Some(id_bytes(shelf)),
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    // Every field but the assertion time, which is not one a client states.
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    cleared: vec![1, 2, 4, 5, 6],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount, None);
+    assert_eq!(row.unit, None);
+    assert_eq!(row.location, None);
+    assert_eq!(row.template, None);
+    assert_eq!(row.asserted_at, None, "the time goes with the amount");
+    assert!(properties_of(&world, id).await.is_empty());
+}
+
+/// **No required fields.** An item with a name and nothing else is a complete
+/// item, and so is one with no name at all.
+#[tokio::test]
+async fn an_item_with_a_name_and_nothing_else_is_complete() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent::default()),
+            v1::EntityContent {
+                title: Some("the good screwdriver".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount, None);
+    assert_eq!(row.asserted_at, None);
+    assert_eq!(row.unit, None);
+    assert_eq!(row.location, None);
+}
+
+// ---------------------------------------------------------------------------
+// The amount and its own timestamp
+// ---------------------------------------------------------------------------
+
+/// **The pair, written in one statement.**
+///
+/// `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))` refuses the state
+/// in between, so an implementation that wrote the two columns in sequence would
+/// fail whichever order it chose — the amount alone leaves the time null, and
+/// the time alone leaves the amount null. Both of these submissions would have
+/// been a store fault rather than an acknowledgement, so the assertion is that
+/// they landed at all as much as it is the values.
+#[tokio::test]
+async fn an_amount_and_its_time_are_written_together_or_the_table_refuses_it() {
+    let world = World::new().await;
+
+    // Setting: both arrive.
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("3.000000000"));
+    assert!(row.asserted_at.is_some());
+
+    // Clearing: both leave.
+    let base = world.counter(id).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    cleared: vec![1],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount, None);
+    assert_eq!(row.asserted_at, None);
+}
+
+/// **The requirement most easily broken by a plausible implementation.**
+///
+/// The assertion time is the amount's own and not a general modified time.
+/// Renaming an item or correcting its notes does not confirm what is on the
+/// shelf, and a timestamp that moves when those happen makes a stale count look
+/// fresh — which the PRD calls worse than showing nothing.
+#[tokio::test]
+async fn an_unrelated_edit_leaves_the_assertion_time_alone() {
+    let world = World::new().await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    let template = declare_template(&world, "filament", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let asserted = item_row(&world, id).await.asserted_at.expect("a time");
+
+    // Everything an item has that is not its amount, one edit at a time.
+    let unrelated = [
+        v1::EntityContent {
+            title: Some("black filament".into()),
+            ..Default::default()
+        },
+        v1::EntityContent {
+            specific: Some(item(v1::ItemContent {
+                unit: Some("rolls".into()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+        v1::EntityContent {
+            specific: Some(item(v1::ItemContent {
+                location_id: Some(id_bytes(shelf)),
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+        v1::EntityContent {
+            specific: Some(item(v1::ItemContent {
+                template_id: Some(template.as_bytes().to_vec()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+        v1::EntityContent {
+            specific: Some(item(v1::ItemContent {
+                property_values: vec![property("material", "PLA")],
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+    ];
+
+    for content in unrelated {
+        let base = world.counter(id).await;
+        world
+            .submit(&world.one, edit_entity(id, base as u64, content))
+            .await;
+        assert_eq!(
+            item_row(&world, id).await.asserted_at,
+            Some(asserted),
+            "an edit that is not the amount moved the time the amount was asserted"
+        );
+    }
+
+    assert_eq!(
+        item_row(&world, id).await.amount.as_deref(),
+        Some("3.000000000"),
+        "and the amount itself is untouched"
+    );
+}
+
+/// The other half of the same rule. *I looked again, still three* is a real act,
+/// and it is how the freshness of a count is recorded.
+#[tokio::test]
+async fn re_asserting_the_same_amount_moves_the_time() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let first = item_row(&world, id).await.asserted_at.expect("a time");
+
+    let base = world.counter(id).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    asserted_amount: Some(decimal(3, 0)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("3.000000000"));
+    assert!(
+        row.asserted_at.expect("a time") > first,
+        "counting again is an assertion, even when the answer is the same"
+    );
+}
+
+/// The assertion time is the instance's to set, and the refusal says what a
+/// client is waiting on rather than that its message was wrong.
+#[tokio::test]
+async fn stating_an_assertion_time_is_refused_with_the_reason() {
+    let world = World::new().await;
+    let at = timestamp(chrono::Utc::now());
+
+    // Alone, and alongside the amount it belongs to. Both are the same refusal.
+    for content in [
+        v1::ItemContent {
+            asserted_at: Some(at),
+            ..Default::default()
+        },
+        v1::ItemContent {
+            asserted_amount: Some(decimal(3, 0)),
+            asserted_at: Some(at),
+            ..Default::default()
+        },
+        v1::ItemContent {
+            cleared: vec![3],
+            ..Default::default()
+        },
+    ] {
+        let ack = world
+            .submit(
+                &world.one,
+                create_entity(
+                    Uuid::new_v4(),
+                    v1::EntityContent {
+                        specific: Some(item(content)),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        let r = refused(&ack);
+        assert_eq!(r.reason, v1::RefusalReason::Malformed as i32, "{r:?}");
+        assert!(
+            r.detail.contains("the amount's own") && r.detail.contains("not served yet"),
+            "{}",
+            r.detail
+        );
+    }
+}
+
+/// Both halves of the pair record their movement.
+///
+/// `entity_part_counter` is per part and conflict detection asks which parts
+/// moved between two counter values. A part that does not record its movement is
+/// invisible to that, and the failure is silent.
+#[tokio::test]
+async fn the_amount_and_its_time_each_record_the_counter_they_moved_at() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                unit: Some("tins".into()),
+                property_values: vec![property("brand", "Heinz")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let moved = moved_parts(&world, id).await;
+    for part in ["specific.1", "specific.2", "specific.3", "specific.6"] {
+        assert!(
+            moved
+                .iter()
+                .any(|(name, counter)| name == part && *counter == 1),
+            "{part} recorded no movement, so nothing can conflict on it: {moved:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The number a household's stock is carried in
+// ---------------------------------------------------------------------------
+
+/// Binary floating point is the wrong place for this, so nothing rounds on the
+/// way through the store either.
+#[tokio::test]
+async fn an_amount_keeps_its_precision_through_the_store() {
+    let world = World::new().await;
+    for (units, nanos, text) in [
+        (0_i64, 1_i32, "0.000000001"),
+        (1, 750_000_000, "1.750000000"),
+        (999_999_999, 999_999_999, "999999999.999999999"),
+        (0, 0, "0.000000000"),
+    ] {
+        let id = world
+            .create(
+                &world.one,
+                item(v1::ItemContent {
+                    asserted_amount: Some(decimal(units, nanos)),
+                    ..Default::default()
+                }),
+                v1::EntityContent::default(),
+            )
+            .await;
+        assert_eq!(item_row(&world, id).await.amount.as_deref(), Some(text));
+    }
+}
+
+/// **Not clamped.** A garbled number is a message that cannot be read, and
+/// absorbing one would store something the client never sent — the same failure
+/// as the base counter that was clamped and silently skipped conflict detection.
+#[tokio::test]
+async fn an_amount_out_of_range_is_refused_rather_than_clamped() {
+    let world = World::new().await;
+    for (units, nanos) in [(0_i64, 1_000_000_000_i32), (1, -1), (-1, 1)] {
+        let ack = world
+            .submit(
+                &world.one,
+                create_entity(
+                    Uuid::new_v4(),
+                    v1::EntityContent {
+                        specific: Some(item(v1::ItemContent {
+                            asserted_amount: Some(decimal(units, nanos)),
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        let r = refused(&ack);
+        assert_eq!(
+            r.reason,
+            v1::RefusalReason::Malformed as i32,
+            "{units} units and {nanos} nanos was absorbed: {r:?}"
+        );
+        assert!(r.detail.contains("decimal"), "{}", r.detail);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// An item's location is a typed foreign key
+// ---------------------------------------------------------------------------
+
+/// The column is `FOREIGN KEY (location_id, location_type) REFERENCES entity`,
+/// so pointing at something that is not a location is a refusal rather than a
+/// cast — and rather than a constraint violation taking the transaction down.
+#[tokio::test]
+async fn an_items_location_must_actually_be_a_location() {
+    let world = World::new().await;
+    let note = world.note(&world.one, "not a place").await;
+
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(item(v1::ItemContent {
+                        location_id: Some(id_bytes(note)),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+}
+
+/// **Refusal on audience and refusal on nonexistence are the same nothing.** A
+/// location the member cannot see, one that does not exist, and one that is not
+/// a location all answer identically — reason and detail alike.
+#[tokio::test]
+async fn a_location_that_is_hidden_and_one_that_does_not_exist_are_indistinguishable() {
+    let world = World::new().await;
+    // Private to two, so one cannot see it.
+    let hidden = a_location(&world, &world.two, "the other shelf").await;
+    let never = EntityId::from_uuid(Uuid::new_v4());
+    let note = world.note(&world.one, "not a place").await;
+
+    let mut answers = Vec::new();
+    for target in [hidden, never, note] {
+        let ack = world
+            .submit(
+                &world.one,
+                create_entity(
+                    Uuid::new_v4(),
+                    v1::EntityContent {
+                        specific: Some(item(v1::ItemContent {
+                            location_id: Some(id_bytes(target)),
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        let r = refused(&ack);
+        answers.push((r.reason, r.detail.clone()));
+    }
+
+    assert_eq!(answers[0].0, v1::RefusalReason::NotAvailable as i32);
+    assert!(
+        answers.windows(2).all(|w| w[0] == w[1]),
+        "the three refusals differ, so one of them answers a question about what exists: \
+         {answers:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A location's fields, there and back
+// ---------------------------------------------------------------------------
+
+/// **The guarantee the spine's stub list used to carry, for this type.**
+///
+/// That list asserted a type refused rather than accepting a write and storing
+/// nothing. Once a type is built the claim inverts, and the honest form of it is
+/// this: every field the message addressed is in the row afterwards. Asserting
+/// the stored value rather than the wording of a refusal is what makes it a
+/// guarantee rather than a description.
+#[tokio::test]
+async fn every_location_field_reaches_the_store_on_creation() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let template = declare_template(&world, "hosting account", &[("renews", "date")]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                parent_location_id: Some(id_bytes(cupboard)),
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("shelf", "third"), property("depth", "40cm")],
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("the shelf".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    assert_eq!(
+        location_row(&world, id).await,
+        (Some(cupboard.as_uuid()), Some(template))
+    );
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![
+            ("depth".to_owned(), Some("40cm".to_owned())),
+            ("shelf".to_owned(), Some("third".to_owned())),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn every_location_field_moves_on_an_edit() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let garage = a_location(&world, &world.one, "the garage").await;
+    let template = declare_template(&world, "hosting account", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                parent_location_id: Some(id_bytes(cupboard)),
+                property_values: vec![property("shelf", "third")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                location(v1::LocationContent {
+                    parent_location_id: Some(id_bytes(garage)),
+                    template_id: Some(template.as_bytes().to_vec()),
+                    property_values: vec![property("shelf", "second")],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert_eq!(
+        location_row(&world, id).await,
+        (Some(garage.as_uuid()), Some(template))
+    );
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![("shelf".to_owned(), Some("second".to_owned()))]
+    );
+}
+
+#[tokio::test]
+async fn clearing_every_location_field_empties_it() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let template = declare_template(&world, "hosting account", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                parent_location_id: Some(id_bytes(cupboard)),
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("shelf", "third")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                location(v1::LocationContent {
+                    cleared: vec![1, 2, 3],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert_eq!(location_row(&world, id).await, (None, None));
+    assert!(properties_of(&world, id).await.is_empty());
+}
+
+/// **No required fields**, on this type too. A location with a name and nothing
+/// else is a complete location, and the row holds nothing rather than a default
+/// somebody invented for it.
+#[tokio::test]
+async fn a_location_with_a_name_and_nothing_else_is_complete() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent::default()),
+            v1::EntityContent {
+                title: Some("the drawer".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert_eq!(location_row(&world, id).await, (None, None));
+    assert!(properties_of(&world, id).await.is_empty());
+}
+
+/// A location's parts record their movement, so conflict detection can see them.
+/// The same silent failure as the item's, on the type that has no companion.
+#[tokio::test]
+async fn a_locations_parts_record_the_counter_they_moved_at() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let template = declare_template(&world, "hosting account", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                parent_location_id: Some(id_bytes(cupboard)),
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("shelf", "third")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let moved = moved_parts(&world, id).await;
+    for part in ["specific.1", "specific.2", "specific.3"] {
+        assert!(
+            moved
+                .iter()
+                .any(|(name, counter)| name == part && *counter == 1),
+            "{part} recorded no movement, so nothing can conflict on it: {moved:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Nesting, and the loop the schema cannot see
+// ---------------------------------------------------------------------------
+
+/// Refused through the write path, which is the caller migration one's gap (h)
+/// was waiting for.
+async fn nest(world: &World, child: EntityId, parent: EntityId) -> v1::Acknowledgement {
+    let base = world.counter(child).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                child,
+                base,
+                location(v1::LocationContent {
+                    parent_location_id: Some(id_bytes(parent)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await
+}
+
+fn is_a_loop(ack: &v1::Acknowledgement) -> bool {
+    match &ack.outcome {
+        Some(v1::acknowledgement::Outcome::Refused(r)) => {
+            r.reason == v1::RefusalReason::Malformed as i32
+                && r.detail.contains("nested inside itself")
+        }
+        _ => false,
+    }
+}
+
+/// Self-reference passes for free — the schema already refuses it — so it is
+/// here only to show it still does through this path.
+#[tokio::test]
+async fn a_location_cannot_be_its_own_parent() {
+    let world = World::new().await;
+    let a = a_location(&world, &world.one, "the cupboard").await;
+    let ack = nest(&world, a, a).await;
+    assert!(is_a_loop(&ack), "{:?}", ack.outcome);
+}
+
+/// **The case that matters.** Two hops, which no constraint can see.
+#[tokio::test]
+async fn a_two_hop_loop_in_nested_locations_is_refused() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+
+    // The shelf goes in the cupboard, and then the cupboard is put on the shelf.
+    assert!(matches!(
+        nest(&world, shelf, cupboard).await.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    let ack = nest(&world, cupboard, shelf).await;
+    assert!(is_a_loop(&ack), "{:?}", ack.outcome);
+    assert_eq!(
+        location_row(&world, cupboard).await.0,
+        None,
+        "the refusal left nothing behind"
+    );
+}
+
+#[tokio::test]
+async fn a_longer_loop_in_nested_locations_is_refused() {
+    let world = World::new().await;
+    let house = a_location(&world, &world.one, "the house").await;
+    let room = a_location(&world, &world.one, "the room").await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+
+    for (child, parent) in [(room, house), (cupboard, room), (shelf, cupboard)] {
+        assert!(matches!(
+            nest(&world, child, parent).await.outcome,
+            Some(v1::acknowledgement::Outcome::Applied(_))
+        ));
+    }
+
+    // Four hops back up to the top.
+    let ack = nest(&world, house, shelf).await;
+    assert!(is_a_loop(&ack), "{:?}", ack.outcome);
+}
+
+/// **Nesting exists and is never required**, and the depth is nowhere bounded.
+/// A flat set of locations is complete rather than degraded.
+#[tokio::test]
+async fn nesting_is_optional_and_its_depth_is_not_bounded() {
+    let world = World::new().await;
+    let flat = a_location(&world, &world.one, "the drawer").await;
+    assert_eq!(location_row(&world, flat).await.0, None);
+
+    let mut previous: Option<EntityId> = None;
+    for depth in 0..8 {
+        let here = a_location(&world, &world.one, &format!("level {depth}")).await;
+        if let Some(parent) = previous {
+            assert!(
+                matches!(
+                    nest(&world, here, parent).await.outcome,
+                    Some(v1::acknowledgement::Outcome::Applied(_))
+                ),
+                "nesting stopped being allowed at depth {depth}"
+            );
+            assert_eq!(location_row(&world, here).await.0, Some(parent.as_uuid()));
+        }
+        previous = Some(here);
+    }
+}
+
+/// A parent the member cannot see answers before anything about ancestry is
+/// read, so the cycle refusal — which says more than nothing — is never reachable
+/// for a location they were not entitled to know about.
+#[tokio::test]
+async fn a_parent_the_member_cannot_see_is_the_same_nothing() {
+    let world = World::new().await;
+    let hidden = a_location(&world, &world.two, "theirs").await;
+    let mine = a_location(&world, &world.one, "mine").await;
+
+    let base = world.counter(mine).await;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_specific(
+                mine,
+                base,
+                location(v1::LocationContent {
+                    parent_location_id: Some(id_bytes(hidden)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+}
+
+// ---------------------------------------------------------------------------
+// Templates and property values
+// ---------------------------------------------------------------------------
+
+/// **Detaching is always available and never destructive.** The entity stops
+/// following the template and keeps every value it holds, with the names it had
+/// at that moment — which is why the store keys a value by name rather than by a
+/// reference to the template's property.
+#[tokio::test]
+async fn a_property_value_survives_its_template_being_detached() {
+    let world = World::new().await;
+    let template = declare_template(
+        &world,
+        "filament",
+        &[("diameter", "text"), ("material", "text")],
+    )
+    .await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("diameter", "1.75mm"), property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let base = world.counter(id).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    cleared: vec![5],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert_eq!(item_row(&world, id).await.template, None);
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![
+            ("diameter".to_owned(), Some("1.75mm".to_owned())),
+            ("material".to_owned(), Some("PLA".to_owned())),
+        ],
+        "detaching a template took the values with it"
+    );
+}
+
+/// **Following is live, not a copy**, so a value is not re-keyed when the
+/// template's property is renamed. It keeps the name it had, which is the whole
+/// reason for keying by name.
+#[tokio::test]
+async fn a_stored_value_keeps_the_name_it_had_when_the_template_renames_its_property() {
+    let world = World::new().await;
+    let template = declare_template(&world, "filament", &[("material", "text")]).await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    sqlx::query("UPDATE template_property SET name = $2 WHERE template_id = $1 AND name = $3")
+        .bind(template)
+        .bind("polymer")
+        .bind("material")
+        .execute(&world.db.pool)
+        .await
+        .expect("rename");
+
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![("material".to_owned(), Some("PLA".to_owned()))]
+    );
+}
+
+/// One shared set reaches items *and* locations. A hosting account is a place a
+/// virtual machine lives and also a thing with credentials and a renewal date,
+/// and whether it is tracked as an item or a location is the person's call.
+#[tokio::test]
+async fn a_template_reaches_a_location_too() {
+    let world = World::new().await;
+    let template = declare_template(&world, "hosting account", &[("renews", "date")]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("account", "vps-1")],
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("the VPS".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    assert_eq!(location_row(&world, id).await.1, Some(template));
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![("account".to_owned(), Some("vps-1".to_owned()))]
+    );
+}
+
+/// A template that was never declared is a refusal, not a foreign-key violation
+/// that takes the transaction down with a message nobody can act on.
+#[tokio::test]
+async fn a_template_that_does_not_exist_is_refused() {
+    let world = World::new().await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(item(v1::ItemContent {
+                        template_id: Some(Uuid::new_v4().as_bytes().to_vec()),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+}
+
+/// **A kind is not a constraint.** No lengths, no ranges, no patterns, and
+/// nothing required. A number property holding *about a dozen* is a real answer,
+/// because an approximate amount is a real answer.
+#[tokio::test]
+async fn a_property_kind_constrains_nothing() {
+    let world = World::new().await;
+    let template = declare_template(
+        &world,
+        "stock",
+        &[("count", "number"), ("bought", "date"), ("open", "boolean")],
+    )
+    .await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![
+                    property("count", "about a dozen"),
+                    property("bought", "some time last spring"),
+                    property("open", "half"),
+                    // And a name the template never declared, which is not the
+                    // template's business either.
+                    property("undeclared", ""),
+                ],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![
+            (
+                "bought".to_owned(),
+                Some("some time last spring".to_owned())
+            ),
+            ("count".to_owned(), Some("about a dozen".to_owned())),
+            ("open".to_owned(), Some("half".to_owned())),
+            ("undeclared".to_owned(), Some(String::new())),
+        ]
+    );
+}
+
+/// The list is the value, so it is replaced whole rather than merged. Anything
+/// nested is replaced whole; the proto says so of a routine's occurrences and
+/// the reasoning is the same.
+#[tokio::test]
+async fn property_values_are_replaced_whole_rather_than_merged() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                property_values: vec![property("a", "1"), property("b", "2")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    property_values: vec![property("b", "two"), property("c", "3")],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![
+            ("b".to_owned(), Some("two".to_owned())),
+            ("c".to_owned(), Some("3".to_owned())),
+        ]
+    );
+}
+
+/// The store keys a value by name, so one name twice is two instructions with no
+/// reading that honours both — and the store's own upsert would silently keep
+/// whichever came last.
+#[tokio::test]
+async fn one_property_name_given_two_values_is_malformed() {
+    let world = World::new().await;
+    for values in [
+        vec![property("material", "PLA"), property("material", "PETG")],
+        vec![property("", "nameless")],
+    ] {
+        let ack = world
+            .submit(
+                &world.one,
+                create_entity(
+                    Uuid::new_v4(),
+                    v1::EntityContent {
+                        specific: Some(item(v1::ItemContent {
+                            property_values: values,
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        let r = refused(&ack);
+        assert_eq!(r.reason, v1::RefusalReason::Malformed as i32, "{r:?}");
+        assert!(r.detail.contains("keyed by its name"), "{}", r.detail);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conflict, on the parts this lane added
+// ---------------------------------------------------------------------------
+
+async fn shared_item(world: &World, content: v1::ItemContent) -> EntityId {
+    world
+        .create(
+            &world.one,
+            item(content),
+            v1::EntityContent {
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+#[tokio::test]
+async fn a_same_part_conflict_on_an_amount_retains_both_values() {
+    let world = World::new().await;
+    let id = shared_item(
+        &world,
+        v1::ItemContent {
+            asserted_amount: Some(decimal(3, 0)),
+            ..Default::default()
+        },
+    )
+    .await;
+    let base = world.counter(id).await;
+
+    for (member, amount) in [(&world.one, decimal(2, 0)), (&world.two, decimal(5, 0))] {
+        world
+            .submit(
+                member,
+                edit_specific(
+                    id,
+                    base,
+                    item(v1::ItemContent {
+                        asserted_amount: Some(amount),
+                        ..Default::default()
+                    }),
+                ),
+            )
+            .await;
+    }
+
+    let conflicts = world.conflicts(id).await;
+    let amount = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.1"))
+        .expect("two people counted the same shelf and got different answers");
+    assert_eq!(amount.mine.as_deref(), Some("5.000000000"));
+    assert_eq!(amount.theirs.as_deref(), Some("2.000000000"));
+    assert_eq!(amount.mine_member, Some(world.two.membership_id()));
+    assert_eq!(
+        item_row(&world, id).await.amount.as_deref(),
+        Some("5.000000000")
+    );
+}
+
+/// **Writes producing the same value are not divergent.** Two people counting
+/// the same shelf and agreeing is the likely case, and forming a conflict out of
+/// agreement is the machinery working against its own purpose.
+#[tokio::test]
+async fn two_members_asserting_the_same_amount_do_not_conflict_on_it() {
+    let world = World::new().await;
+    let id = shared_item(&world, v1::ItemContent::default()).await;
+    let base = world.counter(id).await;
+
+    for member in [&world.one, &world.two] {
+        world
+            .submit(
+                member,
+                edit_specific(
+                    id,
+                    base,
+                    item(v1::ItemContent {
+                        asserted_amount: Some(decimal(4, 0)),
+                        unit: Some("tins".into()),
+                        ..Default::default()
+                    }),
+                ),
+            )
+            .await;
+    }
+
+    let conflicts = world.conflicts(id).await;
+    assert!(
+        !conflicts
+            .iter()
+            .any(|c| c.field.as_deref() == Some("specific.1")),
+        "agreement about the amount was recorded as a disagreement: {:?}",
+        conflicts
+            .iter()
+            .map(|c| c.field.clone())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !conflicts
+            .iter()
+            .any(|c| c.field.as_deref() == Some("specific.2")),
+        "agreement about the unit was recorded as a disagreement"
+    );
+    assert_eq!(
+        item_row(&world, id).await.amount.as_deref(),
+        Some("4.000000000")
+    );
+}
+
+/// **A stale base is never a rejection**, and different parts merge with nobody
+/// involved. One counts the tins, the other names the unit.
+#[tokio::test]
+async fn a_stale_base_over_different_item_parts_merges_and_is_never_a_rejection() {
+    let world = World::new().await;
+    let id = shared_item(&world, v1::ItemContent::default()).await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    unit: Some("tins".into()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+    let ack = world
+        .submit(
+            &world.two,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    asserted_amount: Some(decimal(6, 0)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert!(
+        applied(&ack).conflict.is_none(),
+        "different parts merge; a stale base alone is not a conflict and never a rejection"
+    );
+    let row = item_row(&world, id).await;
+    assert_eq!(row.unit.as_deref(), Some("tins"));
+    assert_eq!(row.amount.as_deref(), Some("6.000000000"));
+}
+
+// ---------------------------------------------------------------------------
+// What Tracking contributes to searchable text
+// ---------------------------------------------------------------------------
+
+/// The person's own words, so a just-captured item is findable by them before
+/// any derivation runs — which is what makes the literal arm a permanent arm
+/// rather than a fallback.
+#[tokio::test]
+async fn an_items_unit_and_property_values_reach_its_searchable_text() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                unit: Some("rolls".into()),
+                property_values: vec![property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("black filament".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    let text = search_text(&world, id).await;
+    for word in ["black filament", "rolls", "material", "PLA"] {
+        assert!(text.contains(word), "{word} is not in {text:?}");
+    }
+    // Not the amount, which is a value rather than a word, and not the
+    // assertion time.
+    assert!(
+        !text.contains("3.0"),
+        "the amount reached search text: {text:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_locations_property_values_reach_its_searchable_text() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                property_values: vec![property("renews", "March")],
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("the VPS".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    let text = search_text(&world, id).await;
+    assert!(
+        text.contains("the VPS") && text.contains("renews") && text.contains("March"),
+        "{text:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The refusal that is not this lane's to lift
+// ---------------------------------------------------------------------------
+
+/// `altair-v0-scope.md` defers shopping lists deliberately rather than
+/// incidentally, and it governs the implementation plan where the two disagree.
+/// Building item and location content does not touch that, and this is the test
+/// that says so.
+#[tokio::test]
+async fn a_shopping_lists_entries_are_still_refused_with_the_reason() {
+    let world = World::new().await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::ShoppingList(
+                        v1::ShoppingListContent {
+                            body: Some("milk\nbread".into()),
+                            cleared: Vec::new(),
+                        },
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let r = refused(&ack);
+    assert_eq!(r.reason, v1::RefusalReason::Malformed as i32, "{r:?}");
+    assert!(
+        r.detail.contains("deferred in v0") && r.detail.contains("anchor granularity"),
+        "{}",
+        r.detail
+    );
+
+    // And the list itself is still a thing that can be created.
+    world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::ShoppingList(v1::ShoppingListContent::default()),
+            v1::EntityContent {
+                title: Some("the weekly shop".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+}

--- a/crates/altaird/tests/type_content_tracking.rs
+++ b/crates/altaird/tests/type_content_tracking.rs
@@ -578,9 +578,13 @@ async fn stating_an_assertion_time_is_refused_with_the_reason() {
 
 /// Both halves of the pair record their movement.
 ///
-/// `entity_part_counter` is per part and conflict detection asks which parts
-/// moved between two counter values. A part that does not record its movement is
-/// invisible to that, and the failure is silent.
+/// `entity_part_counter` is per part, and it answers two questions. For a part
+/// a write addressed, it is what conflict detection reads to ask which parts
+/// moved between two counter values. For the stamp, which no write addresses
+/// and which therefore never conflicts, it is the only record of *when the
+/// count was last taken and by whom* — the time is in the column, the member is
+/// only here. A part that does not record its movement is invisible to both,
+/// and the failure is silent.
 #[tokio::test]
 async fn the_amount_and_its_time_each_record_the_counter_they_moved_at() {
     let world = World::new().await;
@@ -603,7 +607,8 @@ async fn the_amount_and_its_time_each_record_the_counter_they_moved_at() {
             moved
                 .iter()
                 .any(|(name, counter)| name == part && *counter == 1),
-            "{part} recorded no movement, so nothing can conflict on it: {moved:?}"
+            "{part} recorded no movement, so it is invisible to everything that \
+             reads provenance: {moved:?}"
         );
     }
 }
@@ -614,6 +619,11 @@ async fn the_amount_and_its_time_each_record_the_counter_they_moved_at() {
 
 /// Binary floating point is the wrong place for this, so nothing rounds on the
 /// way through the store either.
+///
+/// **A negative amount is carried, not refused**, and the last two rows are
+/// what make that a decision rather than an omission. *Two eggs short* is
+/// something a person means, and the range check next door refuses a decimal
+/// that names no number rather than one that names an inconvenient one.
 #[tokio::test]
 async fn an_amount_keeps_its_precision_through_the_store() {
     let world = World::new().await;
@@ -622,6 +632,8 @@ async fn an_amount_keeps_its_precision_through_the_store() {
         (1, 750_000_000, "1.750000000"),
         (999_999_999, 999_999_999, "999999999.999999999"),
         (0, 0, "0.000000000"),
+        (-2, 0, "-2.000000000"),
+        (-1, -500_000_000, "-1.500000000"),
     ] {
         let id = world
             .create(
@@ -1374,11 +1386,32 @@ async fn a_same_part_conflict_on_an_amount_retains_both_values() {
         item_row(&world, id).await.amount.as_deref(),
         Some("5.000000000")
     );
+
+    // The stamp beside the amount says nothing the amount has not already said,
+    // so it is not a second conflict. Here that only tidies; the test below is
+    // where it decides the answer.
+    assert!(
+        !conflicts
+            .iter()
+            .any(|c| c.field.as_deref() == Some("specific.3")),
+        "the stamp raised a conflict of its own beside the amount's: {:?}",
+        conflicts
+            .iter()
+            .map(|c| c.field.clone())
+            .collect::<Vec<_>>()
+    );
 }
 
 /// **Writes producing the same value are not divergent.** Two people counting
 /// the same shelf and agreeing is the likely case, and forming a conflict out of
 /// agreement is the machinery working against its own purpose.
+///
+/// The stamp is where that is easiest to lose. It moves on every amount write,
+/// including a re-assertion of the same amount, and it carries the instance's
+/// `Utc::now()` — so two members who agree perfectly about the count still hold
+/// two instants that never compare equal. Were the stamp a part conflict
+/// detection saw, agreement would produce a conflict on a field the client is
+/// refused permission to state and therefore cannot settle by restating.
 #[tokio::test]
 async fn two_members_asserting_the_same_amount_do_not_conflict_on_it() {
     let world = World::new().await;
@@ -1419,9 +1452,118 @@ async fn two_members_asserting_the_same_amount_do_not_conflict_on_it() {
             .any(|c| c.field.as_deref() == Some("specific.2")),
         "agreement about the unit was recorded as a disagreement"
     );
+    // The load-bearing one: asserting the amount stamped a fresh instant for
+    // each member, and the two differ by however long the second write took.
+    // Nothing may make a conflict out of that.
+    assert!(
+        !conflicts
+            .iter()
+            .any(|c| c.field.as_deref() == Some("specific.3")),
+        "two people who agreed about the count were handed a conflict on the \
+         stamp, which neither of them wrote and neither can settle"
+    );
+    assert!(
+        conflicts.is_empty(),
+        "agreement produced a conflict somewhere: {:?}",
+        conflicts
+            .iter()
+            .map(|c| c.field.clone())
+            .collect::<Vec<_>>()
+    );
     assert_eq!(
         item_row(&world, id).await.amount.as_deref(),
         Some("4.000000000")
+    );
+}
+
+/// **A placement is not a part the write addressed**, so two members filing one
+/// item into two different shelves conflict over the shelf and not over where
+/// on it the instance put them.
+///
+/// The stamp beside an amount is one instance-assigned companion; the position
+/// inside a category is the other, and it is the shared model's rather than a
+/// type's — so it is the case that proves the rule is general and not a special
+/// arrangement tracking made for itself. Each member enters a container, each
+/// append reads its own next position, and the two differ for exactly the reason
+/// the two stamps do. Neither member named a position; an explicit one is
+/// refused outright. So a conflict here would be as unsettleable as the stamp's,
+/// and it would sit beside a `category_id` conflict that already says the whole
+/// of what happened.
+#[tokio::test]
+async fn two_members_filing_one_item_onto_two_shelves_conflict_only_over_the_shelf() {
+    let world = World::new().await;
+    let id = shared_item(&world, v1::ItemContent::default()).await;
+    let base = world.counter(id).await;
+
+    let mut shelves = Vec::new();
+    for title in ["the cupboard", "the cellar"] {
+        shelves.push(
+            world
+                .create(
+                    &world.one,
+                    v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+                    v1::EntityContent {
+                        title: Some(title.into()),
+                        audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                        ..Default::default()
+                    },
+                )
+                .await,
+        );
+    }
+
+    // The cellar already holds something, so the two appends land on different
+    // numbers. Without this they would both be the first thing in an empty
+    // container, the two positions would agree, and the test would pass on a
+    // coincidence rather than on the rule.
+    world
+        .create(
+            &world.one,
+            item(v1::ItemContent::default()),
+            v1::EntityContent {
+                title: Some("a jar of something older".into()),
+                category_id: Some(id_bytes(shelves[1])),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    for (member, shelf) in [(&world.one, shelves[0]), (&world.two, shelves[1])] {
+        world
+            .submit(
+                member,
+                edit_entity(
+                    id,
+                    base as u64,
+                    v1::EntityContent {
+                        category_id: Some(id_bytes(shelf)),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+    }
+
+    let conflicts = world.conflicts(id).await;
+    let named = || {
+        conflicts
+            .iter()
+            .map(|c| c.field.clone())
+            .collect::<Vec<_>>()
+    };
+    assert!(
+        conflicts
+            .iter()
+            .any(|c| c.field.as_deref() == Some("category_id")),
+        "two shelves were named and neither was recorded as displaced: {:?}",
+        named()
+    );
+    assert!(
+        !conflicts
+            .iter()
+            .any(|c| c.field.as_deref() == Some("category_position")),
+        "the instance's own append raised a conflict the client cannot settle: {:?}",
+        named()
     );
 }
 


### PR DESCRIPTION
Fourth of nine slices of Wave 2.2. Stacked on #23. Fills in one module the spine stubbed — `write/specific/tracking.rs` — and touches nothing else.

## What it does

**An item** carries an asserted amount, the person's word for the unit, when the amount was last asserted, a location, a template, and property values. **A location** carries a parent location, a template, and property values. Neither has a required field: *"an item with a name and nothing else is a complete item"*, and the name is the shared `title` rather than a property of its own.

Availability is **derived, never stored** — computing it here would put a figure in the index that disagrees with itself the moment a relation moves.

## Three things the table forces, and one it does not

**Amount and its timestamp move together or the row is refused.** `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))` means writing them in sequence puts the row through a state the schema rejects, whichever order you pick. Verified by deliberate violation: splitting the write into two statements turns 13 tests red, because the check takes the whole submission down as a store fault rather than producing a refusal anyone can act on.

**`asserted_at` is the amount's own timestamp, not a general modified time.** An unrelated edit must not advance it — walked across title, unit, location, template and properties, one edit at a time. Also verified by violation: making it a general modified time turns that test red. The converse holds too — re-asserting the same amount *does* move the time, because counting again is an assertion even when the answer is unchanged.

**A property value is keyed by the name the property had when it was set**, not by a reference to the template property, so detaching a template keeps every value with the names it had then. Two tests: the value survives detachment, and a template renaming its property does not re-key the stored value.

**A negative asserted amount is accepted.** The PRD never forbids one, and this product does not tell a person they have done something wrong.

## Cycle prevention

The schema refuses self-reference only and records the gap itself: *"Nothing prevents a cycle in nested locations or categories. Self reference is refused; a longer loop is not, and a recursive query would not terminate on one."* This calls the shared `nesting::would_cycle` from the spine rather than writing its own walk.

Tested at two hops and four hops through the write path, not just self-reference — **self-reference passes for free and proves nothing.** Disabling `would_cycle` turns all three loop tests red and leaves the self-reference test green, which is the point.

## Templates are in force, and that is a reading

Migration one records the ambiguity as its gap (i): the scope names Tracking's core as "items, nested locations and quantity", which reads as an enumeration, while also saying anything not named as deferred is in force — and templates are not named as deferred. **The schema resolved it on the second reading by creating the tables.** This follows the schema and cites the gap rather than re-arguing it.

## Two refusals not in the original scope

A property name given two values, and a property with an empty name. The store keys by name and its upsert would otherwise silently keep whichever arrived last.

## One deviation worth reviewing on its own

**`search_text` is contributed here and by no other domain.** An item contributes its unit and its property names and values; a location its property values — the person's own words, and the literal arm is permanent. Excluded: the amount, the assertion time, and every identifier, which are values rather than words.

Guidance, Knowledge and categories all contribute nothing, each for a defensible reason. That means *"the person's own words reach the index"* currently exists in one module, decided in one lane. **It is carried to Wave 3.1 as a named cross-domain decision rather than an inherited default**, and if it lands differently this is the one that changes.

## Verification

- `cargo test --workspace`: 28 targets, 313 tests, 0 failures.
- Three of the four load-bearing claims above were only provably load-bearing after breaking the implementation and watching the right tests go red.
