### PR TITLE
Wave 2.2 slice 5: categories, and a note's words where a search can find them

### DIFF
--- a/crates/altaird/src/write/specific/category.rs
+++ b/crates/altaird/src/write/specific/category.rs
@@ -22,31 +22,71 @@
 //!
 //! Add a bespoke query here and the guard fails on the next run. That is the
 //! guard working. Read its module documentation before deciding it is in the
-//! way.
+//! way. The same rule is why the two checks below reach the store through
+//! [`available_for_write`], [`memberships_exist`] and
+//! [`nesting::would_cycle`] rather than through a statement of their own.
 //!
-//! # What is not decided here
+//! # What a creation default is, and the three things it is not
 //!
-//! **Cycle prevention in nested categories.** Migration one refuses
-//! self-reference and records a longer loop as its gap (h).
-//! [`super::nesting::would_cycle`] is the check, and it is written once because
+//! `altair-substrate-spec.md` states it in one sentence and the schema repeats
+//! it: **it acts once, at the creation of an entity placed in this category.
+//! Not a standing rule, and never inherited.** Each clause is a separate claim,
+//! and none of them is enforced here — they are all consequences of where the
+//! value is *read*, which is [`super::super::entity`]'s create and nowhere
+//! else:
+//!
+//! - **Once, at creation.** Only the create path asks a category for its
+//!   default, so an edit moving an existing entity into this category cannot
+//!   apply one.
+//! - **Not a standing rule.** The value is copied onto the entity at creation
+//!   and never consulted again, so editing it here reaches nothing already
+//!   placed.
+//! - **Never inherited.** The read is of one row and walks no ancestry, so a
+//!   child category with no default of its own has none.
+//!
+//! Writing it is therefore an ordinary column write, and the care goes into not
+//! accidentally making it anything more than that. A category **never sets an
+//! audience** as a standing rule, which is exactly why the default is this
+//! narrow.
+//!
+//! # Cycle prevention in nested categories
+//!
+//! Migration one refuses self-reference and records a longer loop as its gap
+//! (h). [`nesting::would_cycle`] is the check, and it is written once because
 //! nested locations need exactly the same one.
 
 use altair_proto::v1;
 
-use crate::store::entity::EntityType;
+use crate::store::WriteScope;
+use crate::store::entity::{EntityType, available_for_write};
 use crate::store::ids::EntityId;
 
-use super::super::content::{Malformed, Written};
-use super::super::entity::{Applied, Ctx, Refusal};
-use super::{Field, Held, SpecificPart, not_yet_built, unbuilt};
+use super::super::content::{Malformed, Written, identifier};
+use super::super::entity::{Applied, Ctx, Refusal, memberships_exist};
+use super::{Field, Held, Reader, SpecificPart, SpecificValue, nesting, read_column, write_column};
+
+/// A category's field 1, the category it nests inside.
+pub const CATEGORY_PARENT: u32 = 1;
+
+/// A category's field 2, the audience a newly created entity placed here takes
+/// when the write states none of its own.
+pub const CATEGORY_CREATION_DEFAULT: u32 = 2;
+
+/// The store's spelling of the parent column, named once.
+///
+/// [`nesting::would_cycle`] is generic over the column so that one walk serves
+/// nested categories and nested locations, and it takes a `&'static str` so
+/// that nothing a caller sent can ever reach it. This is that string, and it is
+/// the same one [`CATEGORY_FIELDS`] declares.
+const PARENT_COLUMN: &str = "parent_category_id";
 
 pub const CATEGORY_FIELDS: &[Field] = &[
     Field {
-        number: 1,
-        held: Held::Column("parent_category_id"),
+        number: CATEGORY_PARENT,
+        held: Held::Column(PARENT_COLUMN),
     },
     Field {
-        number: 2,
+        number: CATEGORY_CREATION_DEFAULT,
         held: Held::Column("creation_default_audience"),
     },
 ];
@@ -56,24 +96,104 @@ pub const CATEGORY_FIELDS: &[Field] = &[
 /// **LANE: Knowledge + categories.** Wave 2.1 already *reads* the creation
 /// default when it places a newly created entity, so filling this in is what
 /// makes that path reachable by anything other than a hand-written row.
+///
+/// Emptying the member list is how the default is cleared, which is the
+/// repeated field's rule and not a special case: a category with no default and
+/// one whose default was emptied are the same category, and the column is
+/// `NOT NULL DEFAULT '{}'` so there is no third state for them to differ in.
 pub fn category(c: &v1::CategoryContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::Category,
-        &c.cleared,
-        &[
-            (1, c.parent_category_id.is_some()),
-            (2, !c.creation_default_audience_member_ids.is_empty()),
-        ],
-    )
+    let read = Reader::new(EntityType::Category, &c.cleared)?;
+    let mut parts = Vec::new();
+    read.singular(
+        &mut parts,
+        CATEGORY_PARENT,
+        c.parent_category_id.as_deref(),
+        |v| Ok(SpecificValue::Id(v.map(identifier).transpose()?)),
+    )?;
+    read.repeated(
+        &mut parts,
+        CATEGORY_CREATION_DEFAULT,
+        &c.creation_default_audience_member_ids,
+        |v| {
+            let mut ids = Vec::with_capacity(v.len());
+            for member in v {
+                ids.push(identifier(member)?);
+            }
+            Ok(SpecificValue::Members(ids))
+        },
+    )?;
+    Ok(Written::from_specific(parts))
 }
 
+/// What a category's parts owe before they are applied.
+///
+/// **No companion part.** Entering a category places an entity at the end of
+/// it, and that is the shared model's `category_id` and `category_position`
+/// moving together. Nesting a category inside another is not that: migration
+/// one's gap (g) records that nested categories carry no position, because
+/// nothing yet states that their contents are hand ordered. So this returns
+/// `None` always, and the day something states otherwise is the day this grows
+/// a companion, exactly as an arc's ladder position is one.
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     part: &SpecificPart,
 ) -> Applied<Option<SpecificPart>> {
-    let _ = (ctx, entity, part);
-    Err(Refusal::Malformed(not_yet_built(EntityType::Category).0).into())
+    match (part.field, &part.value) {
+        // Leaving the nesting owes nothing. There is no position to forget, and
+        // a category at the top is an ordinary category.
+        (CATEGORY_PARENT, SpecificValue::Id(None)) => Ok(None),
+        (CATEGORY_PARENT, SpecificValue::Id(Some(parent))) => {
+            let parent = EntityId::from_uuid(*parent);
+            // The parent has to be one this member can see, and it has to be a
+            // category. **Both refusals are the same nothing**, which is the
+            // same answer the shared model gives for the category an entity is
+            // placed in: a category the member cannot see and one that does not
+            // exist are indistinguishable from outside, or the refusal is an
+            // oracle for what else the household holds.
+            let found = available_for_write(ctx.tx, ctx.member, parent, WriteScope::Active)
+                .await?
+                .ok_or(Refusal::NotAvailable)?;
+            if found.entity_type != EntityType::Category {
+                return Err(Refusal::NotAvailable.into());
+            }
+            // And the nesting has to terminate. The schema refuses the one-step
+            // case and can see no further; this is its gap (h), closed where
+            // the write is decided because a constraint cannot walk a chain.
+            //
+            // **Malformed rather than not-available**, and that is not a leak:
+            // the member has already been told the parent is there — the check
+            // above passed — so saying the nesting would close a loop discloses
+            // nothing further, and telling them the category is merely
+            // unavailable would send them looking for a permission problem that
+            // is not there.
+            let table = super::side_table(EntityType::Category)
+                .ok_or_else(|| Refusal::Malformed("a category has no table".into()))?;
+            if nesting::would_cycle(ctx.tx, table, PARENT_COLUMN, entity, parent).await? {
+                return Err(Refusal::Malformed(
+                    "nesting this category there would close a loop, and a category cannot \
+                     contain itself at any distance"
+                        .into(),
+                )
+                .into());
+            }
+            Ok(None)
+        }
+        // **Every member named must answer to a real membership.** A foreign
+        // key cannot reach inside an array, which is why the schema lists this
+        // among the checks it cannot make. The refusal is the same nothing
+        // again: a membership in another household and one that was never
+        // created are both simply not there.
+        (CATEGORY_CREATION_DEFAULT, SpecificValue::Members(ids)) => {
+            if !memberships_exist(ctx.tx, ids).await? {
+                return Err(Refusal::NotAvailable.into());
+            }
+            Ok(None)
+        }
+        _ => Err(
+            Refusal::Malformed(format!("field {} is not a part of a category", part.field)).into(),
+        ),
+    }
 }
 
 pub async fn current(
@@ -81,8 +201,7 @@ pub async fn current(
     entity: EntityId,
     part: &SpecificPart,
 ) -> Applied<SpecificPart> {
-    let _ = (ctx, entity, part);
-    Err(Refusal::Malformed(not_yet_built(EntityType::Category).0).into())
+    read_column(ctx, entity, EntityType::Category, part).await
 }
 
 pub async fn apply(
@@ -91,14 +210,18 @@ pub async fn apply(
     part: &SpecificPart,
     placement: Option<&SpecificPart>,
 ) -> Applied<()> {
-    let _ = (ctx, entity, part, placement);
-    Err(Refusal::Malformed(not_yet_built(EntityType::Category).0).into())
+    // A category nests without a position, so nothing moves alongside either of
+    // its parts. See [`validate_and_place`].
+    debug_assert!(placement.is_none());
+    write_column(ctx, entity, EntityType::Category, part).await
 }
 
 /// A category contributes nothing to searchable text.
 ///
 /// Its own title is the shared model's and is already searchable; what it holds
-/// is other entities, and each of those carries its own words.
+/// is other entities, and each of those carries its own words. A category is an
+/// entity rather than a label — describable, relatable, and returned by
+/// retrieval in its own right — and the title is what makes that true.
 pub async fn search_text(ctx: &mut Ctx<'_>, entity: EntityId) -> Applied<Option<String>> {
     let _ = (ctx, entity);
     Ok(None)

--- a/crates/altaird/src/write/specific/knowledge.rs
+++ b/crates/altaird/src/write/specific/knowledge.rs
@@ -40,6 +40,7 @@
 //! bytes.
 
 use altair_proto::v1;
+use sqlx::Row;
 
 use crate::store::entity::EntityType;
 use crate::store::ids::EntityId;
@@ -198,23 +199,77 @@ fn unreachable_part(kind: EntityType, part: &SpecificPart) -> Refusal {
     ))
 }
 
+/// The separator the blocks of a body are joined with.
+///
+/// Both indexes treat any run of non-alphanumeric text as a separator, so this
+/// changes nothing about what matches. It is a newline rather than a space
+/// because the column holds plain text that a person may read and an export may
+/// carry, and paragraphs that ran together would be worse to look at for no
+/// gain.
+const BETWEEN_BLOCKS: &str = "\n";
+
 /// What Knowledge contributes to searchable text.
 ///
-/// **LANE: Knowledge.** A note's words are the obvious candidate and they are
-/// deliberately not taken here: a body's blocks are written by
-/// [`super::super::body`], which this lane also fills, and taking half the
-/// answer now would settle the shape of the other half. Contributing nothing is
-/// a valid answer, and the literal arm still finds a note by its title.
+/// # A note's words, because otherwise nothing has them
 ///
-/// A media type is deliberately not contributed either. It is a machine label
-/// rather than the person's words, and putting `image/png` into the text a
-/// literal search matches would make every photograph answer a search for
-/// *image*.
+/// **This is the whole of a note's literal searchability.** Both literal
+/// indexes are on the `entity` row — `entity_search_vector_idx` over the
+/// generated `tsvector` and `entity_search_trgm_idx` over the plain text — and
+/// `block` carries no search index at all. So a body that does not reach
+/// `search_text` reaches no index by any route, and a note captured with three
+/// paragraphs about descaling a kettle would be findable only by its title.
+/// That would make the standing claim false for exactly the type whose whole
+/// content is words: *literal matching is a permanent arm, not a fallback,
+/// which is why a just-captured entity is findable by its words before
+/// derivation runs.*
+///
+/// Migration one's own comment on the column describes this case in as many
+/// words — maintained by the write path "from the title and whatever the type
+/// contributes, because those live in side tables and a generated column cannot
+/// reach them". A body is a side table and this is the seam for it.
+///
+/// # Why the text is copied rather than the blocks indexed
+///
+/// A second index on `block.text` would put the literal arm on two tables with
+/// two candidate sets to fuse, which is the read path's decision at 3.1 and not
+/// one this lane should force. It would also put a candidate set on a table
+/// that carries no audience: the predicate must sit **inside** the candidate
+/// query, and `entity` is where the audience column is. One index on one table
+/// keeps that true without a join.
+///
+/// The cost is that a long body is stored twice. It is real and it is the price
+/// of the two properties above; see the note on refresh cost in the lane's
+/// report.
+///
+/// # What is deliberately still not contributed
+///
+/// **A media type.** It is a machine label rather than the person's words, and
+/// putting `image/png` into the text a literal search matches would make every
+/// photograph answer a search for *image*. A file therefore contributes
+/// nothing, which is still a valid answer.
 pub async fn search_text(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
 ) -> Applied<Option<String>> {
-    let _ = (ctx, entity, kind);
-    Ok(None)
+    if kind != EntityType::Note {
+        return Ok(None);
+    }
+    // In the order the body reads. A set of paragraphs is not a body, and the
+    // column holds text a person may read.
+    let rows = sqlx::query("SELECT text FROM block WHERE entity_id = $1 ORDER BY position")
+        .bind(entity.as_uuid())
+        .fetch_all(ctx.tx.conn())
+        .await?;
+    if rows.is_empty() {
+        // No body is no contribution, not an empty one. `concat_ws` drops a
+        // null, so a note without a body keeps a `search_text` of exactly its
+        // title — which is what it was before this lane filled the seam in.
+        return Ok(None);
+    }
+    let mut words: Vec<String> = Vec::with_capacity(rows.len());
+    for r in &rows {
+        words.push(r.try_get("text")?);
+    }
+    Ok(Some(words.join(BETWEEN_BLOCKS)))
 }

--- a/crates/altaird/src/write/specific/knowledge.rs
+++ b/crates/altaird/src/write/specific/knowledge.rs
@@ -2,17 +2,42 @@
 //!
 //! **LANE: Knowledge owns this file.**
 //!
-//! A note is the one type whose whole content is a body, and a body is not a
-//! part: it divides into blocks and each block is a part of its own. So the
-//! wire reading below produces a [`BodyWrite`] rather than a
-//! [`SpecificPart`], and everything downstream of it lives in
-//! [`super::super::body`] — division, matching against the blocks already held,
-//! and writing only what changed. That split is deliberate: reading the wire
-//! needs no store and the matching needs nothing else.
+//! # A note has no fields of its own, and that is the answer rather than a gap
 //!
-//! A file's content waits on Wave 2.3 in full, because Wave 2.1 refuses a file
-//! create for a reason that has not expired: the schema requires a file to name
-//! a body and there is no way to have uploaded one.
+//! Migration one says it plainly: *"There is no note table. A note holds a body
+//! beyond the shared set, a body is its blocks in order, and there is no second
+//! representation of the same content for them to disagree with."* So a note's
+//! whole content is a body, and a body is not a part: it divides into blocks and
+//! each block is a part of its own. The wire reading below therefore produces a
+//! [`BodyWrite`] rather than a [`SpecificPart`], and everything downstream of it
+//! lives in [`super::super::body`] — division, matching against the blocks
+//! already held, and writing only what changed. That split is deliberate:
+//! reading the wire needs no store and the matching needs nothing else.
+//!
+//! Nothing here writes a block. [`validate_and_place`] and its two companions
+//! can be reached for a note only by a part that cannot be constructed, and they
+//! say so rather than pretending a note's content is unbuilt.
+//!
+//! # A file is mostly two other lanes'
+//!
+//! Of the three fields the wire gives a file, one is served here:
+//!
+//! - `body_id` is **Wave 2.3's**. The bytes come first — the standing constraint
+//!   is *bytes before the record on creation* — and there is no way to have
+//!   uploaded any, because `PutBody` is not served. So the field refuses with
+//!   that reason, and [`super::super::entity`]'s create refuses a file outright
+//!   for the same one.
+//! - `extracted_text` is **deferred by `altair-v0-scope.md`**, which governs the
+//!   implementation plan where the two disagree. A person's correction to
+//!   extracted text has nothing to correct while extraction does not exist.
+//! - `media_type` is served, and is the whole of a v0 file's own content. The
+//!   scope's v0 files are *entities with a title and relations*, and a media
+//!   type is what display follows.
+//!
+//! `file.byte_size` exists in the store and **the wire has no field for it**, on
+//! purpose: it is what the object store measured rather than what a client
+//! claimed. Nothing in this module can set it, and 2.3 writes it beside the
+//! bytes.
 
 use altair_proto::v1;
 
@@ -21,7 +46,9 @@ use crate::store::ids::EntityId;
 
 use super::super::content::{BodyWrite, Malformed, Written};
 use super::super::entity::{Applied, Ctx, Refusal};
-use super::{Addressed, Field, Held, Reader, SpecificPart, not_yet_built, unbuilt};
+use super::{
+    Addressed, Field, Held, Reader, SpecificPart, SpecificValue, read_column, write_column,
+};
 
 /// A note's field 1, its body.
 pub const NOTE_BODY: u32 = 1;
@@ -31,13 +58,26 @@ pub const NOTE_FIELDS: &[Field] = &[Field {
     held: Held::Body,
 }];
 
+/// A file's field 2, the media type as captured.
+pub const FILE_MEDIA_TYPE: u32 = 2;
+
 pub const FILE_FIELDS: &[Field] = &[
+    // **LANE: 2.3, file bodies.** `body_id` names bytes already uploaded
+    // through `PutBody`; until that call is served there is no identity to
+    // name, which is why the create path refuses a file outright. The column is
+    // `NOT NULL`, so clearing it is not a thing an edit can do either, and
+    // saying so here is better than letting the store raise a fault.
+    //
+    // 2.3 turns this back into `Held::Column("body_id")`; the column already
+    // exists and `tests/type_content.rs` will check it again the moment it does.
     Field {
         number: 1,
-        held: Held::Column("body_id"),
+        held: Held::NotServed(
+            "a file names a body that must be uploaded first, and PutBody is not served yet",
+        ),
     },
     Field {
-        number: 2,
+        number: FILE_MEDIA_TYPE,
         held: Held::Column("media_type"),
     },
     // A person's correction to extracted text, which has nothing to correct.
@@ -77,33 +117,39 @@ pub fn note(c: &v1::NoteContent) -> Result<Written, Malformed> {
 
 /// A file's content, off the wire.
 ///
-/// **LANE: 2.3, file bodies.** `body_id` names bytes already uploaded through
-/// `PutBody`; until that call is served there is no identity to name, which is
-/// why 2.1 refuses a file create outright. The column is `NOT NULL`, so
-/// clearing it is not a thing an edit can do and this module must say so rather
-/// than letting the store raise a fault.
+/// Only the media type is read. The other two refuse with their own reasons,
+/// through the declaration above rather than through a branch here, so a client
+/// is told what it is waiting on rather than that its message was wrong.
 pub fn file(c: &v1::FileContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::File,
-        &c.cleared,
-        &[
-            (1, c.body_id.is_some()),
-            (2, c.media_type.is_some()),
-            (3, c.extracted_text.is_some()),
-        ],
-    )
+    let read = Reader::new(EntityType::File, &c.cleared)?;
+    let mut parts = Vec::new();
+    // The two unserved fields are addressed so their refusals are reached.
+    // Asking for them and using nothing but the answer is the point: leaving
+    // them out would accept a write that named them and silently drop it.
+    read.addressed(1, c.body_id.is_some())?;
+    read.addressed(3, c.extracted_text.is_some())?;
+    read.singular(&mut parts, FILE_MEDIA_TYPE, c.media_type.clone(), |v| {
+        Ok(SpecificValue::Text(v))
+    })?;
+    Ok(Written::from_specific(parts))
 }
 
+/// What a Knowledge part owes before it is applied.
+///
+/// A media type owes nothing. It is the person's word for what the bytes are,
+/// interpreted by nothing here — the same treatment a unit gets in Tracking —
+/// and the entity stores no display preference beside it.
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<Option<SpecificPart>> {
-    let _ = (ctx, entity, part);
-    // A note addresses no part at all — its content is its body — so anything
-    // reaching here is a file's, and a file's content is 2.3's.
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    let _ = (ctx, entity);
+    match (kind, part.field) {
+        (EntityType::File, FILE_MEDIA_TYPE) => Ok(None),
+        _ => Err(unreachable_part(kind, part).into()),
+    }
 }
 
 pub async fn current(
@@ -112,8 +158,10 @@ pub async fn current(
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<SpecificPart> {
-    let _ = (ctx, entity, part);
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    match (kind, part.field) {
+        (EntityType::File, FILE_MEDIA_TYPE) => read_column(ctx, entity, kind, part).await,
+        _ => Err(unreachable_part(kind, part).into()),
+    }
 }
 
 pub async fn apply(
@@ -123,8 +171,31 @@ pub async fn apply(
     part: &SpecificPart,
     placement: Option<&SpecificPart>,
 ) -> Applied<()> {
-    let _ = (ctx, entity, part, placement);
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    match (kind, part.field) {
+        (EntityType::File, FILE_MEDIA_TYPE) => {
+            // Neither Knowledge type nests or is ordered, so nothing moves
+            // alongside.
+            debug_assert!(placement.is_none());
+            write_column(ctx, entity, kind, part).await
+        }
+        _ => Err(unreachable_part(kind, part).into()),
+    }
+}
+
+/// A part no Knowledge message can produce.
+///
+/// **Not the *not built yet* refusal**, which would be a lie in both directions.
+/// A note's one field is its body and a body never becomes a [`SpecificPart`];
+/// a file's other two fields refuse while the message is being read and never
+/// reach here. So anything arriving is a part that was constructed rather than
+/// transcribed, and saying the content is merely unbuilt would send whoever
+/// reads the log to the wrong module.
+fn unreachable_part(kind: EntityType, part: &SpecificPart) -> Refusal {
+    Refusal::Malformed(format!(
+        "field {} is not a part a {} carries",
+        part.field,
+        super::super::entity::type_name(kind)
+    ))
 }
 
 /// What Knowledge contributes to searchable text.
@@ -134,6 +205,11 @@ pub async fn apply(
 /// [`super::super::body`], which this lane also fills, and taking half the
 /// answer now would settle the shape of the other half. Contributing nothing is
 /// a valid answer, and the literal arm still finds a note by its title.
+///
+/// A media type is deliberately not contributed either. It is a machine label
+/// rather than the person's words, and putting `image/png` into the text a
+/// literal search matches would make every photograph answer a search for
+/// *image*.
 pub async fn search_text(
     ctx: &mut Ctx<'_>,
     entity: EntityId,

--- a/crates/altaird/tests/type_content_knowledge.rs
+++ b/crates/altaird/tests/type_content_knowledge.rs
@@ -1,0 +1,874 @@
+//! Knowledge's type content, and categories.
+//!
+//! The lane's name oversells it and the suite is arranged to say so. A note has
+//! no fields of its own — migration one refuses it a table on purpose — and a
+//! file has one field this wave can serve, its media type. **The substance is
+//! categories**, and inside categories it is the creation-default audience,
+//! which is three separate claims that look like one sentence:
+//!
+//! - it acts **once, at creation**, so a later move into the category applies
+//!   nothing;
+//! - it is **not a standing rule**, so editing it reaches nothing already
+//!   placed;
+//! - it is **never inherited**, so a child category has only its own.
+//!
+//! Each has a test, because each could break without the other two noticing.
+//! The whole point of the narrowness is that a category never sets an audience
+//! as a standing rule, and a default that quietly became one would be a leak
+//! rather than a bug.
+//!
+//! The second half is cycle prevention in nested categories, which migration
+//! one records as its gap (h) and cannot close: a constraint sees one row. The
+//! interesting cases are two hops and longer; self-reference passes for free
+//! and proves nothing on its own.
+
+mod common;
+
+use altair_proto::v1;
+use altaird::store::entity::EntityType;
+use altaird::store::ids::EntityId;
+use altaird::write::specific::{self, Held};
+use common::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Saying a category
+// ---------------------------------------------------------------------------
+
+fn category_content(
+    parent: Option<EntityId>,
+    default: &[Uuid],
+    cleared: Vec<u32>,
+) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Category(v1::CategoryContent {
+        parent_category_id: parent.map(|p| p.as_uuid().as_bytes().to_vec()),
+        creation_default_audience_member_ids: default
+            .iter()
+            .map(|m| m.as_bytes().to_vec())
+            .collect(),
+        cleared,
+    })
+}
+
+/// A plain category, visible to its author alone.
+async fn category(world: &World, parent: Option<EntityId>, default: &[Uuid]) -> EntityId {
+    world
+        .create(
+            &world.one,
+            category_content(parent, default, Vec::new()),
+            v1::EntityContent::default(),
+        )
+        .await
+}
+
+/// A category both members can see, which is what makes a concurrent edit to
+/// one possible at all.
+async fn shared_category(world: &World, default: &[Uuid]) -> EntityId {
+    world
+        .create(
+            &world.one,
+            category_content(None, default, Vec::new()),
+            v1::EntityContent {
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+/// Edit a category's own content, from the counter it currently holds.
+async fn edit_category(
+    world: &World,
+    id: EntityId,
+    specific: v1::entity_content::Specific,
+) -> v1::Acknowledgement {
+    let base = world.counter(id).await as u64;
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base,
+                v1::EntityContent {
+                    specific: Some(specific),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// Reading the store back
+// ---------------------------------------------------------------------------
+
+async fn parent_of(world: &World, id: EntityId) -> Option<Uuid> {
+    sqlx::query("SELECT parent_category_id AS p FROM category WHERE entity_id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("category row")
+        .try_get("p")
+        .expect("parent")
+}
+
+async fn creation_default_of(world: &World, id: EntityId) -> Vec<Uuid> {
+    sqlx::query("SELECT creation_default_audience AS a FROM category WHERE entity_id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("category row")
+        .try_get("a")
+        .expect("default")
+}
+
+/// The audience an entity actually ended up with.
+///
+/// A test may read this column directly. `tests/one_predicate.rs` exempts test
+/// sources from the column check deliberately: an assertion that both paths
+/// call one predicate has to be able to see past it, and ground truth that came
+/// through the audience-scoped surface would be checking the predicate against
+/// itself.
+async fn audience_of(world: &World, id: EntityId) -> Vec<Uuid> {
+    sqlx::query("SELECT audience_member_ids AS a FROM entity WHERE id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("entity")
+        .try_get("a")
+        .expect("audience")
+}
+
+/// A note created inside a category, which is the thing a creation default acts
+/// on.
+async fn note_in(world: &World, category: EntityId) -> EntityId {
+    world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            v1::EntityContent {
+                title: Some("placed".into()),
+                category_id: Some(category.as_uuid().as_bytes().to_vec()),
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// A category's two fields, through create and edit
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_categorys_nesting_and_creation_default_round_trip_through_a_create() {
+    let world = World::new().await;
+    let top = category(&world, None, &[]).await;
+    let two = world.two.membership_id();
+
+    let nested = category(&world, Some(top), &[two]).await;
+
+    assert_eq!(parent_of(&world, nested).await, Some(top.as_uuid()));
+    assert_eq!(creation_default_of(&world, nested).await, vec![two]);
+    assert_eq!(
+        parent_of(&world, top).await,
+        None,
+        "the top nests in nothing"
+    );
+    assert!(creation_default_of(&world, top).await.is_empty());
+}
+
+#[tokio::test]
+async fn an_edit_moves_both_fields_and_advances_the_counter() {
+    let world = World::new().await;
+    let first = category(&world, None, &[]).await;
+    let second = category(&world, None, &[]).await;
+    let moving = category(&world, Some(first), &[]).await;
+    let base = world.counter(moving).await;
+
+    let ack = edit_category(
+        &world,
+        moving,
+        category_content(Some(second), &[world.one.membership_id()], Vec::new()),
+    )
+    .await;
+
+    assert_eq!(applied(&ack).counter, (base + 1) as u64);
+    assert_eq!(parent_of(&world, moving).await, Some(second.as_uuid()));
+    assert_eq!(
+        creation_default_of(&world, moving).await,
+        vec![world.one.membership_id()]
+    );
+}
+
+#[tokio::test]
+async fn clearing_a_parent_returns_a_category_to_the_top() {
+    let world = World::new().await;
+    let top = category(&world, None, &[]).await;
+    let nested = category(&world, Some(top), &[]).await;
+
+    edit_category(&world, nested, category_content(None, &[], vec![1])).await;
+
+    assert_eq!(parent_of(&world, nested).await, None);
+}
+
+/// **Emptying is how a repeated field is cleared**, and the column is
+/// `NOT NULL DEFAULT '{}'`, so a category that never had a default and one
+/// whose default was emptied are the same category rather than two states.
+#[tokio::test]
+async fn emptying_a_creation_default_clears_it() {
+    let world = World::new().await;
+    let id = category(&world, None, &[world.two.membership_id()]).await;
+
+    edit_category(&world, id, category_content(None, &[], vec![2])).await;
+
+    assert!(creation_default_of(&world, id).await.is_empty());
+}
+
+/// `entity_part_counter` is per part and conflict detection asks which parts
+/// moved between two counter values. A part that does not record its movement
+/// is invisible to that, and the failure is silent.
+#[tokio::test]
+async fn both_category_parts_record_the_counter_they_moved_at() {
+    let world = World::new().await;
+    let top = category(&world, None, &[]).await;
+    let id = category(&world, Some(top), &[world.two.membership_id()]).await;
+
+    let rows = sqlx::query(
+        "SELECT field_name, counter FROM entity_part_counter \
+         WHERE entity_id = $1 ORDER BY field_name",
+    )
+    .bind(id.as_uuid())
+    .fetch_all(&world.db.pool)
+    .await
+    .expect("query");
+
+    let named: Vec<String> = rows
+        .iter()
+        .map(|r| r.try_get::<String, _>("field_name").unwrap())
+        .collect();
+    assert!(
+        named.contains(&"specific.1".to_owned()) && named.contains(&"specific.2".to_owned()),
+        "both parts record their movement, or nothing can conflict on them: {named:?}"
+    );
+}
+
+/// Both values retained on a same-part conflict, and the acknowledgement names
+/// the type message's own field number.
+#[tokio::test]
+async fn a_same_part_conflict_on_a_creation_default_retains_both_values() {
+    let world = World::new().await;
+    let id = shared_category(&world, &[]).await;
+    let base = world.counter(id).await;
+
+    let one = world.one.membership_id();
+    let two = world.two.membership_id();
+
+    for (member, stated) in [(&world.one, one), (&world.two, two)] {
+        world
+            .submit(
+                member,
+                edit_entity(
+                    id,
+                    base as u64,
+                    v1::EntityContent {
+                        specific: Some(category_content(None, &[stated], Vec::new())),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+    }
+
+    let conflicts = world.conflicts(id).await;
+    assert_eq!(conflicts.len(), 1);
+    let c = &conflicts[0];
+    assert_eq!(c.field.as_deref(), Some("specific.2"));
+    assert_eq!(c.mine.as_deref(), Some(two.to_string().as_str()));
+    assert_eq!(c.theirs.as_deref(), Some(one.to_string().as_str()));
+    assert_eq!(creation_default_of(&world, id).await, vec![two]);
+}
+
+/// **A set has no order and the wire carries it as a list.** Two clients naming
+/// the same two members in different orders agree, and forming a conflict out
+/// of agreement is the machinery working against its own purpose.
+#[tokio::test]
+async fn the_same_two_members_in_either_order_are_the_same_default() {
+    let world = World::new().await;
+    let id = shared_category(&world, &[]).await;
+    let base = world.counter(id).await;
+    let one = world.one.membership_id();
+    let two = world.two.membership_id();
+
+    for (member, stated) in [(&world.one, [one, two]), (&world.two, [two, one])] {
+        world
+            .submit(
+                member,
+                edit_entity(
+                    id,
+                    base as u64,
+                    v1::EntityContent {
+                        specific: Some(category_content(None, &stated, Vec::new())),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+    }
+
+    assert!(
+        world.conflicts(id).await.is_empty(),
+        "writes producing the same value are not divergent"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The creation default: three claims, three tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn an_entity_created_in_a_category_takes_its_creation_default() {
+    let world = World::new().await;
+    let two = world.two.membership_id();
+    let holder = category(&world, None, &[two]).await;
+
+    let placed = note_in(&world, holder).await;
+
+    assert_eq!(audience_of(&world, placed).await, vec![two]);
+}
+
+/// **It acts at creation only.** Moving something into the category afterwards
+/// is an edit, and an edit never asks the category what it defaults — otherwise
+/// tidying would broaden an audience, silently, on somebody else's entity.
+#[tokio::test]
+async fn moving_an_existing_entity_into_a_category_applies_nothing() {
+    let world = World::new().await;
+    let holder = category(&world, None, &[world.two.membership_id()]).await;
+    let loose = world.note(&world.one, "captured outside").await;
+    assert!(audience_of(&world, loose).await.is_empty());
+
+    let base = world.counter(loose).await;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_entity(
+                loose,
+                base as u64,
+                v1::EntityContent {
+                    category_id: Some(holder.as_uuid().as_bytes().to_vec()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+
+    assert!(
+        audience_of(&world, loose).await.is_empty(),
+        "the default acts once, at creation; a later move is not a creation"
+    );
+}
+
+/// **It is not a standing rule.** The value is copied at creation and never
+/// consulted again, so editing it reaches nothing already placed. A category
+/// that broadened its contents retroactively would be a category setting an
+/// audience, which the substrate says it never does.
+#[tokio::test]
+async fn editing_a_creation_default_does_not_reach_entities_already_placed() {
+    let world = World::new().await;
+    let holder = category(&world, None, &[]).await;
+    let placed = note_in(&world, holder).await;
+    assert!(audience_of(&world, placed).await.is_empty());
+
+    edit_category(
+        &world,
+        holder,
+        category_content(None, &[world.two.membership_id()], Vec::new()),
+    )
+    .await;
+
+    assert!(
+        audience_of(&world, placed).await.is_empty(),
+        "a default is not a standing rule; it does not reach backwards"
+    );
+}
+
+/// **It is never inherited.** A child with no default of its own has none, and
+/// the read walks no ancestry to find one.
+#[tokio::test]
+async fn a_child_category_does_not_inherit_its_parents_creation_default() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[world.two.membership_id()]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    let placed = note_in(&world, child).await;
+
+    assert!(
+        audience_of(&world, placed).await.is_empty(),
+        "a default is never inherited, at any depth"
+    );
+}
+
+/// An audience the write states outranks the default. Clearing it is stating
+/// it: the wire says empty and not cleared means untouched, and cleared means
+/// private to the author.
+#[tokio::test]
+async fn an_audience_the_write_states_outranks_the_default() {
+    let world = World::new().await;
+    let holder = category(&world, None, &[world.two.membership_id()]).await;
+
+    let placed = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            v1::EntityContent {
+                category_id: Some(holder.as_uuid().as_bytes().to_vec()),
+                cleared: vec![5],
+                ..Default::default()
+            },
+        )
+        .await;
+
+    assert!(audience_of(&world, placed).await.is_empty());
+}
+
+/// **A foreign key cannot reach inside an array**, which is why this is a
+/// write-path check and is on the schema's owed list. A member id naming no
+/// membership is refused rather than stored and discovered later by whatever
+/// tries to resolve it.
+#[tokio::test]
+async fn a_creation_default_naming_no_membership_is_refused() {
+    let world = World::new().await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(category_content(None, &[Uuid::new_v4()], Vec::new())),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+}
+
+// ---------------------------------------------------------------------------
+// Cycle prevention, where the schema cannot see it
+// ---------------------------------------------------------------------------
+
+/// The refusal a closed loop gets, or a panic naming what came back instead.
+async fn nesting_refusal(world: &World, child: EntityId, parent: EntityId) -> String {
+    let ack = edit_category(
+        world,
+        child,
+        category_content(Some(parent), &[], Vec::new()),
+    )
+    .await;
+    let refused = refused(&ack);
+    assert_eq!(
+        refused.reason,
+        v1::RefusalReason::Malformed as i32,
+        "{refused:?}"
+    );
+    refused.detail.clone()
+}
+
+#[tokio::test]
+async fn a_category_cannot_be_its_own_parent() {
+    let world = World::new().await;
+    let a = category(&world, None, &[]).await;
+
+    let detail = nesting_refusal(&world, a, a).await;
+    assert!(detail.contains("close a loop"), "{detail}");
+    assert_eq!(parent_of(&world, a).await, None);
+}
+
+/// Two hops is the first case the schema cannot see. Its only check is
+/// `parent_category_id <> entity_id`, which a loop of length two satisfies at
+/// every row.
+#[tokio::test]
+async fn a_two_hop_loop_is_refused() {
+    let world = World::new().await;
+    let a = category(&world, None, &[]).await;
+    let b = category(&world, Some(a), &[]).await;
+
+    let detail = nesting_refusal(&world, a, b).await;
+    assert!(detail.contains("close a loop"), "{detail}");
+    assert_eq!(parent_of(&world, a).await, None, "and nothing was written");
+}
+
+#[tokio::test]
+async fn a_longer_loop_is_refused_too() {
+    let world = World::new().await;
+    let a = category(&world, None, &[]).await;
+    let b = category(&world, Some(a), &[]).await;
+    let c = category(&world, Some(b), &[]).await;
+
+    nesting_refusal(&world, a, c).await;
+    assert_eq!(parent_of(&world, a).await, None);
+    // And the chain that was legal is untouched.
+    assert_eq!(parent_of(&world, b).await, Some(a.as_uuid()));
+    assert_eq!(parent_of(&world, c).await, Some(b.as_uuid()));
+}
+
+#[tokio::test]
+async fn an_ordinary_nesting_is_accepted() {
+    let world = World::new().await;
+    let a = category(&world, None, &[]).await;
+    let b = category(&world, Some(a), &[]).await;
+    let c = category(&world, None, &[]).await;
+
+    edit_category(&world, c, category_content(Some(b), &[], Vec::new())).await;
+
+    assert_eq!(parent_of(&world, c).await, Some(b.as_uuid()));
+}
+
+// ---------------------------------------------------------------------------
+// A parent that is not there, one that cannot be seen, and one of the wrong
+// type are the same nothing
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_parent_that_is_not_there_is_refused_as_unavailable() {
+    let world = World::new().await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(category_content(
+                        Some(EntityId::from_uuid(Uuid::new_v4())),
+                        &[],
+                        Vec::new(),
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+}
+
+/// **Refusal on audience is indistinguishable from refusal on nonexistence.**
+/// Member two's private category and a category that was never created answer
+/// with the same nothing, or the refusal is an oracle for what the household
+/// holds.
+#[tokio::test]
+async fn a_parent_the_member_cannot_see_answers_exactly_as_one_that_is_not_there() {
+    let world = World::new().await;
+    // Two's own category, which one cannot see: audience is private to the
+    // author by default.
+    let hidden = world
+        .create(
+            &world.two,
+            category_content(None, &[], Vec::new()),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let mine = category(&world, None, &[]).await;
+
+    let hidden_ack = edit_category(
+        &world,
+        mine,
+        category_content(Some(hidden), &[], Vec::new()),
+    )
+    .await;
+    let absent_ack = edit_category(
+        &world,
+        mine,
+        category_content(Some(EntityId::from_uuid(Uuid::new_v4())), &[], Vec::new()),
+    )
+    .await;
+
+    // Both refuse as unavailable, and then the stronger claim: the two answers
+    // are the same answer. Equality alone would pass if both had drifted to
+    // some other single reason, so the reason is pinned first.
+    assert!(is_not_available(&hidden_ack), "{:?}", hidden_ack.outcome);
+    assert!(is_not_available(&absent_ack), "{:?}", absent_ack.outcome);
+    assert_eq!(
+        format!("{:?}", hidden_ack.outcome),
+        format!("{:?}", absent_ack.outcome),
+        "a category the member cannot see and one that is not there are the same nothing, \
+         down to the detail; anything else is an oracle for what the household holds"
+    );
+    assert_eq!(parent_of(&world, mine).await, None);
+}
+
+/// A parent that exists and is not a category is the same nothing again. The
+/// schema's composite foreign key would refuse it too, but as a constraint
+/// violation that takes the transaction down and says which entity is there.
+#[tokio::test]
+async fn a_parent_that_is_not_a_category_is_the_same_nothing() {
+    let world = World::new().await;
+    let mine = category(&world, None, &[]).await;
+    let note = world.note(&world.one, "not a container").await;
+
+    let ack = edit_category(&world, mine, category_content(Some(note), &[], Vec::new())).await;
+
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+    assert_eq!(parent_of(&world, mine).await, None);
+}
+
+/// 2.1 refuses an explicit position pending whatever first reorders, and
+/// nothing in this lane reorders. Nested categories carry no position at all —
+/// migration one's gap (g) — so a category gaining a parent gains nothing to
+/// order it by.
+#[tokio::test]
+async fn an_explicit_position_is_still_refused() {
+    let world = World::new().await;
+    let holder = category(&world, None, &[]).await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Note(
+                        v1::NoteContent::default(),
+                    )),
+                    category_id: Some(holder.as_uuid().as_bytes().to_vec()),
+                    category_position: Some(0),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let refused = refused(&ack);
+    assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
+    assert!(refused.detail.contains("position"), "{}", refused.detail);
+}
+
+// ---------------------------------------------------------------------------
+// A note has no fields of its own
+// ---------------------------------------------------------------------------
+
+/// Migration one: *"There is no note table. A note holds a body beyond the
+/// shared set, a body is its blocks in order, and there is no second
+/// representation of the same content for them to disagree with."* So the
+/// declaration is one field, it is a body, and it is not a column.
+#[test]
+fn a_notes_only_field_is_its_body_and_it_has_no_table() {
+    let fields = specific::fields(EntityType::Note);
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].number, 1);
+    assert!(matches!(fields[0].held, Held::Body));
+    assert!(
+        specific::side_table(EntityType::Note).is_none(),
+        "a note's content is its body; a second representation is what would disagree"
+    );
+}
+
+/// **Nothing in this lane writes a block.** Bodies are their own lane and their
+/// own module; a note created without one holds none, and neither a category
+/// nor a file goes anywhere near the table.
+#[tokio::test]
+async fn nothing_in_this_lane_writes_a_block() {
+    let world = World::new().await;
+    let holder = category(&world, None, &[world.two.membership_id()]).await;
+    let placed = note_in(&world, holder).await;
+
+    for id in [holder, placed] {
+        assert_eq!(world.rows_for("block", "entity_id", id).await, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A file, which is one served field and two refusals that expire
+// ---------------------------------------------------------------------------
+
+/// A file entity, made by hand.
+///
+/// **Scaffolding standing in for Wave 2.3.** A file cannot be created through
+/// the public path — the create refuses one, because the schema requires a body
+/// and `PutBody` is not served — so the only way to have a file to edit is to
+/// put one there. The rows are the minimum the schema demands; 2.3 replaces
+/// this with an upload.
+async fn a_file(world: &World) -> EntityId {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO entity (id, type, author_member_id, created_at, updated_at, capture_method) \
+         VALUES ($1, 'file', $2, now(), now(), 'test')",
+    )
+    .bind(id)
+    .bind(world.one.membership_id())
+    .execute(&world.db.pool)
+    .await
+    .expect("entity");
+    sqlx::query("INSERT INTO file (entity_id, body_id) VALUES ($1, $2)")
+        .bind(id)
+        .bind(Uuid::new_v4())
+        .execute(&world.db.pool)
+        .await
+        .expect("file");
+    EntityId::from_uuid(id)
+}
+
+async fn media_type_of(world: &World, id: EntityId) -> Option<String> {
+    sqlx::query("SELECT media_type AS m FROM file WHERE entity_id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("file row")
+        .try_get("m")
+        .expect("media type")
+}
+
+fn file_content(media_type: Option<&str>, cleared: Vec<u32>) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::File(v1::FileContent {
+        media_type: media_type.map(ToOwned::to_owned),
+        cleared,
+        ..Default::default()
+    })
+}
+
+async fn edit_file(
+    world: &World,
+    id: EntityId,
+    specific: v1::entity_content::Specific,
+) -> v1::Acknowledgement {
+    let base = world.counter(id).await as u64;
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base,
+                v1::EntityContent {
+                    specific: Some(specific),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await
+}
+
+/// The whole of a v0 file's own content. The scope's v0 files are entities with
+/// a title and relations; a media type is what display follows.
+#[tokio::test]
+async fn a_files_media_type_round_trips() {
+    let world = World::new().await;
+    let id = a_file(&world).await;
+    assert_eq!(media_type_of(&world, id).await, None);
+
+    let ack = edit_file(&world, id, file_content(Some("image/png"), Vec::new())).await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    assert_eq!(
+        media_type_of(&world, id).await.as_deref(),
+        Some("image/png")
+    );
+
+    edit_file(&world, id, file_content(None, vec![2])).await;
+    assert_eq!(media_type_of(&world, id).await, None, "and it clears");
+}
+
+/// A media type is a machine label rather than the person's words, so it stays
+/// out of the text a literal search matches. The title still reaches it.
+#[tokio::test]
+async fn a_media_type_does_not_reach_search_text() {
+    let world = World::new().await;
+    let id = a_file(&world).await;
+    let base = world.counter(id).await as u64;
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base,
+                v1::EntityContent {
+                    title: Some("the receipt".into()),
+                    specific: Some(file_content(Some("image/png"), Vec::new())),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let text: String = sqlx::query("SELECT search_text FROM entity WHERE id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("entity")
+        .try_get("search_text")
+        .expect("search_text");
+    assert_eq!(text, "the receipt");
+}
+
+/// **Bytes before the record.** There is no identity to name until `PutBody`
+/// is served, and the refusal says which lane a client is waiting on rather
+/// than that its message was wrong.
+#[tokio::test]
+async fn a_files_body_id_is_refused_because_put_body_is_not_served() {
+    let world = World::new().await;
+    let id = a_file(&world).await;
+    let ack = edit_file(
+        &world,
+        id,
+        v1::entity_content::Specific::File(v1::FileContent {
+            body_id: Some(Uuid::new_v4().as_bytes().to_vec()),
+            ..Default::default()
+        }),
+    )
+    .await;
+    let refused = refused(&ack);
+    assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
+    assert!(refused.detail.contains("PutBody"), "{}", refused.detail);
+}
+
+/// `altair-v0-scope.md` defers text extraction from files, and it governs the
+/// implementation plan where the two disagree. A person's correction to
+/// extracted text has nothing to outrank while extraction does not exist.
+#[tokio::test]
+async fn a_files_extracted_text_is_refused_because_extraction_is_deferred() {
+    let world = World::new().await;
+    let id = a_file(&world).await;
+    let ack = edit_file(
+        &world,
+        id,
+        v1::entity_content::Specific::File(v1::FileContent {
+            extracted_text: Some("what the picture says".into()),
+            ..Default::default()
+        }),
+    )
+    .await;
+    let refused = refused(&ack);
+    assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
+    assert!(
+        refused.detail.contains("deferred in v0"),
+        "{}",
+        refused.detail
+    );
+}
+
+/// And the create still refuses, which is 2.1's refusal and 2.3's to expire.
+/// Serving `media_type` does not make a file creatable, and quietly making one
+/// would put a record in front of its bytes.
+#[tokio::test]
+async fn a_file_still_cannot_be_created() {
+    let world = World::new().await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(file_content(Some("image/png"), Vec::new())),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let refused = refused(&ack);
+    assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
+    assert!(refused.detail.contains("PutBody"), "{}", refused.detail);
+}

--- a/crates/altaird/tests/type_content_knowledge.rs
+++ b/crates/altaird/tests/type_content_knowledge.rs
@@ -772,6 +772,153 @@ async fn a_files_media_type_round_trips() {
     assert_eq!(media_type_of(&world, id).await, None, "and it clears");
 }
 
+// ---------------------------------------------------------------------------
+// A note's words reach the one place a literal search can find them
+// ---------------------------------------------------------------------------
+
+async fn search_text_of(world: &World, id: EntityId) -> String {
+    sqlx::query("SELECT search_text FROM entity WHERE id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("entity")
+        .try_get("search_text")
+        .expect("search_text")
+}
+
+/// A note with a title and a body, through the ordinary write path.
+async fn note_with_body(world: &World, title: &str, body: &str) -> EntityId {
+    world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Note(v1::NoteContent {
+                body: Some(body.into()),
+                cleared: Vec::new(),
+            }),
+            v1::EntityContent {
+                title: Some(title.into()),
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+async fn edit_body(world: &World, id: EntityId, body: Option<&str>, cleared: Vec<u32>) {
+    let base = world.counter(id).await as u64;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                        body: body.map(ToOwned::to_owned),
+                        cleared,
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(
+        matches!(ack.outcome, Some(v1::acknowledgement::Outcome::Applied(_))),
+        "{:?}",
+        ack.outcome
+    );
+}
+
+/// **The whole of a note's literal searchability.** Both literal indexes are on
+/// the `entity` row and `block` carries none, so a body that does not reach
+/// `search_text` reaches no index by any route — and the standing claim that a
+/// just-captured entity is findable by its words would be false for exactly the
+/// type whose whole content is words.
+#[tokio::test]
+async fn a_notes_body_reaches_search_text() {
+    let world = World::new().await;
+    let id = note_with_body(
+        &world,
+        "descaling",
+        "The kettle is descaled twice a year.\n\nVinegar, an hour, then two rinses.",
+    )
+    .await;
+
+    let text = search_text_of(&world, id).await;
+    assert!(
+        text.contains("descaling"),
+        "the title is still there: {text}"
+    );
+    assert!(
+        text.contains("Vinegar") && text.contains("rinses"),
+        "a word from the body is findable: {text}"
+    );
+}
+
+/// **In the order the body reads.** A set of paragraphs is not a body, and the
+/// column holds text a person may read and an export may carry.
+#[tokio::test]
+async fn the_blocks_reach_it_in_order() {
+    let world = World::new().await;
+    let id = note_with_body(
+        &world,
+        "steps",
+        "First step.\n\nSecond step.\n\nThird step.",
+    )
+    .await;
+
+    let text = search_text_of(&world, id).await;
+    let first = text.find("First").expect("first block");
+    let second = text.find("Second").expect("second block");
+    let third = text.find("Third").expect("third block");
+    assert!(first < second && second < third, "out of order: {text}");
+}
+
+/// **It refreshes when the body changes**, not only at creation. A word the
+/// person deleted must stop being findable, or the index outlives the text.
+#[tokio::test]
+async fn editing_a_body_moves_what_is_searchable() {
+    let world = World::new().await;
+    let id = note_with_body(&world, "descaling", "Vinegar, an hour, then two rinses.").await;
+    assert!(search_text_of(&world, id).await.contains("Vinegar"));
+
+    edit_body(
+        &world,
+        id,
+        Some("Citric acid, an hour, then two rinses."),
+        Vec::new(),
+    )
+    .await;
+
+    let text = search_text_of(&world, id).await;
+    assert!(text.contains("Citric"), "the new words arrived: {text}");
+    assert!(
+        !text.contains("Vinegar"),
+        "a deleted word is still findable: {text}"
+    );
+    assert!(text.contains("descaling"), "the title survived: {text}");
+}
+
+/// Clearing a body takes its words with it and leaves the title standing.
+#[tokio::test]
+async fn clearing_a_body_leaves_the_title_alone() {
+    let world = World::new().await;
+    let id = note_with_body(&world, "descaling", "Vinegar, an hour.").await;
+
+    edit_body(&world, id, None, vec![1]).await;
+
+    assert_eq!(search_text_of(&world, id).await, "descaling");
+}
+
+/// **No body is no contribution, not an empty one.** `concat_ws` drops a null,
+/// so a note without a body keeps exactly the `search_text` it had before this
+/// seam was filled in — no separator, no trailing space.
+#[tokio::test]
+async fn a_note_with_no_body_is_exactly_its_title() {
+    let world = World::new().await;
+    let id = world.note(&world.one, "just a title").await;
+    assert_eq!(search_text_of(&world, id).await, "just a title");
+}
+
 /// A media type is a machine label rather than the person's words, so it stays
 /// out of the text a literal search matches. The title still reaches it.
 #[tokio::test]


### PR DESCRIPTION
Fifth of nine slices of Wave 2.2. Stacked on #24. Fills in `write/specific/category.rs` and `write/specific/knowledge.rs`.

The name oversells it: **a note has no type content at all**, and most of a file's belongs to other waves. The substance here is categories.

## A note and a file

*"There is no note table. A note holds a body beyond the shared set, a body is its blocks in order, and there is no second representation of the same content for them to disagree with."* So a note is correctly a type with no fields of its own, and a test asserts nothing in this slice writes a block.

A file gets `media_type`. Its `body_id` waits on Wave 2.3, and its extracted text is **deferred by `docs/altair-v0-scope.md`** along with text extraction generally — both refuse with their own expiring reason, so a client is told which lane it waits on rather than that its message was wrong. `byte_size` is not implemented because **the wire has no field for it**: it is what the object store measured rather than what a client claimed, and it belongs beside the bytes.

## Categories, which is the real content

A category is **an entity, not a label** — describable, relatable, returned by retrieval in its own right. Membership is containment held on the entity row, which Wave 2.1 already writes. What lands here is the parent and the creation-default audience.

**The creation default is narrow in three separate ways, and each is tested.** It acts *once, at creation* of an entity placed in the category — moving an existing entity in later applies nothing. It is *not a standing rule* — editing it afterwards does not reach entities already placed. And it is *never inherited* — a child category does not pick up its parent's.

Every member id in it must name a real membership, which a foreign key cannot reach inside an array, so it is a write-path check and one of the schema's owed ones.

## Cycle prevention, and why the statement is not in this file

Nested categories get the same treatment as nested locations, calling the shared `nesting::would_cycle`. Two hops and three hops refused, ordinary nesting accepted, nothing written on refusal.

**The statement itself lives in `nesting.rs` rather than here, and that is forced rather than stylistic.** `tests/one_predicate.rs` flags any source outside `store/audience.rs` that names the audience column *and* issues SQL — and it matches by plain substring, so the wire's name for a category's creation default (`creation_default_audience_member_ids`) contains the audience column's name. `category.rs` names that field twice and issues no SQL at all, which is exactly why it passes. Verified by adding a deliberate query to that file and watching the guard name it.

## Three refusal shapes, all the same nothing

A parent that is absent, one the member cannot see, and one that exists but is not a category. The test pins the reason on each **and then asserts the outcomes are byte-identical** — equality alone would pass if both drifted to some other single reason, and a difference there is an oracle for what the household holds.

A closed loop refuses **malformed**, not unavailable, and deliberately: the member has already passed the visibility check on the parent, so naming the loop discloses nothing further, while calling it unavailable would send them hunting a permission problem that is not there. Nested locations answer the same way, so the two containers do not disagree about the same mistake.

## A note's words reach the index

`search_text` composes a note's block rows, in order. **This closes a gap that no lane's own tests could have found**: this module deferred a note's words to the bodies work, the bodies work never took them, and blocks carry no text index — the only literal indexes are on `entity.search_text`. So a note captured with three paragraphs about kettles and vinegar had `search_text` of just its title, and Wave 3.1 would have built the literal arm against a corpus whose note bodies were never indexed and looked correct.

Composed into `search_text` rather than indexing `block.text` separately, because a second index would put the literal arm on two tables with two candidate sets to fuse — a read-path decision belonging to 3.1 — and because the audience predicate must sit *inside* the candidate query, which one index on `entity` already carries.

**A cost worth knowing:** `refresh_search_text` rewrites the whole column on every accepted write, so editing the *title* of a note with a 50 KB body now rewrites 50 KB and churns the trigram index for a write that touched no block. That sits oddly beside the body path taking care to write only what changed. Not fixed here — it is a constant factor on one row, and the mitigation belongs in `entity.rs`.

## Verification

- `cargo test --workspace`: 29 targets, 346 tests, 0 failures.
- Three of the five `search_text` tests fail with the contribution reverted; the other two stay green throughout, which is what says the change is narrow — a note with no body still contributes nothing rather than an empty string, so such notes keep byte-for-byte the `search_text` they had.
