### PR TITLE
Wave 2.2 slice 6: the three states, the one upward movement, and the ladder

### DIFF
--- a/crates/altaird/src/write/specific/guidance.rs
+++ b/crates/altaird/src/write/specific/guidance.rs
@@ -241,7 +241,12 @@ pub fn quest(c: &v1::QuestContent) -> Result<Written, Malformed> {
     read.singular(&mut parts, QUEST_ARC, arc_id, id_value)?;
     read.singular(&mut parts, QUEST_CAMPAIGN, campaign_id, id_value)?;
     read.singular(&mut parts, QUEST_ROUTINE, c.routine_id.as_ref(), id_value)?;
-    read.singular(&mut parts, QUEST_POSITION, c.ladder_position, position_value)?;
+    read.singular(
+        &mut parts,
+        QUEST_POSITION,
+        c.ladder_position,
+        position_value,
+    )?;
     read.singular(&mut parts, STATE, c.state, state_value)?;
     Ok(Written::from_specific(parts))
 }
@@ -516,7 +521,14 @@ async fn start_container(ctx: &mut Ctx<'_>, row: &EntityRow) -> Applied<()> {
         .bind(ctx.at)
         .execute(ctx.tx.conn())
         .await?;
-    provenance::record(ctx.tx, row.id, &[Part::Specific(STATE)], counter, ctx.member).await?;
+    provenance::record(
+        ctx.tx,
+        row.id,
+        &[Part::Specific(STATE)],
+        counter,
+        ctx.member,
+    )
+    .await?;
 
     // Audience did not move, so both sides of the pair are what it already was.
     // The entry still has to exist: to every member who can see this container,

--- a/crates/altaird/src/write/specific/guidance.rs
+++ b/crates/altaird/src/write/specific/guidance.rs
@@ -1,40 +1,126 @@
 //! Guidance's type content: campaign, arc, quest.
 //!
-//! **LANE: Guidance owns this file.** Campaign's `state` is filled in as the
-//! spine's proof that a type-specific part reaches the store, conflicts, and
-//! comes back; arc and quest are declared and refused.
+//! **LANE: Guidance owns this file.** Three types, one state enum, and one
+//! container — the ladder — that the shared model does not cover.
+//!
+//! # The states, and why nothing here refuses a transition
+//!
+//! The shipped set is waiting, working, worked, and the PRD is explicit that a
+//! person may rename them but may not add, remove, reorder, or define their
+//! own. That is settled and the store's enum is the whole of it.
+//!
+//! **No transition is refused, and that is a decision rather than an omission.**
+//! The PRD's state diagram draws five movements between the three states and
+//! leaves worked → waiting undrawn. Read as a prohibition it would make one
+//! write a rejection, and three things say it is not:
+//!
+//! - **No prose forbids it.** The diagram's neighbouring prose constrains the
+//!   *set* of states and the one upward movement below; it says nothing about
+//!   which movements a person may make. A rule this file invented from an
+//!   undrawn arrow would be a rule nothing normative states.
+//! - **The substrate does not reject well-formed writes.** A device that was
+//!   away replays what the person did, and the only ways a write does not land
+//!   are that the content cannot be read or that the entity is not available.
+//!   "The person moved this the wrong way round" is neither.
+//! - **The spine already relies on it.** Clearing the state field sets it back
+//!   to waiting, because the column is `NOT NULL DEFAULT 'waiting'`; a worked
+//!   campaign whose state is cleared therefore performs exactly the undrawn
+//!   movement, and `tests/type_content.rs` has asserted since 2.2's spine that
+//!   it arrives at waiting.
+//!
+//! `tests/type_content_guidance.rs` walks every movement the diagram draws and
+//! names the undrawn one, so the reading is visible rather than inferred from
+//! an absence of code.
+//!
+//! # The one upward movement
+//!
+//! Starting a quest moves the containers above it from waiting to working, and
+//! it happens silently. [`propagate_start_upward`] is the whole of it, and each
+//! clause of the PRD's narrowing has its own test.
+//!
+//! # The ladder is a container, and Arrangement is where its rules come from
+//!
+//! **Two documents disagree about where the ladder's ordering rules live, and
+//! this file does not resolve it.** The substrate spec's *Arrangement* section
+//! says the ladder defines its own order "in the Guidance PRD"; the Guidance
+//! PRD says a campaign's mixed-kind order "needs nothing of its own" and then
+//! defines no rules. Something has to be implemented, so this file implements
+//! **Arrangement's**: entering a container appends at the end, leaving forgets
+//! the position, no container is unordered, and the order is total and stable.
+//! That is the reading that leaves nothing undefined, and it is what the PRD's
+//! "nothing of its own" most plausibly means — the ladder needs no ordering
+//! rules *because the substrate's already cover it*.
+//!
+//! **A campaign is one container over mixed kinds.** Arcs and quests beneath
+//! one campaign are ordered together, in one sequence spanning two tables,
+//! which is why the order cannot be a unique constraint and why
+//! [`next_ladder_position`] takes a maximum across both.
 //!
 //! # What is deliberately not here
 //!
-//! **The Guidance state machine.** Which transitions are legal, the silent
-//! upward `Waiting → Working` propagation when something beneath starts, and
-//! what a state means for the ladder are all the Guidance PRD's and the
-//! Guidance lane's. Nothing below checks a transition, and that is not an
-//! omission: the spine is proving that a value crosses the boundary intact, and
-//! a rule bolted on here would be a rule written by whoever was proving the
-//! plumbing.
+//! - **Explicit reordering.** Appending is what a container entry does; a
+//!   client stating a `ladder_position` is refused as malformed, in the
+//!   register of the three refusals Wave 2.1 makes that expire when a named
+//!   lane lands. See [`explicit_position_refusal`].
+//! - **Recurrence.** `quest.routine_id` is a column with no `routine` table
+//!   behind it, because the scope defers routines. The field is read and stored
+//!   and **nothing interprets it**; whatever builds recurrence owes the
+//!   reference check that no foreign key can make today. The PRD's clause that
+//!   *a recurrence is not a container for this* is therefore moot rather than
+//!   implemented: nothing here walks a routine, so nothing can propagate
+//!   through one.
+//! - **The prompts on a parent reaching the terminal state, and on deleting
+//!   one.** The PRD asks about the children and the person answers. That is a
+//!   client behaviour and there is no client until Wave 4, so this file neither
+//!   prompts nor cascades — a silent cascade would be the exact thing the PRD
+//!   rules out, and building half of it now would foreclose the question.
+//! - **Two open questions the PRD holds, which nothing here closes:** the exact
+//!   inflections of the state names, and the absence of any mechanism for
+//!   ordering one quest against another outside a container.
 //!
-//! What is settled, and is the plumbing's own answer rather than the domain's:
-//! **clearing a state sets it to waiting**, because the column is
+//! # What is settled by the plumbing rather than by the domain
+//!
+//! **Clearing a state sets it to waiting**, because the column is
 //! `NOT NULL DEFAULT 'waiting'` and there is no state a campaign is not in. Two
 //! members arriving at waiting — one by setting it, one by clearing it —
 //! therefore compare equal rather than conflict, which is the substrate's rule
 //! that writes producing the same value are not divergent.
 
+use sqlx::Row;
+use uuid::Uuid;
+
 use altair_proto::v1;
 
-use crate::store::entity::EntityType;
+use crate::store::WriteScope;
+use crate::store::entity::{EntityRow, EntityType, available_for_write};
 use crate::store::ids::EntityId;
 
-use super::super::content::{Malformed, Written};
-use super::super::entity::{Applied, Ctx, Refusal};
+use super::super::changes::{self, EntityChange};
+use super::super::content::{Malformed, Written, identifier, malformed};
+use super::super::entity::{Applied, Ctx, Refusal, type_name};
+use super::super::parts::Part;
+use super::super::provenance;
 use super::{
-    Field, GuidanceState, Held, Reader, SpecificPart, SpecificValue, not_yet_built, read_column,
-    unbuilt, write_column,
+    Field, GuidanceState, Held, Reader, SpecificPart, SpecificValue, read_column, write_column,
 };
 
+/// The state field. **The same number in all three messages**, which is what
+/// lets one propagation record a container's movement without asking which kind
+/// of container it reached.
+pub const STATE: u32 = 1;
+
 /// Campaign's field 1, its state. The only part a campaign carries.
-pub const CAMPAIGN_STATE: u32 = 1;
+pub const CAMPAIGN_STATE: u32 = STATE;
+
+/// An arc's campaign, and its position beneath it.
+const ARC_CAMPAIGN: u32 = 2;
+const ARC_POSITION: u32 = 3;
+
+/// A quest's two possible ladder parents, its routine, and its position.
+const QUEST_ARC: u32 = 2;
+const QUEST_CAMPAIGN: u32 = 3;
+const QUEST_ROUTINE: u32 = 4;
+const QUEST_POSITION: u32 = 5;
 
 pub const CAMPAIGN_FIELDS: &[Field] = &[Field {
     number: CAMPAIGN_STATE,
@@ -43,101 +129,417 @@ pub const CAMPAIGN_FIELDS: &[Field] = &[Field {
 
 pub const ARC_FIELDS: &[Field] = &[
     Field {
-        number: 1,
+        number: STATE,
         held: Held::Column("state"),
     },
     Field {
-        number: 2,
+        number: ARC_CAMPAIGN,
         held: Held::Column("campaign_id"),
     },
     Field {
-        number: 3,
+        number: ARC_POSITION,
         held: Held::Column("ladder_position"),
     },
 ];
 
 pub const QUEST_FIELDS: &[Field] = &[
     Field {
-        number: 1,
+        number: STATE,
         held: Held::Column("state"),
     },
     Field {
-        number: 2,
+        number: QUEST_ARC,
         held: Held::Column("arc_id"),
     },
     Field {
-        number: 3,
+        number: QUEST_CAMPAIGN,
         held: Held::Column("campaign_id"),
     },
     Field {
-        number: 4,
+        number: QUEST_ROUTINE,
         held: Held::Column("routine_id"),
     },
     Field {
-        number: 5,
+        number: QUEST_POSITION,
         held: Held::Column("ladder_position"),
     },
 ];
+
+// ---------------------------------------------------------------------------
+// Reading the three messages
+// ---------------------------------------------------------------------------
+
+/// The state a wire field names, resolving a clear to the column's default.
+fn state_value(v: Option<i32>) -> Result<SpecificValue, Malformed> {
+    Ok(SpecificValue::State(match v {
+        Some(number) => GuidanceState::from_wire(number)?,
+        None => GuidanceState::DEFAULT,
+    }))
+}
+
+/// An identifier a wire field names, or nothing where it was cleared.
+fn id_value(v: Option<&Vec<u8>>) -> Result<SpecificValue, Malformed> {
+    Ok(SpecificValue::Id(
+        v.map(|bytes| identifier(bytes)).transpose()?,
+    ))
+}
+
+/// A position a client stated, which is refused later and read here so that the
+/// refusal is about reordering rather than about the number's width.
+fn position_value(v: Option<u32>) -> Result<SpecificValue, Malformed> {
+    Ok(SpecificValue::Count(
+        v.map(|p| i32::try_from(p).map_err(|_| malformed("a position that large is not one")))
+            .transpose()?,
+    ))
+}
 
 /// A campaign's content, off the wire.
 pub fn campaign(c: &v1::CampaignContent) -> Result<Written, Malformed> {
     let read = Reader::new(EntityType::Campaign, &c.cleared)?;
     let mut parts = Vec::new();
-    read.singular(&mut parts, CAMPAIGN_STATE, c.state, |v| {
-        Ok(SpecificValue::State(match v {
-            Some(number) => GuidanceState::from_wire(number)?,
-            None => GuidanceState::DEFAULT,
-        }))
-    })?;
+    read.singular(&mut parts, CAMPAIGN_STATE, c.state, state_value)?;
     Ok(Written::from_specific(parts))
 }
 
 /// An arc's content, off the wire.
 ///
-/// **LANE: Guidance.** The campaign it hangs beneath and its position on the
-/// ladder are here, and the ladder is a container the shared model does not
-/// cover: entering one appends, exactly as entering a category does, which is
-/// why `campaign_id` and `ladder_position` must move in one statement — the
-/// table's `CHECK ((campaign_id IS NULL) = (ladder_position IS NULL))` refuses
-/// the state in between. [`validate_and_place`] is where that companion is
-/// produced.
+/// **The parent is read before the state, and the order is load-bearing.** A
+/// write applies parts in the order this list gives them, and the upward
+/// propagation a state can trigger asks the store which container the entity is
+/// beneath. Reading the state first would mean a quest created already started
+/// beneath a campaign moved nothing, because at the moment its state landed it
+/// would have had no parent yet. The same order is used here so that all three
+/// messages read the same way.
 pub fn arc(c: &v1::ArcContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::Arc,
-        &c.cleared,
-        &[
-            (1, c.state.is_some()),
-            (2, c.campaign_id.is_some()),
-            (3, c.ladder_position.is_some()),
-        ],
-    )
+    let read = Reader::new(EntityType::Arc, &c.cleared)?;
+    let mut parts = Vec::new();
+    read.singular(&mut parts, ARC_CAMPAIGN, c.campaign_id.as_ref(), id_value)?;
+    read.singular(&mut parts, ARC_POSITION, c.ladder_position, position_value)?;
+    read.singular(&mut parts, STATE, c.state, state_value)?;
+    Ok(Written::from_specific(parts))
 }
 
 /// A quest's content, off the wire.
 ///
-/// **LANE: Guidance.** At most one ladder parent in total, an arc or a
-/// campaign, never both — the wire says so with a `oneof` and the table says so
-/// with `CHECK (num_nonnulls(arc_id, campaign_id) <= 1)`. Moving between them
-/// clears the other, and both move with `ladder_position`.
+/// **At most one ladder parent in total**, an arc or a campaign, never both:
+/// the wire says so with a `oneof` and the table says so with
+/// `CHECK (num_nonnulls(arc_id, campaign_id) <= 1)`. The `oneof` means one
+/// message can only ever *set* one of the two, so they are separate parts here
+/// and setting either clears the other where it is applied.
 pub fn quest(c: &v1::QuestContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::Quest,
-        &c.cleared,
-        &[
-            (1, c.state.is_some()),
-            (
-                2,
-                matches!(c.parent, Some(v1::quest_content::Parent::ArcId(_))),
-            ),
-            (
-                3,
-                matches!(c.parent, Some(v1::quest_content::Parent::CampaignId(_))),
-            ),
-            (4, c.routine_id.is_some()),
-            (5, c.ladder_position.is_some()),
-        ],
+    use v1::quest_content::Parent;
+    let read = Reader::new(EntityType::Quest, &c.cleared)?;
+    let mut parts = Vec::new();
+    let arc_id = match &c.parent {
+        Some(Parent::ArcId(id)) => Some(id),
+        _ => None,
+    };
+    let campaign_id = match &c.parent {
+        Some(Parent::CampaignId(id)) => Some(id),
+        _ => None,
+    };
+    read.singular(&mut parts, QUEST_ARC, arc_id, id_value)?;
+    read.singular(&mut parts, QUEST_CAMPAIGN, campaign_id, id_value)?;
+    read.singular(&mut parts, QUEST_ROUTINE, c.routine_id.as_ref(), id_value)?;
+    read.singular(&mut parts, QUEST_POSITION, c.ladder_position, position_value)?;
+    read.singular(&mut parts, STATE, c.state, state_value)?;
+    Ok(Written::from_specific(parts))
+}
+
+// ---------------------------------------------------------------------------
+// The ladder
+// ---------------------------------------------------------------------------
+
+/// Where an entity sits on the ladder, as its own side table holds it.
+#[derive(Debug, Clone, Copy, Default)]
+struct Ladder {
+    arc: Option<Uuid>,
+    campaign: Option<Uuid>,
+    position: Option<i32>,
+}
+
+impl Ladder {
+    /// The parent to climb from, arc first because a quest beneath an arc is
+    /// beneath that arc's campaign only through the arc.
+    fn parent(self) -> Option<EntityId> {
+        self.arc.or(self.campaign).map(EntityId::from_uuid)
+    }
+}
+
+/// Read one entity's ladder placement.
+///
+/// A campaign has none — it is a container and never a child — so it answers
+/// with the empty placement rather than being refused.
+async fn ladder_of(ctx: &mut Ctx<'_>, entity: EntityId, kind: EntityType) -> Applied<Ladder> {
+    let sql = match kind {
+        EntityType::Arc => {
+            "SELECT NULL::uuid AS arc_id, campaign_id, ladder_position FROM arc WHERE entity_id = $1"
+        }
+        EntityType::Quest => {
+            "SELECT arc_id, campaign_id, ladder_position FROM quest WHERE entity_id = $1"
+        }
+        _ => return Ok(Ladder::default()),
+    };
+    let row = sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(entity.as_uuid())
+        .fetch_optional(ctx.tx.conn())
+        .await?;
+    let Some(row) = row else {
+        return Ok(Ladder::default());
+    };
+    Ok(Ladder {
+        arc: row.try_get("arc_id")?,
+        campaign: row.try_get("campaign_id")?,
+        position: row.try_get("ladder_position")?,
+    })
+}
+
+/// The next position beneath a container, which is one past the last.
+///
+/// **A campaign's order spans two tables.** Arcs and quests beneath one
+/// campaign are one sequence, so the maximum is taken across both and the order
+/// cannot be a unique constraint. An arc holds only quests.
+///
+/// **Deliberately unscoped by audience**, for exactly the reason
+/// `store::entity::next_category_position` records: this produces an integer
+/// and no content, and a maximum taken over only the entities the writing
+/// member can see would hand out a position already held by one they cannot, so
+/// two entities would share a position and the order would stop being total.
+/// That is a correctness failure produced by applying an access rule to
+/// something that is not an access question.
+async fn next_ladder_position(
+    ctx: &mut Ctx<'_>,
+    container: EntityId,
+    kind: EntityType,
+) -> Applied<i32> {
+    let sql = match kind {
+        EntityType::Campaign => {
+            "SELECT coalesce(max(p), -1) + 1 AS next FROM ( \
+               SELECT ladder_position AS p FROM arc WHERE campaign_id = $1 \
+               UNION ALL \
+               SELECT ladder_position AS p FROM quest WHERE campaign_id = $1 \
+             ) AS beneath"
+        }
+        EntityType::Arc => {
+            "SELECT coalesce(max(ladder_position), -1) + 1 AS next FROM quest WHERE arc_id = $1"
+        }
+        // Nothing else is a ladder container, and the typed foreign keys refuse
+        // one. Reached only if this file grows a caller it should not have.
+        _ => return Err(Refusal::NotAvailable.into()),
+    };
+    let row = sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(container.as_uuid())
+        .fetch_one(ctx.tx.conn())
+        .await?;
+    Ok(row.try_get("next")?)
+}
+
+/// The position field of the type whose parent is being written.
+fn position_field(kind: EntityType) -> u32 {
+    match kind {
+        EntityType::Arc => ARC_POSITION,
+        _ => QUEST_POSITION,
+    }
+}
+
+/// **An expiring refusal, in the register of the three Wave 2.1 makes.**
+///
+/// Wave 2.1 refuses an explicit `category_position` in the same words and for
+/// the same reason: appending is the only placement an entry performs, and
+/// reordering is a deliberate act on a surface with the container in front of
+/// the person. Neither exists until something reorders.
+fn explicit_position_refusal() -> Refusal {
+    Refusal::Malformed(
+        "a position on the ladder is assigned by the instance, which appends on entry to a \
+         container; explicit reordering is not served yet"
+            .into(),
     )
 }
+
+/// The ladder position a parent part carries with it.
+///
+/// **The parent and the position are one movement.** Both of the schema's
+/// checks tie them together — an arc's
+/// `CHECK ((campaign_id IS NULL) = (ladder_position IS NULL))` and a quest's
+/// `CHECK ((num_nonnulls(arc_id, campaign_id) = 0) = (ladder_position IS NULL))`
+/// — so writing them in sequence puts the row through a state the schema
+/// refuses, whichever order the sequence is in. This is the same shape
+/// `write::entity` solves for a category and its position, and the companion
+/// travels the same channel.
+async fn parent_placement(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+    container_kind: EntityType,
+) -> Applied<Option<SpecificPart>> {
+    let SpecificValue::Id(target) = part.value else {
+        return Err(Refusal::Malformed("a ladder parent is an identifier".into()).into());
+    };
+    let ladder = ladder_of(ctx, entity, kind).await?;
+    let position = |p: Option<i32>| {
+        Some(SpecificPart {
+            field: position_field(kind),
+            value: SpecificValue::Count(p),
+        })
+    };
+
+    let Some(target) = target else {
+        // Leaving a container forgets the position — unless the *other* parent
+        // column still holds one. Clearing an arc a quest never had must not
+        // strip the position its campaign gave it.
+        let other = match (kind, container_kind) {
+            (EntityType::Quest, EntityType::Arc) => ladder.campaign,
+            (EntityType::Quest, EntityType::Campaign) => ladder.arc,
+            _ => None,
+        };
+        return Ok(position(other.and(ladder.position)));
+    };
+
+    // The container has to be one this member can see, and it has to be the
+    // right kind of container. Both refusals are the same nothing, which is
+    // what makes refusal on audience indistinguishable from refusal on
+    // nonexistence.
+    let target = EntityId::from_uuid(target);
+    let found = available_for_write(ctx.tx, ctx.member, target, WriteScope::Active)
+        .await?
+        .ok_or(Refusal::NotAvailable)?;
+    if found.entity_type != container_kind {
+        return Err(Refusal::NotAvailable.into());
+    }
+    // A cycle is not reachable here and needs no check: a campaign has no
+    // parent, an arc's only parent is a campaign, and a quest is never a
+    // container. The typed foreign keys refuse anything else.
+
+    let already = match container_kind {
+        EntityType::Arc => ladder.arc,
+        _ => ladder.campaign,
+    };
+    if already == Some(target.as_uuid()) {
+        // Not an entry. The position stands, and is handed back anyway so the
+        // parent and the position still move in one statement.
+        return Ok(position(ladder.position));
+    }
+    let next = next_ladder_position(ctx, target, container_kind).await?;
+    Ok(position(Some(next)))
+}
+
+// ---------------------------------------------------------------------------
+// The one upward movement
+// ---------------------------------------------------------------------------
+
+/// Starting a quest moves the containers above it from waiting to working.
+///
+/// Every clause of the PRD's narrowing is a line of this function, and
+/// `tests/type_content_guidance.rs` has a test per clause:
+///
+/// - **Waiting to working only, and never in reverse.** [`start_container`]
+///   writes nothing unless it finds waiting.
+/// - **Upward only.** Nothing here reads a container's children.
+/// - **It never touches a parent already in the terminal state**, because a
+///   stray child would silently reopen something the person deliberately
+///   closed.
+/// - **It climbs the whole chain, skipping any container already working**, and
+///   a quest attached directly to a campaign moves that campaign because
+///   attachment need not be adjacent. The clauses are stated per parent, so a
+///   worked arc is left alone *and the climb continues past it*: nothing says a
+///   campaign's movement depends on the state of the arc below it.
+/// - **A recurrence is not a container for this.** Nothing here walks
+///   `routine_id`, so nothing can.
+///
+/// **Only a quest's own state triggers this.** The PRD names the trigger
+/// exactly once — *starting a quest moves the containers above it* — and every
+/// clause of the narrowing is written about a quest. An arc set to working by
+/// hand therefore moves nothing, and a working quest *moved into* a waiting
+/// container moves nothing either: neither is somebody starting work. Both are
+/// the drift the PRD accepts as this rule's cost, and closing them would be
+/// this file deciding something the PRD did not.
+///
+/// **The climb stops at a container this member cannot see.** The chain is
+/// followed through each container's own row, and moving a state on an entity
+/// the writer is not entitled to see would attribute a write — in provenance
+/// and in the change sequence — to a member who cannot see what they moved.
+///
+/// **A container this moves gets a counter and a change entry of its own.** The
+/// state is a part like any other: a part that does not record the counter it
+/// moved at is invisible to conflict detection, and a movement nothing records
+/// is one no client ever learns about.
+async fn propagate_start_upward(ctx: &mut Ctx<'_>, quest: EntityId) -> Applied<()> {
+    let mut next = ladder_of(ctx, quest, EntityType::Quest).await?.parent();
+    while let Some(id) = next {
+        let Some(row) = available_for_write(ctx.tx, ctx.member, id, WriteScope::Active).await?
+        else {
+            break;
+        };
+        next = match row.entity_type {
+            EntityType::Arc => {
+                start_container(ctx, &row).await?;
+                ladder_of(ctx, id, EntityType::Arc).await?.parent()
+            }
+            EntityType::Campaign => {
+                start_container(ctx, &row).await?;
+                None
+            }
+            // A ladder parent of any other type is not representable: both
+            // foreign keys carry the container's type.
+            _ => None,
+        };
+    }
+    Ok(())
+}
+
+/// Move one container from waiting to working, or leave it exactly as it is.
+async fn start_container(ctx: &mut Ctx<'_>, row: &EntityRow) -> Applied<()> {
+    let asking = SpecificPart {
+        field: STATE,
+        value: SpecificValue::State(GuidanceState::DEFAULT),
+    };
+    let current = read_column(ctx, row.id, row.entity_type, &asking).await?;
+    if current.value != SpecificValue::State(GuidanceState::Waiting) {
+        // Already working, so there is nothing to do; or already worked, which
+        // this movement never touches.
+        return Ok(());
+    }
+
+    let working = SpecificPart {
+        field: STATE,
+        value: SpecificValue::State(GuidanceState::Working),
+    };
+    write_column(ctx, row.id, row.entity_type, &working).await?;
+
+    // The counter advances because this is an accepted write to that entity,
+    // and a client holding the old one has to learn its state moved.
+    let counter = row.counter + 1;
+    sqlx::query("UPDATE entity SET counter = $2, updated_at = $3 WHERE id = $1")
+        .bind(row.id.as_uuid())
+        .bind(counter)
+        .bind(ctx.at)
+        .execute(ctx.tx.conn())
+        .await?;
+    provenance::record(ctx.tx, row.id, &[Part::Specific(STATE)], counter, ctx.member).await?;
+
+    // Audience did not move, so both sides of the pair are what it already was.
+    // The entry still has to exist: to every member who can see this container,
+    // its state changed.
+    changes::entity_written(
+        ctx.tx,
+        ctx.at,
+        &EntityChange {
+            entity: row.id,
+            audience_before: Some(row.audience.clone()),
+            audience_after: Some(row.audience.clone()),
+            author_before: row.author,
+            author_after: row.author,
+            changed_blocks: Vec::new(),
+        },
+    )
+    .await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The seams the dispatch calls
+// ---------------------------------------------------------------------------
 
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
@@ -145,13 +547,27 @@ pub async fn validate_and_place(
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<Option<SpecificPart>> {
-    let _ = (ctx, entity);
     match (kind, part.field) {
-        // A state owes nothing before it is written. Whether the transition is
-        // legal is the Guidance lane's question and is deliberately not asked
-        // here; see the note at the head of this module.
-        (EntityType::Campaign, CAMPAIGN_STATE) => Ok(None),
-        _ => Err(Refusal::Malformed(not_yet_built(kind).0).into()),
+        // A state owes nothing before it is written. No transition is refused;
+        // see the head of this module for why the diagram's undrawn arrow is
+        // not a prohibition.
+        (EntityType::Campaign | EntityType::Arc | EntityType::Quest, STATE) => Ok(None),
+        (EntityType::Arc, ARC_CAMPAIGN) => {
+            parent_placement(ctx, entity, kind, part, EntityType::Campaign).await
+        }
+        (EntityType::Quest, QUEST_ARC) => {
+            parent_placement(ctx, entity, kind, part, EntityType::Arc).await
+        }
+        (EntityType::Quest, QUEST_CAMPAIGN) => {
+            parent_placement(ctx, entity, kind, part, EntityType::Campaign).await
+        }
+        // Stored and never interpreted, because the routine it would name has
+        // no table to be checked against. See the head of this module.
+        (EntityType::Quest, QUEST_ROUTINE) => Ok(None),
+        (EntityType::Arc, ARC_POSITION) | (EntityType::Quest, QUEST_POSITION) => {
+            Err(explicit_position_refusal().into())
+        }
+        _ => Err(unknown_field(kind, part).into()),
     }
 }
 
@@ -161,9 +577,18 @@ pub async fn current(
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<SpecificPart> {
+    // Every Guidance field is one column of the type's own side table, so the
+    // generic reader serves all of them — including the position, which a
+    // client may not address but which travels as a companion and needs its
+    // stored value read for the same conflict comparison as anything else.
     match (kind, part.field) {
-        (EntityType::Campaign, CAMPAIGN_STATE) => read_column(ctx, entity, kind, part).await,
-        _ => Err(Refusal::Malformed(not_yet_built(kind).0).into()),
+        (EntityType::Campaign, CAMPAIGN_STATE)
+        | (EntityType::Arc, STATE | ARC_CAMPAIGN | ARC_POSITION)
+        | (
+            EntityType::Quest,
+            STATE | QUEST_ARC | QUEST_CAMPAIGN | QUEST_ROUTINE | QUEST_POSITION,
+        ) => read_column(ctx, entity, kind, part).await,
+        _ => Err(unknown_field(kind, part).into()),
     }
 }
 
@@ -175,14 +600,115 @@ pub async fn apply(
     placement: Option<&SpecificPart>,
 ) -> Applied<()> {
     match (kind, part.field) {
-        (EntityType::Campaign, CAMPAIGN_STATE) => {
-            // A campaign has no companion part, so there is nothing to write
-            // alongside. An arc's or a quest's ladder position will be one.
+        (EntityType::Campaign | EntityType::Arc, STATE) => {
+            // Neither is a child of anything that starts, so neither has a
+            // companion and neither propagates.
             debug_assert!(placement.is_none());
             write_column(ctx, entity, kind, part).await
         }
-        _ => Err(Refusal::Malformed(not_yet_built(kind).0).into()),
+        (EntityType::Quest, STATE) => {
+            debug_assert!(placement.is_none());
+            write_column(ctx, entity, kind, part).await?;
+            if part.value == SpecificValue::State(GuidanceState::Working) {
+                propagate_start_upward(ctx, entity).await?;
+            }
+            Ok(())
+        }
+        (EntityType::Arc, ARC_CAMPAIGN) => {
+            write_parent(
+                ctx,
+                entity,
+                "UPDATE arc SET campaign_id = $2, ladder_position = $3 WHERE entity_id = $1",
+                part,
+                placement,
+            )
+            .await
+        }
+        (EntityType::Quest, QUEST_ARC) => {
+            // Setting one ladder parent clears the other, in the same statement
+            // and for the same reason the position moves in it: the row may
+            // never hold two. Clearing this one leaves the other alone, because
+            // clearing an arc a quest never had is not a request to detach it
+            // from its campaign.
+            write_parent(
+                ctx,
+                entity,
+                "UPDATE quest SET arc_id = $2, \
+                 campaign_id = CASE WHEN $2::uuid IS NULL THEN campaign_id ELSE NULL END, \
+                 ladder_position = $3 WHERE entity_id = $1",
+                part,
+                placement,
+            )
+            .await
+        }
+        (EntityType::Quest, QUEST_CAMPAIGN) => {
+            write_parent(
+                ctx,
+                entity,
+                "UPDATE quest SET campaign_id = $2, \
+                 arc_id = CASE WHEN $2::uuid IS NULL THEN arc_id ELSE NULL END, \
+                 ladder_position = $3 WHERE entity_id = $1",
+                part,
+                placement,
+            )
+            .await
+        }
+        (EntityType::Quest, QUEST_ROUTINE) => write_column(ctx, entity, kind, part).await,
+        // Unreachable: `validate_and_place` refuses a client-stated position
+        // before anything is applied, and the instance's own position arrives
+        // as the companion above rather than as a part of its own. Refused
+        // rather than written, so a future caller finds the rule instead of a
+        // silent second path into the column.
+        (EntityType::Arc, ARC_POSITION) | (EntityType::Quest, QUEST_POSITION) => {
+            Err(explicit_position_refusal().into())
+        }
+        _ => Err(unknown_field(kind, part).into()),
     }
+}
+
+/// Write a ladder parent and the position that belongs with it, in one
+/// statement.
+async fn write_parent(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    sql: &'static str,
+    part: &SpecificPart,
+    placement: Option<&SpecificPart>,
+) -> Applied<()> {
+    let SpecificValue::Id(parent) = part.value else {
+        return Err(Refusal::Malformed("a ladder parent is an identifier".into()).into());
+    };
+    // The companion is produced by `parent_placement` for every parent part, so
+    // an absent one means this file has grown a second path into the column.
+    let position = match placement.map(|p| &p.value) {
+        Some(SpecificValue::Count(p)) => *p,
+        _ => {
+            return Err(Refusal::Malformed(
+                "a ladder parent moves with the position that belongs to it".into(),
+            )
+            .into());
+        }
+    };
+    sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(entity.as_uuid())
+        .bind(parent)
+        .bind(position)
+        .execute(ctx.tx.conn())
+        .await?;
+    Ok(())
+}
+
+/// A number that names no field of this type.
+///
+/// [`Reader`] refuses a *cleared* number that names nothing before a part is
+/// ever built, so reaching this means a part was constructed inside the
+/// instance with a number its type does not have.
+fn unknown_field(kind: EntityType, part: &SpecificPart) -> Refusal {
+    Refusal::Malformed(format!(
+        "field {} is not a part of a {}",
+        part.field,
+        type_name(kind)
+    ))
 }
 
 /// Guidance contributes nothing to searchable text.

--- a/crates/altaird/tests/type_content_guidance.rs
+++ b/crates/altaird/tests/type_content_guidance.rs
@@ -1,0 +1,1455 @@
+//! Guidance's type content: the three states, the one upward movement, and the
+//! ladder.
+//!
+//! **Every assertion here reads the stored row.** An acknowledgement says a
+//! write was applied; it does not say anything landed in a column, and a type
+//! module that accepted a message and wrote nothing would satisfy every
+//! acknowledgement-shaped assertion in the suite. So state, ladder parent, and
+//! ladder position are read back out of `campaign`, `arc`, and `quest`
+//! throughout, including the cases where the right answer is null.
+//!
+//! Three groups, and the middle one is the domain behaviour:
+//!
+//! - **Round trips.** Every field of all three messages, through a create and
+//!   through an edit, set and cleared.
+//! - **The state machine and the one upward movement.** Each transition the
+//!   PRD's diagram draws, and one test per clause of the propagation rule's
+//!   narrowing.
+//! - **The ladder as a container.** Arrangement's rules, including the campaign
+//!   ordering arcs and quests together in a sequence that spans two tables.
+
+mod common;
+
+use altair_proto::v1;
+use altaird::store::ids::EntityId;
+use common::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Saying things to the instance
+// ---------------------------------------------------------------------------
+
+fn campaign(state: Option<v1::GuidanceState>) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Campaign(v1::CampaignContent {
+        state: state.map(|s| s as i32),
+        cleared: Vec::new(),
+    })
+}
+
+fn arc(state: Option<v1::GuidanceState>, campaign: Option<EntityId>) -> v1::ArcContent {
+    v1::ArcContent {
+        state: state.map(|s| s as i32),
+        campaign_id: campaign.map(|c| c.as_uuid().as_bytes().to_vec()),
+        ladder_position: None,
+        cleared: Vec::new(),
+    }
+}
+
+fn quest(
+    state: Option<v1::GuidanceState>,
+    parent: Option<v1::quest_content::Parent>,
+) -> v1::QuestContent {
+    v1::QuestContent {
+        state: state.map(|s| s as i32),
+        parent,
+        routine_id: None,
+        ladder_position: None,
+        cleared: Vec::new(),
+    }
+}
+
+fn beneath_arc(id: EntityId) -> Option<v1::quest_content::Parent> {
+    Some(v1::quest_content::Parent::ArcId(
+        id.as_uuid().as_bytes().to_vec(),
+    ))
+}
+
+fn beneath_campaign(id: EntityId) -> Option<v1::quest_content::Parent> {
+    Some(v1::quest_content::Parent::CampaignId(
+        id.as_uuid().as_bytes().to_vec(),
+    ))
+}
+
+fn as_arc(c: v1::ArcContent) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Arc(c)
+}
+
+fn as_quest(c: v1::QuestContent) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Quest(c)
+}
+
+/// An edit carrying one type message and nothing else.
+fn edit_specific(
+    id: EntityId,
+    base: i64,
+    specific: v1::entity_content::Specific,
+) -> v1::intent::Action {
+    edit_entity(
+        id,
+        base as u64,
+        v1::EntityContent {
+            specific: Some(specific),
+            ..Default::default()
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Reading the stored row
+// ---------------------------------------------------------------------------
+
+async fn state_of(world: &World, table: &str, id: EntityId) -> String {
+    let sql = format!("SELECT state::text AS s FROM {table} WHERE entity_id = $1");
+    sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("the side-table row exists")
+        .try_get("s")
+        .expect("state")
+}
+
+/// An arc's stored placement: its campaign and its position beneath it.
+async fn arc_row(world: &World, id: EntityId) -> (Option<Uuid>, Option<i32>) {
+    let row = sqlx::query("SELECT campaign_id, ladder_position FROM arc WHERE entity_id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("the arc row exists");
+    (
+        row.try_get("campaign_id").unwrap(),
+        row.try_get("ladder_position").unwrap(),
+    )
+}
+
+/// A quest's stored placement: both parent columns, its routine, its position.
+struct QuestRow {
+    arc: Option<Uuid>,
+    campaign: Option<Uuid>,
+    routine: Option<Uuid>,
+    position: Option<i32>,
+}
+
+async fn quest_row(world: &World, id: EntityId) -> QuestRow {
+    let row = sqlx::query(
+        "SELECT arc_id, campaign_id, routine_id, ladder_position FROM quest WHERE entity_id = $1",
+    )
+    .bind(id.as_uuid())
+    .fetch_one(&world.db.pool)
+    .await
+    .expect("the quest row exists");
+    QuestRow {
+        arc: row.try_get("arc_id").unwrap(),
+        campaign: row.try_get("campaign_id").unwrap(),
+        routine: row.try_get("routine_id").unwrap(),
+        position: row.try_get("ladder_position").unwrap(),
+    }
+}
+
+/// How many change entries name this entity.
+async fn changes_naming(world: &World, id: EntityId) -> usize {
+    world
+        .changes()
+        .await
+        .iter()
+        .filter(|c| c.entity == Some(id.as_uuid()))
+        .count()
+}
+
+/// The counter a part last moved at, or nothing if it never recorded one.
+async fn part_counter(world: &World, id: EntityId, field: &str) -> Option<i64> {
+    sqlx::query("SELECT counter FROM entity_part_counter WHERE entity_id = $1 AND field_name = $2")
+        .bind(id.as_uuid())
+        .bind(field)
+        .fetch_optional(&world.db.pool)
+        .await
+        .expect("query")
+        .map(|r| r.try_get("counter").expect("counter"))
+}
+
+// ---------------------------------------------------------------------------
+// Building a ladder
+// ---------------------------------------------------------------------------
+
+/// A campaign, an arc beneath it, and a quest beneath the arc, all waiting.
+///
+/// Shared with member two throughout, because the propagation tests need a
+/// container the writing member can see and one of them needs to take that
+/// away.
+struct Chain {
+    campaign: EntityId,
+    arc: EntityId,
+    quest: EntityId,
+}
+
+fn shared_with(world: &World) -> v1::EntityContent {
+    v1::EntityContent {
+        audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+        ..Default::default()
+    }
+}
+
+async fn chain(world: &World) -> Chain {
+    let campaign_id = world
+        .create(&world.one, campaign(None), shared_with(world))
+        .await;
+    let arc_id = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(campaign_id))),
+            shared_with(world),
+        )
+        .await;
+    let quest_id = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_arc(arc_id))),
+            shared_with(world),
+        )
+        .await;
+    Chain {
+        campaign: campaign_id,
+        arc: arc_id,
+        quest: quest_id,
+    }
+}
+
+/// Move one entity's state, and take the acknowledgement.
+async fn set_state(
+    world: &World,
+    member: &altaird::auth::Member,
+    id: EntityId,
+    specific: impl Fn(Option<v1::GuidanceState>) -> v1::entity_content::Specific,
+    state: v1::GuidanceState,
+) -> v1::Acknowledgement {
+    let base = world.counter(id).await;
+    world
+        .submit(member, edit_specific(id, base, specific(Some(state))))
+        .await
+}
+
+fn quest_state(state: Option<v1::GuidanceState>) -> v1::entity_content::Specific {
+    as_quest(quest(state, None))
+}
+
+fn arc_state(state: Option<v1::GuidanceState>) -> v1::entity_content::Specific {
+    as_arc(arc(state, None))
+}
+
+// ---------------------------------------------------------------------------
+// Round trips: every field of every message, stored and read back
+// ---------------------------------------------------------------------------
+
+/// A bare create writes a row with the schema's defaults, and the defaults are
+/// what the store says they are rather than what the write path assumed.
+#[tokio::test]
+async fn a_bare_create_of_each_type_leaves_the_defaults_in_the_row() {
+    let world = World::new().await;
+
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    assert_eq!(state_of(&world, "campaign", c).await, "waiting");
+
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, None)),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(state_of(&world, "arc", a).await, "waiting");
+    assert_eq!(arc_row(&world, a).await, (None, None));
+
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, None)),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(state_of(&world, "quest", q).await, "waiting");
+    let row = quest_row(&world, q).await;
+    assert_eq!(
+        (row.arc, row.campaign, row.routine, row.position),
+        (None, None, None, None)
+    );
+}
+
+#[tokio::test]
+async fn an_arc_round_trips_every_field_through_a_create_and_an_edit() {
+    let world = World::new().await;
+    let first = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let second = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+
+    // Create: both fields stated, and the position the instance assigned.
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(Some(v1::GuidanceState::Worked), Some(first))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(state_of(&world, "arc", a).await, "worked");
+    assert_eq!(arc_row(&world, a).await, (Some(first.as_uuid()), Some(0)));
+
+    // Edit: both fields moved.
+    let base = world.counter(a).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                a,
+                base,
+                as_arc(arc(Some(v1::GuidanceState::Working), Some(second))),
+            ),
+        )
+        .await;
+    assert_eq!(state_of(&world, "arc", a).await, "working");
+    assert_eq!(arc_row(&world, a).await, (Some(second.as_uuid()), Some(0)));
+
+    // Cleared: the campaign goes, and the position goes with it.
+    let base = world.counter(a).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                a,
+                base,
+                as_arc(v1::ArcContent {
+                    cleared: vec![2],
+                    ..arc(None, None)
+                }),
+            ),
+        )
+        .await;
+    assert_eq!(arc_row(&world, a).await, (None, None));
+    assert_eq!(
+        state_of(&world, "arc", a).await,
+        "working",
+        "leaving a container is not a state change"
+    );
+}
+
+#[tokio::test]
+async fn a_quest_round_trips_every_field_through_a_create_and_an_edit() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let routine = Uuid::new_v4();
+
+    let q = world
+        .create(
+            &world.one,
+            as_quest(v1::QuestContent {
+                routine_id: Some(routine.as_bytes().to_vec()),
+                ..quest(Some(v1::GuidanceState::Worked), beneath_arc(a))
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(state_of(&world, "quest", q).await, "worked");
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, Some(a.as_uuid()));
+    assert_eq!(row.campaign, None);
+    assert_eq!(row.routine, Some(routine));
+    assert_eq!(row.position, Some(0));
+
+    // The routine is a column with no table behind it: stored, uninterpreted,
+    // and cleared like anything else. Recurrence is deferred by the scope.
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                q,
+                base,
+                as_quest(v1::QuestContent {
+                    cleared: vec![4],
+                    ..quest(Some(v1::GuidanceState::Working), None)
+                }),
+            ),
+        )
+        .await;
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.routine, None);
+    assert_eq!(
+        row.arc,
+        Some(a.as_uuid()),
+        "clearing a routine is not a move"
+    );
+    assert_eq!(state_of(&world, "quest", q).await, "working");
+}
+
+/// The state is a part, and a part that records no counter movement is
+/// invisible to conflict detection. So is a ladder parent, and so is the
+/// position that moved with it.
+#[tokio::test]
+async fn every_guidance_part_records_the_counter_it_moved_at() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(Some(v1::GuidanceState::Working), Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    assert_eq!(
+        part_counter(&world, a, "specific.1").await,
+        Some(1),
+        "state"
+    );
+    assert_eq!(
+        part_counter(&world, a, "specific.2").await,
+        Some(1),
+        "the campaign"
+    );
+    assert_eq!(
+        part_counter(&world, a, "specific.3").await,
+        Some(1),
+        "the position the instance assigned alongside it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The state machine
+// ---------------------------------------------------------------------------
+
+/// The five movements the PRD's diagram draws, on all three types.
+///
+/// `[*] → Waiting` is the sixth and is the column default, which
+/// `a_bare_create_of_each_type_leaves_the_defaults_in_the_row` covers.
+#[tokio::test]
+async fn every_transition_the_diagram_draws_holds() {
+    use v1::GuidanceState::{Waiting, Worked, Working};
+    let world = World::new().await;
+
+    for (from, to) in [
+        (Waiting, Working),
+        (Working, Worked),
+        (Working, Waiting),
+        (Worked, Working),
+        (Waiting, Worked),
+    ] {
+        for (table, of) in [
+            ("campaign", campaign as fn(Option<v1::GuidanceState>) -> _),
+            ("arc", arc_state),
+            ("quest", quest_state),
+        ] {
+            let id = world
+                .create(&world.one, of(Some(from)), v1::EntityContent::default())
+                .await;
+            assert_eq!(state_of(&world, table, id).await, store_name(from));
+
+            let ack = set_state(&world, &world.one, id, of, to).await;
+            assert!(
+                matches!(ack.outcome, Some(v1::acknowledgement::Outcome::Applied(_))),
+                "{table}: {from:?} to {to:?} was not applied: {:?}",
+                ack.outcome
+            );
+            assert_eq!(
+                state_of(&world, table, id).await,
+                store_name(to),
+                "{table}: {from:?} to {to:?}"
+            );
+        }
+    }
+}
+
+fn store_name(state: v1::GuidanceState) -> &'static str {
+    match state {
+        v1::GuidanceState::Waiting => "waiting",
+        v1::GuidanceState::Working => "working",
+        v1::GuidanceState::Worked => "worked",
+        v1::GuidanceState::Unspecified => unreachable!(),
+    }
+}
+
+/// **The movement the diagram does not draw is still not refused**, and this
+/// test is where that reading is visible rather than inferred from an absence
+/// of code.
+///
+/// Worked → waiting is the one ordered pair of distinct states the PRD's
+/// diagram leaves undrawn. Nothing in the prose forbids it, the substrate does
+/// not reject a well-formed write, and the spine's rule that clearing a state
+/// returns it to the column default performs exactly this movement — so a
+/// prohibition invented here would contradict behaviour the spine already
+/// tests.
+#[tokio::test]
+async fn the_movement_the_diagram_leaves_undrawn_is_not_refused() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            campaign(Some(v1::GuidanceState::Worked)),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let ack = set_state(&world, &world.one, id, campaign, v1::GuidanceState::Waiting).await;
+    assert!(
+        matches!(ack.outcome, Some(v1::acknowledgement::Outcome::Applied(_))),
+        "{:?}",
+        ack.outcome
+    );
+    assert_eq!(state_of(&world, "campaign", id).await, "waiting");
+}
+
+/// Restating the state something is already in is not a movement and not a
+/// refusal. Two members doing it are not divergent either, which the spine
+/// tests; this is the single-member half.
+#[tokio::test]
+async fn restating_the_state_something_is_already_in_is_accepted() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            campaign(Some(v1::GuidanceState::Working)),
+            v1::EntityContent::default(),
+        )
+        .await;
+    set_state(&world, &world.one, id, campaign, v1::GuidanceState::Working).await;
+    assert_eq!(state_of(&world, "campaign", id).await, "working");
+}
+
+// ---------------------------------------------------------------------------
+// The one upward movement, one test per clause of the narrowing
+// ---------------------------------------------------------------------------
+
+/// The rule itself: starting a quest moves the containers above it, silently,
+/// and it climbs the whole chain.
+#[tokio::test]
+async fn starting_a_quest_starts_the_whole_chain_above_it() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+
+    assert_eq!(state_of(&world, "quest", l.quest).await, "working");
+    assert_eq!(state_of(&world, "arc", l.arc).await, "working");
+    assert_eq!(state_of(&world, "campaign", l.campaign).await, "working");
+}
+
+/// **Attachment need not be adjacent.** A quest hanging directly off a campaign
+/// moves that campaign, with no arc in between.
+#[tokio::test]
+async fn a_quest_attached_directly_to_a_campaign_starts_it() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    set_state(
+        &world,
+        &world.one,
+        q,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+    assert_eq!(state_of(&world, "campaign", c).await, "working");
+}
+
+/// **Waiting to working only, and never in reverse.** A quest reaching the
+/// terminal state moves nothing, and neither does one going back to waiting.
+#[tokio::test]
+async fn the_movement_never_runs_in_reverse() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+
+    // The containers are working; the quest finishes.
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+    let arc_counter = world.counter(l.arc).await;
+    let campaign_counter = world.counter(l.campaign).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Worked,
+    )
+    .await;
+    assert_eq!(state_of(&world, "arc", l.arc).await, "working");
+    assert_eq!(state_of(&world, "campaign", l.campaign).await, "working");
+
+    // And going back to waiting does not drag them back either.
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Waiting,
+    )
+    .await;
+    assert_eq!(state_of(&world, "arc", l.arc).await, "working");
+    assert_eq!(state_of(&world, "campaign", l.campaign).await, "working");
+
+    // Nothing was written to them at all: no counter moved.
+    assert_eq!(world.counter(l.arc).await, arc_counter);
+    assert_eq!(world.counter(l.campaign).await, campaign_counter);
+}
+
+/// **Upward only. Nothing a container does moves a child.**
+#[tokio::test]
+async fn nothing_a_container_does_moves_a_child() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.campaign,
+        campaign,
+        v1::GuidanceState::Working,
+    )
+    .await;
+    assert_eq!(state_of(&world, "arc", l.arc).await, "waiting");
+    assert_eq!(state_of(&world, "quest", l.quest).await, "waiting");
+
+    set_state(
+        &world,
+        &world.one,
+        l.arc,
+        arc_state,
+        v1::GuidanceState::Worked,
+    )
+    .await;
+    assert_eq!(state_of(&world, "quest", l.quest).await, "waiting");
+}
+
+/// **It never touches a parent already in the terminal state**, because a stray
+/// child would silently reopen something the person deliberately closed.
+///
+/// The clauses are stated per parent, so the climb continues past the worked
+/// arc and the campaign above it still moves. Nothing in the PRD makes a
+/// campaign's movement depend on the state of the arc below it, and stopping
+/// there would be this suite deciding something the PRD did not.
+#[tokio::test]
+async fn it_never_reopens_a_container_already_worked_and_climbs_past_it() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+    set_state(
+        &world,
+        &world.one,
+        l.arc,
+        arc_state,
+        v1::GuidanceState::Worked,
+    )
+    .await;
+    let arc_counter = world.counter(l.arc).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+
+    assert_eq!(
+        state_of(&world, "arc", l.arc).await,
+        "worked",
+        "a stray child may not reopen what the person closed"
+    );
+    assert_eq!(
+        world.counter(l.arc).await,
+        arc_counter,
+        "and nothing was written to it"
+    );
+    assert_eq!(state_of(&world, "campaign", l.campaign).await, "working");
+}
+
+/// **It skips any container already working**, which means leaving it entirely
+/// alone rather than writing the value it already holds.
+#[tokio::test]
+async fn the_climb_skips_a_container_already_working() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+    set_state(
+        &world,
+        &world.one,
+        l.arc,
+        arc_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+    let arc_counter = world.counter(l.arc).await;
+    let arc_changes = changes_naming(&world, l.arc).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+
+    assert_eq!(state_of(&world, "arc", l.arc).await, "working");
+    assert_eq!(world.counter(l.arc).await, arc_counter);
+    assert_eq!(
+        changes_naming(&world, l.arc).await,
+        arc_changes,
+        "a container that was already working produced no change entry"
+    );
+    assert_eq!(
+        state_of(&world, "campaign", l.campaign).await,
+        "working",
+        "and the climb carried on past it"
+    );
+}
+
+/// A quest created already started moves its containers.
+///
+/// **This is why a parent is read off the wire before the state.** A create
+/// applies parts in the order the type's reader produced them; reading the
+/// state first would leave the quest parentless at the moment its state landed,
+/// and the movement would find nothing above it.
+#[tokio::test]
+async fn a_quest_created_already_started_starts_its_containers() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    world
+        .create(
+            &world.one,
+            as_quest(quest(Some(v1::GuidanceState::Working), beneath_arc(a))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    assert_eq!(state_of(&world, "arc", a).await, "working");
+    assert_eq!(state_of(&world, "campaign", c).await, "working");
+}
+
+/// A container this moves takes a counter and a change entry of its own.
+///
+/// Both are load-bearing: a part that does not record the counter it moved at
+/// is invisible to conflict detection, and a movement nothing records is one no
+/// client ever learns about. The audience did not change, so both sides of the
+/// change entry's pair are what it already was.
+#[tokio::test]
+async fn a_container_the_movement_starts_records_a_counter_and_a_change() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+    let before = world.counter(l.campaign).await;
+    let entries = changes_naming(&world, l.campaign).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+
+    assert_eq!(world.counter(l.campaign).await, before + 1);
+    assert_eq!(
+        part_counter(&world, l.campaign, "specific.1").await,
+        Some(before + 1),
+        "the state part records the counter the instance moved it at"
+    );
+    assert_eq!(changes_naming(&world, l.campaign).await, entries + 1);
+
+    let last = world
+        .changes()
+        .await
+        .into_iter()
+        .rfind(|c| c.entity == Some(l.campaign.as_uuid()))
+        .expect("an entry for the campaign");
+    assert_eq!(last.kind, "entity_written");
+    assert_eq!(last.audience_before, last.audience_after);
+}
+
+/// **The climb stops at a container this member cannot see.** Moving a state on
+/// an entity the writer is not entitled to see would attribute a write, in
+/// provenance and in the change sequence, to a member who cannot see what they
+/// moved. The PRD already accepts that a container can drift out of step with
+/// the work beneath it; this is one more way, and it is the safe way.
+#[tokio::test]
+async fn the_climb_stops_at_a_container_the_writer_cannot_see() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+
+    // One narrows the campaign to itself. Two can still see the arc and quest.
+    let base = world.counter(l.campaign).await;
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                l.campaign,
+                base as u64,
+                v1::EntityContent {
+                    cleared: vec![5],
+                    specific: Some(campaign(None)),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    set_state(
+        &world,
+        &world.two,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+
+    assert_eq!(state_of(&world, "arc", l.arc).await, "working");
+    assert_eq!(
+        state_of(&world, "campaign", l.campaign).await,
+        "waiting",
+        "the climb does not reach past a container the writer cannot see"
+    );
+}
+
+/// A quest with no ladder parent starts nothing, and says so by not failing.
+///
+/// **A recurrence is not a container for this**, and in v0 that clause is moot
+/// rather than implemented: `routine_id` is a column with no `routine` table
+/// behind it, nothing walks it, and so nothing can propagate through one. The
+/// quest here holds a routine and no ladder parent, which is the shape the
+/// clause is about.
+#[tokio::test]
+async fn a_quest_with_no_ladder_parent_starts_nothing() {
+    let world = World::new().await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(v1::QuestContent {
+                routine_id: Some(Uuid::new_v4().as_bytes().to_vec()),
+                ..quest(None, None)
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    set_state(
+        &world,
+        &world.one,
+        q,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+    assert_eq!(state_of(&world, "quest", q).await, "working");
+    assert_eq!(
+        world.changes().await.len(),
+        2,
+        "the create and the edit, and nothing the movement added"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The ladder as a container
+// ---------------------------------------------------------------------------
+
+/// **A campaign is one container over mixed kinds.** Arcs and quests beneath it
+/// are one sequence, so the order spans two tables and cannot be a constraint.
+#[tokio::test]
+async fn a_campaign_orders_arcs_and_quests_together_in_one_sequence() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+
+    let a1 = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q1 = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let a2 = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q2 = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    assert_eq!(arc_row(&world, a1).await.1, Some(0));
+    assert_eq!(quest_row(&world, q1).await.position, Some(1));
+    assert_eq!(arc_row(&world, a2).await.1, Some(2));
+    assert_eq!(
+        quest_row(&world, q2).await.position,
+        Some(3),
+        "the order is total across both kinds: a quest never reuses an arc's position"
+    );
+}
+
+/// **Leaving a container forgets the position**, and the gap it leaves is not
+/// reused. Nothing shifts to close it: the substrate's order is the one the
+/// person gave, and repairing it would move things they did not move.
+#[tokio::test]
+async fn leaving_forgets_the_position_and_nothing_is_repaired() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(arc_row(&world, a).await.1, Some(0));
+    assert_eq!(quest_row(&world, q).await.position, Some(1));
+
+    // The arc leaves.
+    let base = world.counter(a).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                a,
+                base,
+                as_arc(v1::ArcContent {
+                    cleared: vec![2],
+                    ..arc(None, None)
+                }),
+            ),
+        )
+        .await;
+    assert_eq!(arc_row(&world, a).await, (None, None));
+    assert_eq!(
+        quest_row(&world, q).await.position,
+        Some(1),
+        "nothing else moved to close the gap"
+    );
+
+    // And the next entrant appends past the gap.
+    let next = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(quest_row(&world, next).await.position, Some(2));
+}
+
+/// Restating the container something is already in is not an entry, so it does
+/// not append. The position the person can predict is the one it keeps.
+#[tokio::test]
+async fn restating_the_same_container_does_not_move_the_position() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let first = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let second = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(arc_row(&world, first).await.1, Some(0));
+
+    let base = world.counter(first).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(first, base, as_arc(arc(None, Some(c)))),
+        )
+        .await;
+    assert_eq!(
+        arc_row(&world, first).await,
+        (Some(c.as_uuid()), Some(0)),
+        "restating the container is not entering it again"
+    );
+    assert_eq!(arc_row(&world, second).await.1, Some(1));
+}
+
+/// **Entering a different container appends at the end of that one**, and the
+/// order does not survive the move. That is the substrate's accepted cost.
+#[tokio::test]
+async fn entering_a_different_container_appends_at_the_end_of_it() {
+    let world = World::new().await;
+    let from = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let to = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    // Something already sits in the destination.
+    world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(to))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(from))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(arc_row(&world, a).await.1, Some(0));
+
+    let base = world.counter(a).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(a, base, as_arc(arc(None, Some(to)))),
+        )
+        .await;
+    assert_eq!(arc_row(&world, a).await, (Some(to.as_uuid()), Some(1)));
+}
+
+/// **A parent and its position never move in separate statements**, and this is
+/// the test that would trip the table check if they did.
+///
+/// A quest moving from an arc to a campaign passes through no intermediate row.
+/// Either order in a sequence of two statements is refused by the schema:
+/// setting `campaign_id` first leaves both parents non-null, which
+/// `CHECK (num_nonnulls(arc_id, campaign_id) <= 1)` refuses; clearing `arc_id`
+/// first leaves a position with no parent, which
+/// `CHECK ((num_nonnulls(arc_id, campaign_id) = 0) = (ladder_position IS NULL))`
+/// refuses. A store fault rather than an acknowledgement is what this failing
+/// looks like.
+#[tokio::test]
+async fn a_quest_moving_between_an_arc_and_a_campaign_moves_in_one_statement() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_arc(a))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(quest_row(&world, q).await.arc, Some(a.as_uuid()));
+
+    // Arc to campaign. The arc is cleared in the same statement.
+    let base = world.counter(q).await;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_campaign(c)))),
+        )
+        .await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, None);
+    assert_eq!(row.campaign, Some(c.as_uuid()));
+    assert_eq!(
+        row.position,
+        Some(1),
+        "the arc beneath the campaign already holds 0"
+    );
+
+    // And back again.
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(a)))),
+        )
+        .await;
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, Some(a.as_uuid()));
+    assert_eq!(row.campaign, None);
+    assert_eq!(row.position, Some(0), "the arc was empty");
+}
+
+/// Leaving with nothing left to hold the position clears both, in one
+/// statement. Clearing the position alone would trip the same check.
+#[tokio::test]
+async fn a_quest_leaving_its_campaign_forgets_the_position_in_one_statement() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(quest_row(&world, q).await.position, Some(0));
+
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                q,
+                base,
+                as_quest(v1::QuestContent {
+                    cleared: vec![3],
+                    ..quest(None, None)
+                }),
+            ),
+        )
+        .await;
+    let row = quest_row(&world, q).await;
+    assert_eq!((row.arc, row.campaign, row.position), (None, None, None));
+}
+
+/// Clearing the parent a quest does not have leaves the one it does have alone.
+///
+/// The two parents are separate parts because the wire's `oneof` can only set
+/// one of them, and a clear of the empty one is not a request to detach from
+/// the other. Getting this wrong would strip a position the campaign gave.
+#[tokio::test]
+async fn clearing_the_parent_a_quest_does_not_have_leaves_the_other_alone() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    // Clear field 2, the arc, which this quest never had.
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                q,
+                base,
+                as_quest(v1::QuestContent {
+                    cleared: vec![2],
+                    ..quest(None, None)
+                }),
+            ),
+        )
+        .await;
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.campaign, Some(c.as_uuid()));
+    assert_eq!(
+        row.position,
+        Some(0),
+        "the campaign still holds the position"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// What a ladder parent has to be
+// ---------------------------------------------------------------------------
+
+async fn refusal_creating(world: &World, specific: v1::entity_content::Specific) -> v1::Refused {
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(specific),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    refused(&ack).clone()
+}
+
+/// **Refusal on audience is indistinguishable from refusal on nonexistence**,
+/// and from a parent of the wrong kind. All three are the same nothing.
+#[tokio::test]
+async fn a_ladder_parent_that_is_not_available_is_always_the_same_nothing() {
+    let world = World::new().await;
+
+    // Member two's campaign, which one cannot see.
+    let hidden = world
+        .create(&world.two, campaign(None), v1::EntityContent::default())
+        .await;
+    // A note is not a campaign.
+    let note = world.note(&world.one, "not a campaign").await;
+    let nothing = EntityId::from_uuid(Uuid::new_v4());
+
+    let mut answers = Vec::new();
+    for parent in [hidden, note, nothing] {
+        let refused = refusal_creating(&world, as_arc(arc(None, Some(parent)))).await;
+        answers.push((refused.reason, refused.detail));
+    }
+    assert_eq!(
+        answers[0].0,
+        v1::RefusalReason::NotAvailable as i32,
+        "{answers:?}"
+    );
+    assert!(
+        answers.windows(2).all(|w| w[0] == w[1]),
+        "the three answers differ, which is an oracle for what exists: {answers:?}"
+    );
+
+    // And the same for a quest's two parent fields.
+    for parent in [beneath_arc(hidden), beneath_campaign(note)] {
+        let refused = refusal_creating(&world, as_quest(quest(None, parent))).await;
+        assert_eq!(refused.reason, v1::RefusalReason::NotAvailable as i32);
+        assert_eq!(refused.detail, answers[0].1);
+    }
+}
+
+/// **An explicit ladder position is refused**, in the register of the three
+/// refusals Wave 2.1 makes that expire when a named lane lands. Appending is
+/// what this build implements; reordering is a deliberate act on a surface with
+/// the container in front of the person, and nothing reorders yet.
+#[tokio::test]
+async fn an_explicit_ladder_position_is_refused_with_the_reason_it_expires() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+
+    let stated = [
+        as_arc(v1::ArcContent {
+            ladder_position: Some(3),
+            ..arc(None, Some(c))
+        }),
+        as_quest(v1::QuestContent {
+            ladder_position: Some(3),
+            ..quest(None, beneath_campaign(c))
+        }),
+    ];
+    for specific in stated {
+        let refused = refusal_creating(&world, specific).await;
+        assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
+        assert!(
+            refused.detail.contains("appends on entry to a container")
+                && refused.detail.contains("not served yet"),
+            "{}",
+            refused.detail
+        );
+    }
+
+    // On an edit too, and nothing was written on the way to the refusal.
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(a).await;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_specific(
+                a,
+                base,
+                as_arc(v1::ArcContent {
+                    ladder_position: Some(7),
+                    state: Some(v1::GuidanceState::Working as i32),
+                    ..arc(None, None)
+                }),
+            ),
+        )
+        .await;
+    assert_eq!(
+        refused(&ack).reason,
+        v1::RefusalReason::Malformed as i32,
+        "{:?}",
+        ack.outcome
+    );
+    assert_eq!(
+        state_of(&world, "arc", a).await,
+        "waiting",
+        "the refusal rolled back the state that travelled with it"
+    );
+    assert_eq!(arc_row(&world, a).await, (Some(c.as_uuid()), Some(0)));
+}
+
+// ---------------------------------------------------------------------------
+// Conflict, on a part that is Guidance's own
+// ---------------------------------------------------------------------------
+
+/// A same-part conflict on a ladder parent retains both values, and the write
+/// still applies. **A stale base is never a rejection.**
+#[tokio::test]
+async fn a_same_part_conflict_on_a_ladder_parent_retains_both_values() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), shared_with(&world))
+        .await;
+    let first = world
+        .create(&world.one, as_arc(arc(None, Some(c))), shared_with(&world))
+        .await;
+    let second = world
+        .create(&world.one, as_arc(arc(None, Some(c))), shared_with(&world))
+        .await;
+    let q = world
+        .create(&world.one, as_quest(quest(None, None)), shared_with(&world))
+        .await;
+    let base = world.counter(q).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(first)))),
+        )
+        .await;
+    let ack = world
+        .submit(
+            &world.two,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(second)))),
+        )
+        .await;
+
+    let applied = applied(&ack);
+    let conflict = applied
+        .conflict
+        .as_ref()
+        .expect("two members moving one quest's arc is one part twice");
+    assert!(conflict.specific_fields.contains(&2));
+
+    let conflicts = world.conflicts(q).await;
+    let arc_conflict = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.2"))
+        .expect("the arc is the conflicted part");
+    assert_eq!(
+        arc_conflict.mine.as_deref(),
+        Some(second.as_uuid().to_string()).as_deref()
+    );
+    assert_eq!(
+        arc_conflict.theirs.as_deref(),
+        Some(first.as_uuid().to_string()).as_deref()
+    );
+    assert_eq!(
+        quest_row(&world, q).await.arc,
+        Some(second.as_uuid()),
+        "the write still applied"
+    );
+}
+
+/// Different parts of one type merge with nobody involved: one member moves the
+/// state, the other the parent, both from the same base.
+#[tokio::test]
+async fn two_members_moving_different_guidance_parts_merge() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), shared_with(&world))
+        .await;
+    let q = world
+        .create(&world.one, as_quest(quest(None, None)), shared_with(&world))
+        .await;
+    let base = world.counter(q).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                q,
+                base,
+                as_quest(quest(Some(v1::GuidanceState::Worked), None)),
+            ),
+        )
+        .await;
+    let ack = world
+        .submit(
+            &world.two,
+            edit_specific(q, base, as_quest(quest(None, beneath_campaign(c)))),
+        )
+        .await;
+
+    assert!(
+        applied(&ack).conflict.is_none(),
+        "different parts merge, and a stale base alone is never a rejection"
+    );
+    assert_eq!(state_of(&world, "quest", q).await, "worked");
+    assert_eq!(quest_row(&world, q).await.campaign, Some(c.as_uuid()));
+}


### PR DESCRIPTION
Sixth of nine slices of Wave 2.2. Stacked on #25. Fills in `write/specific/guidance.rs`.

## The three states and every transition

`waiting | working | worked`, the same three at every level with no reduced set for containers. Users may not add, remove, reorder or define states.

`every_transition_the_diagram_draws_holds` walks all five drawn movements across campaign, arc **and** quest — fifteen combinations, each asserted against the stored column. `[*] → Waiting` is the column default.

**No transition is refused, and a reviewer should expect that to look like an omission.** Three reasons, and the third is decisive: no prose forbids any movement — the PRD constrains the *set* of states and the one upward movement, and says nothing about which movements a person may make; the substrate does not reject well-formed writes, and "moved it the wrong way round" is neither unreadable content nor an unavailable entity; and **the spine's own `clearing_a_state_returns_it_to_the_default` creates a worked campaign, clears the state, and expects `waiting`** — performing the one movement the diagram leaves undrawn. A prohibition would have made a test in an earlier slice fail. `the_movement_the_diagram_leaves_undrawn_is_not_refused` makes the reading visible rather than inferable from absent code.

## The one upward movement, with a test per clause

*"Starting a quest moves the containers above it from Waiting to Working"*, silently. Every clause of the narrowing is load-bearing and each has its own test:

- Waiting→Working only, **never in reverse** — and the containers' counters are asserted unchanged, so nothing was written to them at all.
- **Upward only** — nothing a container does moves a child.
- **Never touches an already-terminal parent** — a worked arc keeps its state and its counter, and the campaign above it still moves.
- **Climbs the whole chain**, skipping one already working — and a skipped arc gains no counter and no change entry, because skipping means leaving alone rather than rewriting the value it already holds.
- **A campaign reached without an arc** starts too.

Three narrowings are stated here rather than in the PRD, and are deviations a reviewer should judge:

**Only a quest's own state triggers it.** An arc set to working by hand moves nothing; a working quest moved *into* a waiting container moves nothing. The PRD names the trigger once and every clause is written about a quest. Neither case is somebody starting work, and both are the drift the PRD explicitly accepts as this rule's cost.

**A worked container is left alone and the climb continues past it.** The clauses are stated per parent; nothing makes a campaign's movement depend on the arc below it.

**The climb stops at a container the writer cannot see.** Not in the PRD at all. Moving a state on an entity the writer is not entitled to see would attribute a write — in provenance *and* in the change sequence — to a member who cannot see what they moved. A propagation that quietly climbs past the audience boundary is a leak through a side channel.

## Ladder position

`arc.ladder_position` and `quest.ladder_position` live on the side tables, distinct from the `entity.category_position` Wave 2.1 already assigns — an entity holds an unrelated position in each container it sits in.

**A campaign is one container over mixed kinds**, so arcs and quests are ordered *together* beneath it and the order spans two tables, which is why it cannot be a constraint. `a_campaign_orders_arcs_and_quests_together_in_one_sequence` asserts A1=0, Q1=1, A2=2, Q2=3 read from both tables.

**A parent and its position never move in separate statements.** Moving a quest from an arc to a campaign: setting `campaign_id` first leaves both parents non-null, which `num_nonnulls(arc_id, campaign_id) <= 1` refuses; clearing `arc_id` first leaves a position with no parent, which the other check refuses. Either order in two statements is a store fault rather than an acknowledgement. One `UPDATE` per parent write, clearing the sibling via `CASE`.

**An explicit `ladder_position` from a client is refused**, in the same register as Wave 2.1 refusing an explicit `category_position`: position is assigned by the instance, which appends on entry, and reordering is not served yet.

## Two documented disagreements, named rather than resolved

The substrate says the ladder defines its own ordering rules "in the Guidance PRD"; the PRD says the campaign's mixed-kind ordering "needs nothing of its own" and then defines none. This implements the substrate's Arrangement rules and says so, on the reading that "nothing of its own" means the substrate's rules already cover it.

The prompted-but-not-cascaded behaviour — moving a parent to terminal asks about its children, deleting one asks the same — is **client behaviour**, and there is no client before Wave 4. No prompt is built and no silent cascade either, since a silent cascade is the exact thing the PRD rules out.

## Not here

`routine_id` is stored and uninterpreted: the column exists, no `routine` table does, and there is no foreign key. Routines are deferred by `docs/altair-v0-scope.md`, so the field round-trips and nothing walks it. Whatever builds recurrence owes that check.

The ladder needs **no** cycle check, unlike nested locations and categories: a campaign has no parent, an arc's only parent is a campaign, a quest is never a container, and the typed foreign keys refuse anything else.

## Verification

- `cargo test --workspace`: 30 targets, 374 tests, 0 failures.
- Every assertion reads the **stored row** — state, both parent columns, `routine_id`, ladder position — including null and cleared cases. Nothing in this slice passes on an acknowledgement alone.
