### PR TITLE
Wave 2.2 slice 7: what putting the lanes together turned up

### DIFF
--- a/crates/altaird/src/store/entity.rs
+++ b/crates/altaird/src/store/entity.rs
@@ -255,6 +255,81 @@ pub async fn uncategorise_all(
         .collect()
 }
 
+/// Finish detaching entities a vanished type-specific container let go of.
+///
+/// # Why this is here and not in the type's own module
+///
+/// The release itself is the type's: an arc's `campaign_id`, a location's
+/// `parent_location_id`, an item's `location_id`. Each is a column of that
+/// type's own side table and belongs in that type's module, which is the whole
+/// point of the type-content seam.
+///
+/// What cannot live there is this half. A change entry per orphan needs the
+/// audience, and `tests/one_predicate.rs` refuses any source outside
+/// `store/audience.rs` that names the audience column and issues SQL — rightly,
+/// because a paraphrased predicate is a second implementation whatever it is
+/// spelled like. [`uncategorise_all`] gets to write `RETURNING … audience`
+/// precisely because it lives here. So the split is: the type module clears its
+/// own column and hands back identities, and this reads what the change sequence
+/// needs.
+///
+/// One helper rather than one per container, because the ladder and nested
+/// locations owe exactly the same thing and two implementations of *what a
+/// detach does to the entity row* is two chances to forget the counter.
+///
+/// # Deliberately unscoped
+///
+/// The same reason [`uncategorise_all`] gives, and it is not a smaller reason
+/// here: **the container is gone for everybody.** Leaving the entities a writing
+/// member cannot see still pointing at it would keep a dangling reference alive
+/// precisely where nobody can find it. Nothing leaves this function that a
+/// caller can show anyone — the identities become change entries, and those are
+/// assembled per member by the read path, which applies the predicate then.
+///
+/// Do not add a predicate here. A later reader who "fixes" this will produce
+/// orphans that only the invisible members keep.
+///
+/// The counter advances on each, because losing a container is an accepted write
+/// to the entity that lost it, and a client holding the old counter has to learn
+/// it happened.
+pub async fn detached_from_container(
+    tx: &mut WriteTx,
+    released: &[EntityId],
+    at: DateTime<Utc>,
+) -> sqlx::Result<Vec<Uncategorised>> {
+    if released.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ids: Vec<uuid::Uuid> = released.iter().map(|e| e.as_uuid()).collect();
+    let sql = format!(
+        "UPDATE entity SET counter = counter + 1, updated_at = $2 \
+         WHERE id = ANY($1) \
+         RETURNING id, {AUDIENCE_COLUMN} AS audience, author_member_id, counter"
+    );
+    let rows = sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(&ids)
+        .bind(at)
+        .fetch_all(tx.conn())
+        .await?;
+
+    rows.iter()
+        .map(|r| {
+            Ok(Uncategorised {
+                id: r.try_get("id")?,
+                audience: r
+                    .try_get::<Vec<uuid::Uuid>, _>("audience")?
+                    .into_iter()
+                    .map(MemberRef::from_uuid)
+                    .collect(),
+                author: r
+                    .try_get::<Option<uuid::Uuid>, _>("author_member_id")?
+                    .map(MemberRef::from_uuid),
+                counter: r.try_get("counter")?,
+            })
+        })
+        .collect()
+}
+
 /// The entities a single removal act put into holding, as this member can see
 /// them.
 ///

--- a/crates/altaird/src/write/entity.rs
+++ b/crates/altaird/src/write/entity.rs
@@ -38,8 +38,8 @@ use crate::store::{WriteScope, WriteTx};
 use super::changes::{self, EntityChange};
 use super::content::{Date, Malformed, PartWrite, Written};
 use super::outcome::{ConflictParts, Outcome};
-use super::parts::Part;
-use super::specific;
+use super::parts::{ContentPart, Part};
+use super::specific::{self, SpecificPart};
 use super::{body, provenance};
 
 /// One intent's worth of context: the transaction, who is writing, and when.
@@ -169,17 +169,22 @@ async fn current(ctx: &mut Ctx<'_>, row: &EntityRow, part: &PartWrite) -> Applie
 
 /// Apply one part to the store. Assumes it has already been validated.
 ///
-/// `placement` is the position the instance assigned as a consequence, which is
-/// only ever set alongside a category. **The two move in one statement**,
-/// because the store's own check says a category and a position are either both
-/// there or both absent: writing them in sequence puts the row through a state
-/// the schema refuses, whichever order the sequence is in.
+/// `placements` are the parts the instance moved as a consequence. The shared
+/// model produces at most one — the position assigned alongside a category, and
+/// **the two move in one statement**, because the store's own check says a
+/// category and a position are either both there or both absent: writing them in
+/// sequence puts the row through a state the schema refuses, whichever order the
+/// sequence is in.
+///
+/// A type's content may produce more than one, so this takes a slice. **Each
+/// arm finds what it needs by kind rather than by position**, because the order
+/// a lane returns companions in is that lane's business.
 async fn apply_part(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &PartWrite,
-    placement: Option<&PartWrite>,
+    placements: &[PartWrite],
 ) -> Applied<()> {
     match part {
         PartWrite::Title(v) => {
@@ -213,38 +218,17 @@ async fn apply_part(
             }
         }
         PartWrite::Category(v) => {
-            match placement {
-                // Entering a container, or leaving one. The instance decided a
-                // position either way, and the two columns move in one
-                // statement because the schema refuses the state between them.
-                Some(PartWrite::CategoryPosition(p)) => {
-                    sqlx::query(
-                        "UPDATE entity SET category_id = $2, category_position = $3 \
-                         WHERE id = $1",
-                    )
-                    .bind(entity.as_uuid())
-                    .bind(v.map(EntityId::as_uuid))
-                    .bind(*p)
-                    .execute(ctx.tx.conn())
-                    .await?;
-                }
-                // **Naming the container it is already in leaves it where it
-                // sits.** A client that resends the whole of `EntityContent` on
-                // every edit — which is the ordinary shape of a client, not an
-                // odd one — states the category each time without meaning to
-                // move anything. Writing a null position here would be the
-                // schema's `(category_id IS NULL) = (category_position IS
-                // NULL)` violated, so this was not a silent reordering waiting
-                // to happen; it was the whole transaction failing on the second
-                // edit that mentioned a category.
-                _ => {
-                    sqlx::query("UPDATE entity SET category_id = $2 WHERE id = $1")
-                        .bind(entity.as_uuid())
-                        .bind(v.map(EntityId::as_uuid))
-                        .execute(ctx.tx.conn())
-                        .await?;
-                }
-            }
+            let position = placements.iter().find_map(|p| match p {
+                PartWrite::CategoryPosition(v) => Some(*v),
+                _ => None,
+            });
+            let position = position.flatten();
+            sqlx::query("UPDATE entity SET category_id = $2, category_position = $3 WHERE id = $1")
+                .bind(entity.as_uuid())
+                .bind(v.map(EntityId::as_uuid))
+                .bind(position)
+                .execute(ctx.tx.conn())
+                .await?;
         }
         PartWrite::CategoryPosition(v) => {
             sqlx::query("UPDATE entity SET category_position = $2 WHERE id = $1")
@@ -290,11 +274,14 @@ async fn apply_part(
             // amount — and is handed through so the module can write both in
             // one statement, for the same reason a category and its position
             // move together here.
-            let placement = placement.and_then(|p| match p {
-                PartWrite::Specific(s) => Some(s),
-                _ => None,
-            });
-            specific::apply(ctx, entity, kind, s, placement).await?;
+            let companions: Vec<SpecificPart> = placements
+                .iter()
+                .filter_map(|p| match p {
+                    PartWrite::Specific(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .collect();
+            specific::apply(ctx, entity, kind, s, &companions).await?;
         }
     }
     Ok(())
@@ -320,27 +307,37 @@ async fn refresh_search_text(ctx: &mut Ctx<'_>, entity: EntityId, kind: EntityTy
     Ok(())
 }
 
-/// Checks a part owes before it is applied, and the placement the instance
+/// Checks a part owes before it is applied, and the placements the instance
 /// makes rather than the client.
 ///
-/// Returns any extra part the instance moved as a consequence — a position,
-/// when a category changed.
+/// Returns every extra part the instance moved as a consequence — a position,
+/// when a category changed, and whatever a type's content moved beside the part
+/// the write named.
+///
+/// `addressed` is every type-specific part this same message writes, handed
+/// down because a type sometimes cannot decide one part without seeing another.
+/// See [`specific::validate_and_place`] for the two cases that need it.
 async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     entering: Option<EntityId>,
     part: &PartWrite,
-) -> Applied<Option<PartWrite>> {
+    addressed: &[SpecificPart],
+) -> Applied<Vec<PartWrite>> {
     match part {
-        PartWrite::Specific(s) => Ok(specific::validate_and_place(ctx, entity, kind, s)
-            .await?
-            .map(PartWrite::Specific)),
+        PartWrite::Specific(s) => Ok(
+            specific::validate_and_place(ctx, entity, kind, s, addressed)
+                .await?
+                .into_iter()
+                .map(PartWrite::Specific)
+                .collect(),
+        ),
         PartWrite::Audience(ids) | PartWrite::Assignments(ids) => {
             if !memberships_exist(ctx.tx, ids).await? {
                 return Err(Refusal::NotAvailable.into());
             }
-            Ok(None)
+            Ok(Vec::new())
         }
         PartWrite::CategoryPosition(_) => Err(Refusal::Malformed(
             "position is assigned by the instance, which appends on entry to a container; \
@@ -364,15 +361,30 @@ async fn validate_and_place(
             let entering_this = entering != Some(*category);
             if entering_this {
                 let next = crate::store::entity::next_category_position(ctx.tx, *category).await?;
-                return Ok(Some(PartWrite::CategoryPosition(Some(next))));
+                return Ok(vec![PartWrite::CategoryPosition(Some(next))]);
             }
-            Ok(None)
+            Ok(Vec::new())
         }
         // Leaving a container forgets the position. Nothing is carried and
         // nothing needs repair.
-        PartWrite::Category(None) => Ok(Some(PartWrite::CategoryPosition(None))),
-        _ => Ok(None),
+        PartWrite::Category(None) => Ok(vec![PartWrite::CategoryPosition(None)]),
+        _ => Ok(Vec::new()),
     }
+}
+
+/// Every type-specific part one message writes.
+///
+/// Built once per write rather than per part: it is the same set for every part
+/// in the loop, and a type asking about a sibling field is asking about this.
+fn addressed_specifics(written: &Written) -> Vec<SpecificPart> {
+    written
+        .parts
+        .iter()
+        .filter_map(|p| match p {
+            PartWrite::Specific(s) => Some(s.clone()),
+            _ => None,
+        })
+        .collect()
 }
 
 /// The side-table row a type carries beyond the shared model, with its
@@ -496,12 +508,13 @@ pub async fn create(
 
     make_type_row(ctx, id, kind).await?;
 
+    let addressed = addressed_specifics(&written);
     let mut moved = Vec::new();
     for part in &written.parts {
-        let placement = validate_and_place(ctx, id, kind, None, part).await?;
-        apply_part(ctx, id, kind, part, placement.as_ref()).await?;
+        let placements = validate_and_place(ctx, id, kind, None, part, &addressed).await?;
+        apply_part(ctx, id, kind, part, &placements).await?;
         moved.push(part.part());
-        if let Some(placement) = &placement {
+        for placement in &placements {
             moved.push(placement.part());
         }
     }
@@ -527,7 +540,7 @@ pub async fn create(
                 return Err(Refusal::NotAvailable.into());
             }
             let part = PartWrite::Audience(default);
-            apply_part(ctx, id, kind, &part, None).await?;
+            apply_part(ctx, id, kind, &part, &[]).await?;
             moved.push(part.part());
         }
     }
@@ -610,44 +623,43 @@ pub async fn edit(
     let mut moved = Vec::new();
     let counter = row.counter + 1;
 
+    let addressed = addressed_specifics(&written);
     for part in &written.parts {
-        let placement = validate_and_place(ctx, id, kind, row.category_id, part).await?;
+        let placements =
+            validate_and_place(ctx, id, kind, row.category_id, part, &addressed).await?;
         let stored = current(ctx, &row, part).await?;
         touching.push((part.part(), part.text(), stored.text()));
-        apply_part(ctx, id, kind, part, placement.as_ref()).await?;
-        moved.push(part.part());
-        // **A placement moves, and does not conflict.** It goes into `moved` —
-        // it did move, and which member moved it is a fact provenance owes an
-        // answer to — but deliberately not into `touching`, which is what the
-        // write *addressed*. The client addressed the part beside it; the
-        // instance chose this one.
+        // **A write that changed nothing did not move the part.** The same
+        // comparison that decides a conflict decides this, and it has to: a
+        // part's provenance row carries *who* last moved it, so recording a
+        // no-op would hand ownership to a member who wrote nothing and erase the
+        // one who did. A later conflict would then name the wrong person, and
+        // `conflict.theirs_member_id` is stored and crosses the wire — the
+        // substrate requires that whose edit each value was is known and may be
+        // shown, and after a same-value write it would be known and wrong.
         //
-        // The distinction is load-bearing rather than tidy, because a placement
-        // is a part the client is refused permission to state — an explicit
-        // `category_position` and an `asserted_at` are both malformed. A
-        // conflict is something a person is shown and asked to settle, and
-        // settling one means restating the part. So a conflict on a placement
-        // is one nothing can clear.
+        // The entity's own counter still advances below, which is what tells a
+        // client there was a write at all. Only the per-part record is withheld,
+        // and a part a write does not address already goes unrecorded — so this
+        // is the existing shape rather than a new rule.
         //
-        // It would also be a conflict carrying no information. A placement
-        // moves only when the part it accompanies moves, so it overlaps what
-        // moved since exactly when that part does, and there are only two
-        // outcomes: the two writes disagree about the amount, and the amount
-        // already conflicts with the time beside it saying nothing further; or
-        // the two writes agree — *both counted four tins* — and the amount
-        // rightly does not conflict while two `Utc::now()` readings a
-        // millisecond apart never compare equal and would raise a conflict out
-        // of agreement. That second case is the machinery working against its
-        // own purpose, on the one field a person could otherwise have acted on.
-        //
-        // **Not a claim that these parts can never conflict.** Reordering is
-        // not served yet; when it is, a write that names a position addresses
-        // it, and it enters `touching` through the loop above like any other
-        // part and conflicts normally. The rule is about what a write said, not
-        // about which parts are special.
-        if let Some(placement) = &placement {
-            moved.push(placement.part());
+        // `specific::guidance` already does this in the upward climb, reading the
+        // current state and returning before recording when nothing moves. The
+        // general edit path now agrees with it.
+        let mut record = |part: &PartWrite, stored: &PartWrite| {
+            if part.text() != stored.text() {
+                moved.push(part.part());
+            }
+        };
+        record(part, &stored);
+        // Each companion is compared like any other part, and against what the
+        // store holds *now* — which is why this runs before the write below.
+        for placement in &placements {
+            let stored = current(ctx, &row, placement).await?;
+            touching.push((placement.part(), placement.text(), stored.text()));
+            record(placement, &stored);
         }
+        apply_part(ctx, id, kind, part, &placements).await?;
     }
 
     // A body reads what is stored and writes what changed in one step, because
@@ -848,7 +860,7 @@ pub async fn restore(
         if let Some(category) = row.category_id {
             let next = crate::store::entity::next_category_position(ctx.tx, category).await?;
             let part = PartWrite::CategoryPosition(Some(next));
-            apply_part(ctx, row.id, row.entity_type, &part, None).await?;
+            apply_part(ctx, row.id, row.entity_type, &part, &[]).await?;
             provenance::record(ctx.tx, row.id, &[part.part()], row.counter + 1, ctx.member).await?;
         }
 
@@ -961,10 +973,92 @@ pub async fn erase(ctx: &mut Ctx<'_>, ids: &[EntityId]) -> Applied<(Vec<EntityId
         // fortiori to an erased one, and leaving the reference would point
         // every member of the category at a tombstone.
         //
-        // The type-specific containers, the ladder and nested locations, are
-        // Wave 2.2's for the same reason their content is.
+        // **That is category *membership*, and it is only half of what a
+        // category holds.** The other half is category *nesting* —
+        // `category.parent_category_id` — and `uncategorise_all` does not touch
+        // it. An earlier version of this comment named "the ladder and nested
+        // locations" and omitted the third case, which is where the blind spot
+        // started; it is spelled out here so the next reader does not inherit
+        // it.
+        //
+        // The type-specific containers — the ladder, nested locations, and
+        // nested categories — release through the type-content seam, because
+        // the column that points at the container is a column of the type's own
+        // side table. The seam hands back identities and which part of each
+        // moved; the counter and the audience a change entry needs come from the
+        // store layer, which is the only place entitled to read that column. See
+        // `specific::detach_contained`.
+        //
+        // **A type that has not built its release must not look like an empty
+        // one.** `Detachment::NotBuilt` is a distinct answer for exactly that
+        // reason, and it is stepped over here rather than treated as nothing to
+        // do. Two types still answer that way and both are visible rather than
+        // silent: Guidance's arcs and quests, and a nested category.
+        let contained = match specific::detach_contained(ctx, *id, row.entity_type).await? {
+            specific::Detachment::Released(released) => released,
+            specific::Detachment::NoContainer | specific::Detachment::NotBuilt => Vec::new(),
+        };
+        let ids: Vec<EntityId> = contained.iter().map(|r| r.entity).collect();
+        for orphan in crate::store::entity::detached_from_container(ctx.tx, &ids, ctx.at).await? {
+            // **A release is a write, so it owes provenance.** The counter
+            // advanced, and a part that moves a counter without recording which
+            // part moved is invisible to conflict detection: a later stale edit
+            // to the same field would merge silently, losing the fact that the
+            // container went away underneath it. `restore` already records the
+            // position it moves as a consequence of something else; this is the
+            // same shape and now gets the same treatment.
+            //
+            // Attributed to the member who erased the container, because that is
+            // who caused it.
+            for r in contained.iter().filter(|r| r.entity == orphan.id) {
+                provenance::record(
+                    ctx.tx,
+                    orphan.id,
+                    std::slice::from_ref(&r.part),
+                    orphan.counter,
+                    ctx.member,
+                )
+                .await?;
+            }
+            changes::entity_written(
+                ctx.tx,
+                ctx.at,
+                &EntityChange {
+                    entity: orphan.id,
+                    audience_before: Some(orphan.audience.clone()),
+                    audience_after: Some(orphan.audience),
+                    author_before: orphan.author,
+                    author_after: orphan.author,
+                    changed_blocks: Vec::new(),
+                },
+            )
+            .await?;
+        }
+
         if row.entity_type == EntityType::Category {
             for orphan in crate::store::entity::uncategorise_all(ctx.tx, *id, ctx.at).await? {
+                // The same reasoning, for the membership half. Two parts move —
+                // the category and the position within it — and both are
+                // recorded, because the counter advanced and something has to be
+                // able to say what changed.
+                //
+                // **The alternative reading was considered and rejected**: that
+                // uncategorising is a consequence rather than an authored
+                // placement and so should not conflict. It cannot be had for
+                // free — the counter already advances here, and a write that
+                // moves a counter and records nothing is the silent case. Either
+                // it is a write to this entity or it is not; it is, so it pays.
+                provenance::record(
+                    ctx.tx,
+                    orphan.id,
+                    &[
+                        Part::Content(ContentPart::Category),
+                        Part::Content(ContentPart::CategoryPosition),
+                    ],
+                    orphan.counter,
+                    ctx.member,
+                )
+                .await?;
                 changes::entity_written(
                     ctx.tx,
                     ctx.at,

--- a/crates/altaird/src/write/mod.rs
+++ b/crates/altaird/src/write/mod.rs
@@ -286,6 +286,30 @@ async fn act(ctx: &mut Ctx<'_>, intent: &v1::Intent) -> Result<Outcome, Failed> 
                 // detection entirely — the one mechanism this item exists to
                 // build — rather than being refused as the unreadable message
                 // it is.
+                //
+                // **Zero is refused for the same reason, from the other end.**
+                // The first counter an entity has is 1, issued by its own
+                // create, so zero is not a counter this instance could have
+                // issued either — and it is the value the wire produces when a
+                // client omits the field, because `base_counter` is a proto3
+                // `uint64` whose default is indistinguishable from unset.
+                //
+                // Accepting it was not harmless. A create records the parts it
+                // applied without comparing them, because on a create there is
+                // no prior value to compare against; so an entity created with
+                // its title explicitly cleared carries provenance for a title
+                // that never changed. An edit arriving with base zero reads
+                // `0 < 1`, asks what moved since, finds that record, and retains
+                // a conflict over a part only the second write ever touched.
+                // The client that hits this is one that forgot a field, not one
+                // doing anything exotic.
+                if e.base_counter == 0 {
+                    return Err(Refusal::Malformed(
+                        "a base counter is a counter this instance could have issued,                          and the first one is 1"
+                            .into(),
+                    )
+                    .into());
+                }
                 let base = i64::try_from(e.base_counter).map_err(|_| {
                     Refusal::Malformed(
                         "a base counter is a counter this instance could have issued".into(),

--- a/crates/altaird/src/write/specific/category.rs
+++ b/crates/altaird/src/write/specific/category.rs
@@ -63,7 +63,11 @@ use crate::store::ids::EntityId;
 
 use super::super::content::{Malformed, Written, identifier};
 use super::super::entity::{Applied, Ctx, Refusal, memberships_exist};
-use super::{Field, Held, Reader, SpecificPart, SpecificValue, nesting, read_column, write_column};
+use super::super::parts::Part;
+use super::{
+    Detachment, Field, Held, Reader, Released, SpecificPart, SpecificValue, nesting, read_column,
+    write_column,
+};
 
 /// A category's field 1, the category it nests inside.
 pub const CATEGORY_PARENT: u32 = 1;
@@ -225,4 +229,64 @@ pub async fn apply(
 pub async fn search_text(ctx: &mut Ctx<'_>, entity: EntityId) -> Applied<Option<String>> {
     let _ = (ctx, entity);
     Ok(None)
+}
+
+/// Let go of the categories nested inside this one, because it is gone.
+///
+/// # A category is a container in two senses and only one of them is here
+///
+/// **Membership** is an entity filed *in* a category, held on the `entity` row
+/// as `category_id`, and released by `uncategorise_all` — the shared model's,
+/// built in Wave 2.1, and called in the same erase path a few lines further on.
+/// **Nesting** is a category sitting *under* another, held in this type's own
+/// side table as `parent_category_id`, and released by nobody until now. The
+/// erase path's comment names "the ladder and nested locations" and silently
+/// omits this third case, which is how it stayed missing.
+///
+/// The two sets are different and the two releases do not double-count. A
+/// category nested under the erased one is reached here, through
+/// `parent_category_id`. An entity filed in it is reached there, through
+/// `category_id`. A category that is *both* — nested under it and filed in it —
+/// is released once by each, of two different columns, and ends up with neither
+/// a parent nor a filing, which is exactly right. Nothing is written twice
+/// because nothing writes the same column twice.
+///
+/// # Parentless, not promoted
+///
+/// A child does not inherit its erased parent's parent. Guidance settled this
+/// for the ladder and the reasoning carries without change: promotion would be
+/// the system moving something into a container the person never put it in.
+/// Being parentless is a complete state — the substrate's rule that *an entity
+/// whose category is deleted becomes uncategorised, which is a valid state
+/// requiring no repair* is the same rule one level up.
+///
+/// # Erasure only, never removal
+///
+/// Removal is recoverable and grouped, and restoring the group is meant to put
+/// back what was there. A child detached on removal would come back parentless,
+/// so the release would quietly destroy what the deletion group exists to
+/// preserve. This is reached from the erase path alone.
+///
+/// # Unscoped
+///
+/// [`nesting::detach_children`] applies no audience predicate, and that is
+/// deliberate rather than overlooked — see its documentation for the reasoning,
+/// which is `uncategorise_all`'s and is no smaller here.
+pub async fn detach_contained(ctx: &mut Ctx<'_>, entity: EntityId) -> Applied<Detachment> {
+    let table = super::side_table(EntityType::Category)
+        .ok_or_else(|| Refusal::Malformed("a category has no table".into()))?;
+    let released = nesting::detach_children(ctx.tx, table, PARENT_COLUMN, entity).await?;
+    Ok(Detachment::Released(
+        released
+            .into_iter()
+            // The part that moved is this type's field 1. A release advances the
+            // released entity's counter, and a write that advances a counter
+            // owes provenance; which part moved is the type's knowledge, and a
+            // child category lost its parent rather than its shelf.
+            .map(|entity| Released {
+                entity,
+                part: Part::Specific(CATEGORY_PARENT),
+            })
+            .collect(),
+    ))
 }

--- a/crates/altaird/src/write/specific/guidance.rs
+++ b/crates/altaird/src/write/specific/guidance.rs
@@ -101,7 +101,8 @@ use super::super::entity::{Applied, Ctx, Refusal, type_name};
 use super::super::parts::Part;
 use super::super::provenance;
 use super::{
-    Field, GuidanceState, Held, Reader, SpecificPart, SpecificValue, read_column, write_column,
+    Detachment, Field, GuidanceState, Held, Reader, Released, SpecificPart, SpecificValue,
+    part_held_in, read_column, write_column,
 };
 
 /// The state field. **The same number in all three messages**, which is what
@@ -122,38 +123,51 @@ const QUEST_CAMPAIGN: u32 = 3;
 const QUEST_ROUTINE: u32 = 4;
 const QUEST_POSITION: u32 = 5;
 
+/// The columns this file names in a statement as well as in a declaration.
+///
+/// **Named once because two things must not drift.** [`detach_contained`] and
+/// [`apply`] write these columns by name, and the `FIELDS` tables below declare
+/// the same columns as where a wire field is held; `tests/type_content.rs`
+/// checks the declarations against the store but cannot see a statement that
+/// spells one differently. Following the convention Tracking arrived at for
+/// exactly this reason.
+const STATE_COLUMN: &str = "state";
+const CAMPAIGN_COLUMN: &str = "campaign_id";
+const ARC_COLUMN: &str = "arc_id";
+const LADDER_POSITION_COLUMN: &str = "ladder_position";
+
 pub const CAMPAIGN_FIELDS: &[Field] = &[Field {
     number: CAMPAIGN_STATE,
-    held: Held::Column("state"),
+    held: Held::Column(STATE_COLUMN),
 }];
 
 pub const ARC_FIELDS: &[Field] = &[
     Field {
         number: STATE,
-        held: Held::Column("state"),
+        held: Held::Column(STATE_COLUMN),
     },
     Field {
         number: ARC_CAMPAIGN,
-        held: Held::Column("campaign_id"),
+        held: Held::Column(CAMPAIGN_COLUMN),
     },
     Field {
         number: ARC_POSITION,
-        held: Held::Column("ladder_position"),
+        held: Held::Column(LADDER_POSITION_COLUMN),
     },
 ];
 
 pub const QUEST_FIELDS: &[Field] = &[
     Field {
         number: STATE,
-        held: Held::Column("state"),
+        held: Held::Column(STATE_COLUMN),
     },
     Field {
         number: QUEST_ARC,
-        held: Held::Column("arc_id"),
+        held: Held::Column(ARC_COLUMN),
     },
     Field {
         number: QUEST_CAMPAIGN,
-        held: Held::Column("campaign_id"),
+        held: Held::Column(CAMPAIGN_COLUMN),
     },
     Field {
         number: QUEST_ROUTINE,
@@ -161,9 +175,19 @@ pub const QUEST_FIELDS: &[Field] = &[
     },
     Field {
         number: QUEST_POSITION,
-        held: Held::Column("ladder_position"),
+        held: Held::Column(LADDER_POSITION_COLUMN),
     },
 ];
+
+/// The side table a type keeps its content in.
+///
+/// Taken from [`super::side_table`] rather than written out, so the statements
+/// here cannot disagree with the one place that decides which table a type has.
+fn table_of(kind: EntityType) -> Applied<&'static str> {
+    super::side_table(kind).ok_or_else(|| {
+        Refusal::Malformed(format!("a {} has no table of its own", type_name(kind))).into()
+    })
+}
 
 // ---------------------------------------------------------------------------
 // Reading the three messages
@@ -361,7 +385,8 @@ fn explicit_position_refusal() -> Refusal {
     )
 }
 
-/// The ladder position a parent part carries with it.
+/// The companions a parent part carries with it: the ladder position always,
+/// and the parent it vacated where it vacated one.
 ///
 /// **The parent and the position are one movement.** Both of the schema's
 /// checks tie them together — an arc's
@@ -369,36 +394,60 @@ fn explicit_position_refusal() -> Refusal {
 /// `CHECK ((num_nonnulls(arc_id, campaign_id) = 0) = (ladder_position IS NULL))`
 /// — so writing them in sequence puts the row through a state the schema
 /// refuses, whichever order the sequence is in. This is the same shape
-/// `write::entity` solves for a category and its position, and the companion
-/// travels the same channel.
+/// `write::entity` solves for a category and its position.
+///
+/// **The vacated parent is a companion too, and it is provenance rather than
+/// placement.** A quest has two parent columns and may hold only one, so
+/// setting an arc clears the campaign — in the same statement, by the `CASE`
+/// in [`apply`], because the row may never hold two. That vacated column is a
+/// part like any other: a part that does not record the counter it moved at is
+/// invisible to conflict detection, so a concurrent edit to it would merge
+/// silently instead of retaining both values. Returning it here is what puts it
+/// in provenance. It is already written by the statement that clears it, so it
+/// never needs to reach [`apply`].
+///
+/// **A companion is owed only when the part genuinely moved.** Handing back a
+/// vacated parent that was already null would not manufacture a conflict —
+/// `provenance::detect` compares rendered text, and arriving equals stored —
+/// but it *would* write an `entity_part_counter` row claiming that part moved,
+/// and a later unrelated edit would read that as an overlap.
+///
+/// **The position comes first, and [`write_parent`] checks that rather than
+/// trusting it.** The dispatch hands a narrow lane only the first companion, so
+/// the one `apply` needs has to lead; the check turns an ordering assumption
+/// into a refusal somebody sees.
 async fn parent_placement(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
     container_kind: EntityType,
-) -> Applied<Option<SpecificPart>> {
+) -> Applied<Vec<SpecificPart>> {
     let SpecificValue::Id(target) = part.value else {
         return Err(Refusal::Malformed("a ladder parent is an identifier".into()).into());
     };
     let ladder = ladder_of(ctx, entity, kind).await?;
-    let position = |p: Option<i32>| {
-        Some(SpecificPart {
-            field: position_field(kind),
-            value: SpecificValue::Count(p),
-        })
+    let position = |p: Option<i32>| SpecificPart {
+        field: position_field(kind),
+        value: SpecificValue::Count(p),
+    };
+
+    // The other parent column, which setting this one clears in the same
+    // statement, paired with what it holds now. Only a quest has one; an arc's
+    // single parent has nothing to displace.
+    let sibling = match (kind, container_kind) {
+        (EntityType::Quest, EntityType::Arc) => Some((QUEST_CAMPAIGN, ladder.campaign)),
+        (EntityType::Quest, EntityType::Campaign) => Some((QUEST_ARC, ladder.arc)),
+        _ => None,
     };
 
     let Some(target) = target else {
         // Leaving a container forgets the position — unless the *other* parent
         // column still holds one. Clearing an arc a quest never had must not
-        // strip the position its campaign gave it.
-        let other = match (kind, container_kind) {
-            (EntityType::Quest, EntityType::Arc) => ladder.campaign,
-            (EntityType::Quest, EntityType::Campaign) => ladder.arc,
-            _ => None,
-        };
-        return Ok(position(other.and(ladder.position)));
+        // strip the position its campaign gave it. Nothing is vacated here:
+        // clearing leaves the sibling exactly as it was.
+        let held = sibling.and_then(|(_, holds)| holds);
+        return Ok(vec![position(held.and(ladder.position))]);
     };
 
     // The container has to be one this member can see, and it has to be the
@@ -422,11 +471,21 @@ async fn parent_placement(
     };
     if already == Some(target.as_uuid()) {
         // Not an entry. The position stands, and is handed back anyway so the
-        // parent and the position still move in one statement.
-        return Ok(position(ladder.position));
+        // parent and the position still move in one statement. Nothing is
+        // vacated: the two parents are exclusive, so the sibling is already
+        // null.
+        return Ok(vec![position(ladder.position)]);
     }
+
     let next = next_ladder_position(ctx, target, container_kind).await?;
-    Ok(position(Some(next)))
+    let mut companions = vec![position(Some(next))];
+    if let Some((field, Some(_))) = sibling {
+        companions.push(SpecificPart {
+            field,
+            value: SpecificValue::Id(None),
+        });
+    }
+    Ok(companions)
 }
 
 // ---------------------------------------------------------------------------
@@ -558,12 +617,12 @@ pub async fn validate_and_place(
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
-) -> Applied<Option<SpecificPart>> {
+) -> Applied<Vec<SpecificPart>> {
     match (kind, part.field) {
         // A state owes nothing before it is written. No transition is refused;
         // see the head of this module for why the diagram's undrawn arrow is
         // not a prohibition.
-        (EntityType::Campaign | EntityType::Arc | EntityType::Quest, STATE) => Ok(None),
+        (EntityType::Campaign | EntityType::Arc | EntityType::Quest, STATE) => Ok(Vec::new()),
         (EntityType::Arc, ARC_CAMPAIGN) => {
             parent_placement(ctx, entity, kind, part, EntityType::Campaign).await
         }
@@ -575,7 +634,7 @@ pub async fn validate_and_place(
         }
         // Stored and never interpreted, because the routine it would name has
         // no table to be checked against. See the head of this module.
-        (EntityType::Quest, QUEST_ROUTINE) => Ok(None),
+        (EntityType::Quest, QUEST_ROUTINE) => Ok(Vec::new()),
         (EntityType::Arc, ARC_POSITION) | (EntityType::Quest, QUEST_POSITION) => {
             Err(explicit_position_refusal().into())
         }
@@ -626,28 +685,21 @@ pub async fn apply(
             }
             Ok(())
         }
+        // An arc has one parent and nothing to displace.
         (EntityType::Arc, ARC_CAMPAIGN) => {
-            write_parent(
-                ctx,
-                entity,
-                "UPDATE arc SET campaign_id = $2, ladder_position = $3 WHERE entity_id = $1",
-                part,
-                placement,
-            )
-            .await
+            write_parent(ctx, entity, kind, CAMPAIGN_COLUMN, None, part, placement).await
         }
+        // Setting one ladder parent clears the other, in the same statement and
+        // for the same reason the position moves in it: the row may never hold
+        // two. Clearing this one leaves the other alone, because clearing an arc
+        // a quest never had is not a request to detach it from its campaign.
         (EntityType::Quest, QUEST_ARC) => {
-            // Setting one ladder parent clears the other, in the same statement
-            // and for the same reason the position moves in it: the row may
-            // never hold two. Clearing this one leaves the other alone, because
-            // clearing an arc a quest never had is not a request to detach it
-            // from its campaign.
             write_parent(
                 ctx,
                 entity,
-                "UPDATE quest SET arc_id = $2, \
-                 campaign_id = CASE WHEN $2::uuid IS NULL THEN campaign_id ELSE NULL END, \
-                 ladder_position = $3 WHERE entity_id = $1",
+                kind,
+                ARC_COLUMN,
+                Some(CAMPAIGN_COLUMN),
                 part,
                 placement,
             )
@@ -657,9 +709,9 @@ pub async fn apply(
             write_parent(
                 ctx,
                 entity,
-                "UPDATE quest SET campaign_id = $2, \
-                 arc_id = CASE WHEN $2::uuid IS NULL THEN arc_id ELSE NULL END, \
-                 ladder_position = $3 WHERE entity_id = $1",
+                kind,
+                CAMPAIGN_COLUMN,
+                Some(ARC_COLUMN),
                 part,
                 placement,
             )
@@ -680,20 +732,41 @@ pub async fn apply(
 
 /// Write a ladder parent and the position that belongs with it, in one
 /// statement.
+///
+/// `sibling` is the other parent column where the type has one, cleared in this
+/// same statement because the row may never hold two. It is left alone when the
+/// addressed parent is being cleared: clearing a parent a quest never had is not
+/// a request to detach it from the one it does have.
 async fn write_parent(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
-    sql: &'static str,
+    kind: EntityType,
+    column: &'static str,
+    sibling: Option<&'static str>,
     part: &SpecificPart,
     placement: Option<&SpecificPart>,
 ) -> Applied<()> {
     let SpecificValue::Id(parent) = part.value else {
         return Err(Refusal::Malformed("a ladder parent is an identifier".into()).into());
     };
-    // The companion is produced by `parent_placement` for every parent part, so
-    // an absent one means this file has grown a second path into the column.
-    let position = match placement.map(|p| &p.value) {
-        Some(SpecificValue::Count(p)) => *p,
+    // **The companion is identified by field number, not by having arrived.**
+    // `parent_placement` can return two — the position and a vacated parent —
+    // and the dispatch hands a narrow lane only the first, so this checks that
+    // what arrived is the position rather than assuming it. An absent or
+    // mismatched companion means the ordering there changed, or that this file
+    // has grown a second path into the column; either is a refusal somebody
+    // sees rather than a position silently written from the wrong part.
+    let expected = position_field(kind);
+    let position = match placement {
+        Some(p) if p.field == expected => match p.value {
+            SpecificValue::Count(v) => v,
+            _ => {
+                return Err(Refusal::Malformed(
+                    "a ladder position is a whole number of places".into(),
+                )
+                .into());
+            }
+        },
         _ => {
             return Err(Refusal::Malformed(
                 "a ladder parent moves with the position that belongs to it".into(),
@@ -701,6 +774,15 @@ async fn write_parent(
             .into());
         }
     };
+    let table = table_of(kind)?;
+    let clear_sibling = match sibling {
+        Some(other) => format!("{other} = CASE WHEN $2::uuid IS NULL THEN {other} ELSE NULL END, "),
+        None => String::new(),
+    };
+    let sql = format!(
+        "UPDATE {table} SET {column} = $2, {clear_sibling}{LADDER_POSITION_COLUMN} = $3 \
+         WHERE entity_id = $1"
+    );
     sqlx::query(sqlx::AssertSqlSafe(sql))
         .bind(entity.as_uuid())
         .bind(parent)
@@ -721,6 +803,134 @@ fn unknown_field(kind: EntityType, part: &SpecificPart) -> Refusal {
         part.field,
         type_name(kind)
     ))
+}
+
+// ---------------------------------------------------------------------------
+// What an erased ladder container lets go of
+// ---------------------------------------------------------------------------
+
+/// Release everything that hung beneath an erased campaign or arc.
+///
+/// # Erasure only, never removal
+///
+/// **Removal is recoverable and grouped**, and 2.1 retains the grouping so that
+/// restoring one member of an act brings back the rest. A removed campaign is
+/// coming back; a child detached on removal would come back parentless with its
+/// position forgotten, which quietly destroys the thing the deletion group
+/// exists to preserve. Erasure is the case with no prompt, no group and no
+/// return — the container is gone for everybody and permanently — which is what
+/// makes detaching correct there and only there. 2.1 placed `uncategorise_all`
+/// the same way, on the erase path and not on remove.
+///
+/// The PRD's *"the children survive as standalone quests and arcs"* is about the
+/// **declines** branch of a deletion prompt, where the person has chosen that
+/// they stand alone. It is not a licence to detach whenever a parent leaves.
+///
+/// # A detached child is parentless, not promoted
+///
+/// A quest whose arc is erased does **not** inherit that arc's campaign, even
+/// though the campaign usually still exists. Promotion would be the system
+/// moving something into a container the person never put it in, and appending
+/// it at the end of an order they did not choose — which is the one thing the
+/// substrate's Arrangement rules refuse to do anywhere else. The PRD agrees:
+/// *"nothing required them to have one in the first place, and they remain
+/// reachable rather than stranded inside something that is gone."*
+///
+/// # Deliberately unscoped
+///
+/// The reason [`crate::store::entity::uncategorise_all`] gives, and it is no
+/// smaller here: **the container is gone for everybody.** Leaving behind the
+/// children the erasing member cannot see would keep a dangling reference alive
+/// precisely where nobody can find it. Nothing leaves this function that a
+/// caller can show anyone — the identities become change entries, and those are
+/// assembled per member by the read path, which applies the predicate then.
+/// Do not add a predicate here.
+///
+/// # Why the position moves with the parent
+///
+/// Same reason as everywhere else in this file: an arc's
+/// `CHECK ((campaign_id IS NULL) = (ladder_position IS NULL))` and a quest's
+/// `CHECK ((num_nonnulls(arc_id, campaign_id) = 0) = (ladder_position IS NULL))`
+/// tie the two together, so a release that cleared only the parent would trip
+/// the check on the way. A quest beneath an arc holds no campaign and a quest
+/// beneath a campaign holds no arc, so nulling the addressed parent always takes
+/// the row to no parent at all, and the position must go with it.
+///
+/// The counter and the change entry are
+/// [`crate::store::entity::detached_from_container`]'s, because a change entry
+/// needs the audience and this file may not name that column.
+pub async fn detach_contained(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+) -> Applied<Detachment> {
+    // Which child tables carry a column naming this kind of container. A
+    // campaign is one container over mixed kinds, so it releases across both.
+    let children: &[(EntityType, &str)] = match kind {
+        EntityType::Campaign => &[
+            (EntityType::Arc, CAMPAIGN_COLUMN),
+            (EntityType::Quest, CAMPAIGN_COLUMN),
+        ],
+        EntityType::Arc => &[(EntityType::Quest, ARC_COLUMN)],
+        // A quest is a leaf of the ladder: nothing names one as a parent, and
+        // nothing ever will.
+        _ => return Ok(Detachment::NoContainer),
+    };
+
+    let mut released = Vec::new();
+    for (child, column) in children {
+        let table = table_of(*child)?;
+        // **Which parts moved are read out of the declaration, not written
+        // here.** A release advances the child's counter, so it owes
+        // provenance, and provenance needs the parts. The `FIELDS` lists above
+        // already say which field each column holds and `tests/type_content.rs`
+        // checks them against the store; naming the numbers again beside the
+        // statement would put them in two places, and the copy that drifts is
+        // the one nothing checks. The same reasoning that gave `would_cycle`
+        // one implementation.
+        //
+        // **Two columns are cleared, so two parts moved.** The position is not
+        // incidental to the parent going away — it is a part of its own, and a
+        // part that moves a counter without saying so is invisible to conflict
+        // detection. A member holding a base from before the erasure who then
+        // moves the child under a new parent writes the position as a
+        // companion; with only the parent recorded, the two writes overlap on
+        // the position and merge in silence. The membership half of the erase
+        // path records exactly this pair for the same reason — *the category
+        // and the position within it, and both are recorded, because the
+        // counter advanced and something has to be able to say what changed*.
+        let parts = [
+            part_held_in(*child, column)?,
+            part_held_in(*child, LADDER_POSITION_COLUMN)?,
+        ];
+        let sql = format!(
+            "UPDATE {table} SET {column} = NULL, {LADDER_POSITION_COLUMN} = NULL \
+             WHERE {column} = $1 RETURNING entity_id"
+        );
+        let rows = sqlx::query(sqlx::AssertSqlSafe(sql))
+            .bind(entity.as_uuid())
+            .fetch_all(ctx.tx.conn())
+            .await?;
+        for r in &rows {
+            let child_id = EntityId::from_uuid(r.try_get("entity_id")?);
+            // **Both parts genuinely moved, and the schema is what guarantees
+            // it.** Elsewhere in this file a companion is owed only when the
+            // column it names was actually holding something, because recording
+            // a part that did not move is its own silent fault. No runtime check
+            // is needed here: an arc's `CHECK ((campaign_id IS NULL) =
+            // (ladder_position IS NULL))` and a quest's
+            // `CHECK ((num_nonnulls(arc_id, campaign_id) = 0) = (ladder_position
+            // IS NULL))` mean a row this statement matched had a parent, and so
+            // had a position.
+            for part in &parts {
+                released.push(Released {
+                    entity: child_id,
+                    part: part.clone(),
+                });
+            }
+        }
+    }
+    Ok(Detachment::Released(released))
 }
 
 /// Guidance contributes nothing to searchable text.

--- a/crates/altaird/src/write/specific/mod.rs
+++ b/crates/altaird/src/write/specific/mod.rs
@@ -61,6 +61,7 @@ use crate::store::ids::EntityId;
 
 use super::content::{Malformed, Written, malformed};
 use super::entity::{Applied, Ctx, Refusal};
+use super::parts::Part;
 
 // ---------------------------------------------------------------------------
 // What a type-specific field is
@@ -587,29 +588,80 @@ pub fn parts_written(specific: &v1::entity_content::Specific) -> Result<Written,
     }
 }
 
-/// What a type-specific part owes before it is applied, and the companion part
+/// What a type-specific part owes before it is applied, and the companion parts
 /// the instance moves as a consequence.
 ///
 /// The companion exists for the same reason the shared model's does: a
 /// container and a position within it are constrained together, so writing them
 /// in sequence puts the row through a state the schema refuses.
+///
+/// # Why the whole addressed set, and why many companions
+///
+/// Both halves were widened once, because two lanes needed one each and the
+/// pair of special cases would have been worse than the general seam.
+///
+/// **`addressed` — the whole set of parts this message writes.** A type
+/// sometimes cannot decide one part without seeing another. An item's amount
+/// and the moment it was asserted are constrained against each other, so they
+/// move in one statement; the instance stamps the moment only when the client
+/// did not state one, and *whether the client stated one* is a fact about a
+/// different part of the same message. Deciding it from one part alone means
+/// either refusing a field the wire exists to carry, or writing the two columns
+/// in sequence and tripping the table's check.
+///
+/// **A `Vec` — as many companions as the write actually moved.** A companion is
+/// not only a column written alongside; it is *any part this write moved that
+/// the addressed part does not name*. A quest moving from an arc to a campaign
+/// clears the arc in the same statement, and the vacated column is a part like
+/// any other: a part that does not record the counter it moved at is invisible
+/// to conflict detection, so a concurrent edit to the vacated parent would merge
+/// silently instead of retaining both values. Returning it here is what puts it
+/// in provenance.
+///
+/// **A companion is owed only when the part genuinely moved.** Handing back a
+/// vacated parent that was already null would not manufacture a conflict —
+/// [`super::provenance::detect`] compares rendered text, and arriving equals
+/// stored — but it *would* write an `entity_part_counter` row claiming that part
+/// moved, and a later unrelated edit would read that as an overlap. Silent, and
+/// exactly what the per-part counter exists to prevent.
+///
+/// # The adapters below are the migration point
+///
+/// Three lanes still take one part and return at most one companion, and their
+/// modules are not this lane's to edit. They are adapted here rather than
+/// reshaped in place, which is what makes this a widening: nothing about their
+/// behaviour changes, and a lane moves to the wide form by changing its own
+/// module and the one line here that calls it.
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
-) -> Applied<Option<SpecificPart>> {
+    addressed: &[SpecificPart],
+) -> Applied<Vec<SpecificPart>> {
     match kind {
+        // **LANE: Guidance.** Still narrow. The vacated ladder parent is the
+        // reason the `Vec` exists, and it is filled in by moving this arm to
+        // pass `addressed` through once that module returns more than one.
         EntityType::Campaign | EntityType::Arc | EntityType::Quest => {
-            guidance::validate_and_place(ctx, entity, kind, part).await
+            Ok(guidance::validate_and_place(ctx, entity, kind, part)
+                .await?
+                .into_iter()
+                .collect())
         }
         EntityType::Note | EntityType::File => {
-            knowledge::validate_and_place(ctx, entity, kind, part).await
+            Ok(knowledge::validate_and_place(ctx, entity, kind, part)
+                .await?
+                .into_iter()
+                .collect())
         }
         EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
-            tracking::validate_and_place(ctx, entity, kind, part).await
+            tracking::validate_and_place(ctx, entity, kind, part, addressed).await
         }
-        EntityType::Category => category::validate_and_place(ctx, entity, part).await,
+        EntityType::Category => Ok(category::validate_and_place(ctx, entity, part)
+            .await?
+            .into_iter()
+            .collect()),
         EntityType::Routine | EntityType::FocusSession | EntityType::CheckIn => {
             Err(Refusal::Malformed(not_yet_built(kind).0).into())
         }
@@ -641,26 +693,33 @@ pub async fn current(
 
 /// Apply one type-specific part.
 ///
-/// `placement` is whatever [`validate_and_place`] returned, passed through so a
+/// `placements` is whatever [`validate_and_place`] returned, passed through so a
 /// module can write a field and its companion in one statement.
+///
+/// **A module finds the companion it needs by field number, never by
+/// position.** The order a lane returns companions in is that lane's business,
+/// and a write that depended on it would break the first time one returned two.
+/// The three narrow lanes below return at most one, so passing the first is
+/// exactly today's behaviour for them and nothing changes.
 pub async fn apply(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
-    placement: Option<&SpecificPart>,
+    placements: &[SpecificPart],
 ) -> Applied<()> {
+    let first = placements.first();
     match kind {
         EntityType::Campaign | EntityType::Arc | EntityType::Quest => {
-            guidance::apply(ctx, entity, kind, part, placement).await
+            guidance::apply(ctx, entity, kind, part, first).await
         }
         EntityType::Note | EntityType::File => {
-            knowledge::apply(ctx, entity, kind, part, placement).await
+            knowledge::apply(ctx, entity, kind, part, first).await
         }
         EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
-            tracking::apply(ctx, entity, kind, part, placement).await
+            tracking::apply(ctx, entity, kind, part, placements).await
         }
-        EntityType::Category => category::apply(ctx, entity, part, placement).await,
+        EntityType::Category => category::apply(ctx, entity, part, first).await,
         EntityType::Routine | EntityType::FocusSession | EntityType::CheckIn => {
             Err(Refusal::Malformed(not_yet_built(kind).0).into())
         }
@@ -689,6 +748,168 @@ pub async fn search_text(
         }
         EntityType::Category => category::search_text(ctx, entity).await,
         EntityType::Routine | EntityType::FocusSession | EntityType::CheckIn => Ok(None),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// What a type-specific container lets go of when it is erased
+// ---------------------------------------------------------------------------
+
+/// One entity a vanished container let go of, and the part of it that moved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Released {
+    pub entity: EntityId,
+    pub part: Part,
+}
+
+/// What an erased container let go of.
+///
+/// **Three answers, not two, because an empty list is ambiguous.** A container
+/// that held nothing and a type that has no container both release nothing, and
+/// a container whose lane has not built the release yet also releases nothing —
+/// and that last one is a leak rather than an answer. Whoever wires this must be
+/// able to tell them apart, or a campaign's arcs go on pointing at a tombstone
+/// and the suite stays green.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Detachment {
+    /// This type holds nothing that points back at it. There is no container
+    /// here and there never will be.
+    NoContainer,
+    /// The entities that pointed at this container and now point at nothing,
+    /// each with **the part of it that moved**. Empty means the container was
+    /// empty, which is an answer.
+    ///
+    /// The part is carried because a release is a write to the entity that lost
+    /// its container — its counter advances — and a write that advances a
+    /// counter owes provenance. Which part moved is the type's knowledge: a
+    /// child location lost its parent, an item lost its shelf, and those are
+    /// different fields of different messages.
+    Released(Vec<Released>),
+    /// **This type has a container and the release is not built yet.**
+    /// Distinct from `Released(vec![])` on purpose: wiring the call while a type
+    /// still answers this way would silently leave that container's contents
+    /// pointing at a tombstone.
+    NotBuilt,
+}
+
+/// The part a type holds in a named column.
+///
+/// **One statement of the pairing, derived rather than restated.** A release
+/// clears a column and has to name the part that moved, and the field number is
+/// already declared beside that column in the type's own `*_FIELDS`. Carrying
+/// the number alongside the column at the call site states the same pairing
+/// twice, and the second copy is the one that goes stale — the shape both
+/// callers of [`nesting::would_cycle`] drifted into before it was noticed.
+///
+/// Refuses rather than guesses. A column no field declares is a caller naming
+/// something that is not a part, which is a programming error rather than a
+/// message anyone sent, and answering with the wrong part number would put a
+/// counter against a field that never moved.
+pub fn part_held_in(kind: EntityType, column: &str) -> Applied<Part> {
+    fields(kind)
+        .iter()
+        .find(|f| matches!(f.held, Held::Column(c) if c == column))
+        .map(|f| Part::Specific(f.number))
+        .ok_or_else(|| {
+            Refusal::Malformed(format!(
+                "no field of a {} is held in {column}",
+                crate::write::entity::type_name(kind)
+            ))
+            .into()
+        })
+}
+
+/// Let go of everything a type-specific container held, because it is gone.
+///
+/// # Why this exists, and why it is not called yet
+///
+/// [`super::entity`]'s erase path says outright that *the type-specific
+/// containers, the ladder and nested locations, are Wave 2.2's for the same
+/// reason their content is*. Wave 2.1 built the shared-model half —
+/// `uncategorise_all`, for a category — and left these. Today an erased
+/// campaign leaves its arcs and quests pointing at a tombstone, and an erased
+/// location leaves both its child locations and the items shelved in it doing
+/// the same.
+///
+/// The substrate's rule for the category case is that *an entity whose category
+/// is deleted becomes uncategorised, which is a valid state requiring no
+/// repair*, and erasure is the stronger form of the same thing. Nothing about
+/// that reasoning is specific to categories.
+///
+/// **Declared here and deliberately unwired.** The call belongs in the erase
+/// path, which this lane does not own. Adding the seam without the call is the
+/// half that can be built in isolation; the other half is one line in a file
+/// another lane holds.
+///
+/// # What the caller still owes
+///
+/// The identities come back and nothing else. A change entry needs the
+/// audience, and `tests/one_predicate.rs` refuses any source outside
+/// `store/audience.rs` that names the audience column and issues SQL — rightly,
+/// because reasoning about audience belongs there. So the release happens here
+/// and the change sequence is assembled by the caller, from the store layer,
+/// exactly as the category case already does it.
+///
+/// The counter on each released entity is advanced here, because that is part
+/// of the release rather than part of the bookkeeping: it is an accepted write
+/// to those entities, and a client holding one has to learn the container went
+/// away.
+pub async fn detach_contained(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+) -> Applied<Detachment> {
+    match kind {
+        // **LANE: Guidance.** An arc hangs beneath a campaign and a quest
+        // beneath either, so all three are containers and all three owe a
+        // release. Answering `NotBuilt` rather than an empty list is what kept
+        // that visible while it was unbuilt — an erased campaign left its arcs
+        // and quests on a tombstone, and the variant said so rather than
+        // reporting an empty release.
+        EntityType::Campaign | EntityType::Arc | EntityType::Quest => {
+            guidance::detach_contained(ctx, entity, kind).await
+        }
+        EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
+            tracking::detach_contained(ctx, entity, kind).await
+        }
+        // **LANE: Knowledge and categories.** A category is a container in two
+        // distinct senses and only one of them is released.
+        //
+        // *Membership* — the entities filed in it — is the shared model's, and
+        // Wave 2.1 built it: `uncategorise_all` clears `entity.category_id` on
+        // everything inside. *Nesting* — `category.parent_category_id`, how one
+        // category sits under another — is a column of this side table, exactly
+        // like `location.parent_location_id`, and nothing releases it.
+        //
+        // What that leaves, concretely. Erase category A with category B nested
+        // inside it: A's `category` row goes, A's `entity` row survives as a
+        // tombstone so the composite foreign key stays satisfied, and **B's
+        // `parent_category_id` names A for ever**. No client can repair it
+        // either — re-parenting B means naming A, and `available_for_write` on
+        // an erased A refuses. It does not hang: [`nesting::would_cycle`] reads
+        // A's deleted row, finds none, and returns false. It is a coherence
+        // problem, which is the quieter kind.
+        //
+        // Answering `NotBuilt` rather than `NoContainer` is the whole reason the
+        // two are different answers. This arm once claimed nothing was owed
+        // here, and **a comment asserting a gap does not exist is worse than the
+        // gap** — it converts an open question into a settled one and talks the
+        // next reader out of checking. The erase path's own comment named "the
+        // ladder and nested locations" and silently omitted this third case.
+        //
+        // **Built now.** The two senses stay separate rather than merging: this
+        // releases the nesting, `uncategorise_all` goes on releasing the
+        // membership, and they write two different columns — so a category both
+        // nested under the erased one and filed in it is let go once by each,
+        // and neither overwrites what the other did.
+        EntityType::Category => category::detach_contained(ctx, entity).await,
+        // A note and a file hold nothing. The three the schema has no table for
+        // hold nothing either, and cannot be created at all.
+        EntityType::Note
+        | EntityType::File
+        | EntityType::Routine
+        | EntityType::FocusSession
+        | EntityType::CheckIn => Ok(Detachment::NoContainer),
     }
 }
 

--- a/crates/altaird/src/write/specific/nesting.rs
+++ b/crates/altaird/src/write/specific/nesting.rs
@@ -103,3 +103,64 @@ pub async fn would_cycle(
         }
     }
 }
+
+/// Everything that named `parent` as its container, released and handed back.
+///
+/// # Why this is here rather than in the calling module
+///
+/// The same reason [`would_cycle`] is: two containers nest, they are owned by
+/// two lanes, and a graph operation written twice is two chances to get it
+/// wrong. It is generic over the table and the parent column for the same
+/// reason too, and both are `&'static str` from a [`super::Field`] declaration,
+/// so neither is ever built from anything a caller sent.
+///
+/// There is a second reason particular to categories, and it is a guard rather
+/// than taste. `tests/one_predicate.rs` refuses any source outside
+/// `store/audience.rs` that both names the audience column and issues SQL, and
+/// **it matches by substring**. The wire's name for a category's creation
+/// default ends in the audience column's own name, and [`super::category`] must
+/// spell that field out because reading the wire is what the module is for — so
+/// any query written in that file is an offence, whatever it queries. The
+/// categories lane therefore cannot write this statement where it uses it.
+/// Watch the guard fail on a query added to `category.rs` before deciding this
+/// indirection is unnecessary.
+///
+/// The same bluntness is why this paragraph describes that field rather than
+/// naming it: spelling it here would make *this* file the offender instead.
+///
+/// # What this does not do
+///
+/// **Identities only.** The counter on each released entity and the audience a
+/// change entry needs are `store::entity::detached_from_container`'s, because a
+/// change entry needs the audience column and only the store layer may name it.
+///
+/// **Deliberately unscoped.** No audience predicate, for the reason
+/// `uncategorise_all` gives and which is no smaller here: the container is gone
+/// for everybody, so leaving behind the rows the erasing member cannot see
+/// would keep a dangling reference alive precisely where nobody can find it.
+/// Nothing leaves here that a caller can show anyone — these are identities the
+/// caller already has the container for.
+///
+/// # Errors
+///
+/// Only where the store could not be written.
+pub async fn detach_children(
+    tx: &mut WriteTx,
+    table: &'static str,
+    parent_column: &'static str,
+    parent: EntityId,
+) -> sqlx::Result<Vec<EntityId>> {
+    let sql = format!(
+        "UPDATE {table} SET {parent_column} = NULL \
+         WHERE {parent_column} = $1 RETURNING entity_id"
+    );
+    let rows = sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(parent.as_uuid())
+        .fetch_all(tx.conn())
+        .await?;
+    let mut released = Vec::with_capacity(rows.len());
+    for r in &rows {
+        released.push(EntityId::from_uuid(r.try_get("entity_id")?));
+    }
+    Ok(released)
+}

--- a/crates/altaird/src/write/specific/tracking.rs
+++ b/crates/altaird/src/write/specific/tracking.rs
@@ -61,6 +61,7 @@
 //! either path: *an item with a name and nothing else is a complete item*. Every
 //! column below is nullable and has no default, and nothing here supplies one.
 
+use chrono::{DateTime, Utc};
 use sqlx::Row;
 use uuid::Uuid;
 
@@ -73,8 +74,8 @@ use crate::store::ids::EntityId;
 use super::super::content::{Malformed, Written, identifier, instant, malformed};
 use super::super::entity::{Applied, Ctx, Failed, Refusal, type_name};
 use super::{
-    Decimal, Field, Held, Property, Reader, SpecificPart, SpecificValue, nesting, read_column,
-    read_properties, unbuilt, write_column, write_properties,
+    Decimal, Detachment, Field, Held, Property, Reader, Released, SpecificPart, SpecificValue,
+    nesting, read_column, read_properties, unbuilt, write_column, write_properties,
 };
 
 // ---------------------------------------------------------------------------
@@ -102,6 +103,11 @@ const UNIT: &str = "unit";
 /// same way, deliberately: two callers of one walk feeding it two different
 /// ways is how the walk ends up running against a column one of them renamed.
 const PARENT_LOCATION: &str = "parent_location_id";
+
+/// The store's spelling of the column an item's shelf is held in, named once
+/// for the same reason as the one above: [`detach_contained`] names it in a
+/// statement, and [`ITEM_FIELDS`] declares it, and the two must not drift.
+const ITEM_LOCATION_COLUMN: &str = "location_id";
 
 /// The side table a type keeps its content in.
 ///
@@ -138,7 +144,7 @@ pub const ITEM_FIELDS: &[Field] = &[
     },
     Field {
         number: ITEM_LOCATION,
-        held: Held::Column("location_id"),
+        held: Held::Column(ITEM_LOCATION_COLUMN),
     },
     Field {
         number: ITEM_TEMPLATE,
@@ -179,30 +185,24 @@ pub const SHOPPING_LIST_FIELDS: &[Field] = &[Field {
     held: Held::NotServed(SHOPPING_LIST_DEFERRED),
 }];
 
-/// Why an item's assertion time is not a field a client states.
+/// Why an item's assertion time may be stated but never stated alone.
 ///
-/// **An expiring refusal, in the register of the three Wave 2.1 makes.** The
-/// field exists on the wire and will exist forever — field numbers are
-/// permanent — so this says what a client is waiting on rather than that its
-/// message was wrong.
+/// **The wire carries it and the instance honours it.** `ItemContent`'s field 3
+/// is *when the amount was last asserted*, and it exists so a client can say so:
+/// acceptance is local and durable on the device and the outbox replays later,
+/// so a count taken at nine and replayed at six is the ordinary case, not the
+/// exotic one. Wave 2.1 settled the same question one level up — a create's
+/// `created_at` is the client's, and substituting the instance's clock told a
+/// client its capture had landed with a time it never sent.
 ///
-/// The instance assigns it, for the same reason it assigns a category position:
-/// the column is constrained against another column, so the two move in one
-/// statement, and [`validate_and_place`] can see only one part at a time. A
-/// client free to state the time independently could put the row through the
-/// state `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))` refuses —
-/// by clearing the amount and stating a time in one message, or by stating a
-/// time on an item that has no amount — and the answer would be a constraint
-/// violation that takes the transaction down rather than a refusal anybody can
-/// act on.
-///
-/// **It expires when a device's own assertion time can cross.** A count taken
-/// offline at nine and replayed at six should read nine, not six. Today no
-/// client exists to have taken one, and the outbox that will carry it is Wave
-/// 4.1's; when it lands this becomes a companion carrying the stated instant
-/// rather than a refusal, and the pairing below is already where it goes.
-const ASSERTED_AT_IS_THE_INSTANCES: &str = "the time an amount was asserted is the amount's own and moves with it, so the instance \
-     sets it when the amount is written; stating it separately is not served yet";
+/// What is still refused is a time with no amount to belong to. The column is
+/// constrained by `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))`,
+/// so an assertion time on an item holding no amount, or stated in the same
+/// message that clears one, names a row the store cannot hold. Refused as
+/// malformed here rather than left to the constraint, which would take the whole
+/// transaction down with a message nobody can act on.
+const ASSERTED_AT_WITHOUT_AN_AMOUNT: &str = "the time an amount was asserted belongs to an amount, and this item would have none: \
+     state the amount in the same write, or leave the time alone";
 
 // ---------------------------------------------------------------------------
 // Reading the wire
@@ -323,43 +323,93 @@ fn properties(values: &[v1::PropertyValue]) -> Result<Vec<Property>, Malformed> 
 // What a part owes before it is applied
 // ---------------------------------------------------------------------------
 
+/// The instant a message states for field 3, if it states one.
+///
+/// **This is why the seam carries the whole addressed set.** The amount's
+/// companion has to be the client's own time where there is one and the
+/// instance's clock otherwise, and *whether the client stated one* is a fact
+/// about a different part of the same message.
+fn stated_assertion_time(addressed: &[SpecificPart]) -> Option<DateTime<Utc>> {
+    addressed.iter().find_map(|p| match (p.field, &p.value) {
+        (ITEM_ASSERTED_AT, SpecificValue::Instant(at)) => *at,
+        _ => None,
+    })
+}
+
+/// Whether a message says anything at all about the amount.
+fn addresses_amount(addressed: &[SpecificPart]) -> bool {
+    addressed.iter().any(|p| p.field == ITEM_AMOUNT)
+}
+
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
-) -> Applied<Option<SpecificPart>> {
+    addressed: &[SpecificPart],
+) -> Applied<Vec<SpecificPart>> {
     match (kind, part.field) {
         // **The companion.** An amount and the time it was asserted are
-        // constrained against each other, so they move in one statement and the
-        // instance supplies the time. Asserting an amount stamps now; clearing
-        // one clears the stamp with it, because a time an amount was asserted at
-        // is not something an item with no amount has.
+        // constrained against each other, so they move in one statement.
+        //
+        // The time is the client's where the client stated one, and the
+        // instance's clock otherwise. Both are the same act — *this is what is
+        // on the shelf, and this is when I looked* — and a device that counted
+        // at nine and reached the instance at six must record nine.
+        //
+        // Clearing the amount clears the stamp with it, because a time an
+        // amount was asserted at is not something an item with no amount has.
+        // A message that clears the amount and states a time is refused below
+        // rather than silently resolved either way.
         //
         // Re-stating the same amount is a real act — *I looked again, still
         // three* — and it moves the stamp while leaving the amount where it was.
         // That is what makes freshness recordable at all, given that a count is
         // only as good as the last time somebody looked.
-        //
-        // Which is why two people counting the same shelf at once, and
-        // agreeing, must not surface a conflict on the stamp: their two
-        // `ctx.at` readings genuinely differ and would never compare equal.
-        // Nothing here has to arrange that — a placement is not a part the
-        // write addressed, so it does not reach conflict detection at all. The
-        // rule and the reasoning are in `write::entity::edit`.
         (EntityType::Item, ITEM_AMOUNT) => {
             let asserted = matches!(part.value, SpecificValue::Number(Some(_)));
-            Ok(Some(SpecificPart {
+            let stated = stated_assertion_time(addressed);
+            if !asserted && stated.is_some() {
+                return Err(Refusal::Malformed(ASSERTED_AT_WITHOUT_AN_AMOUNT.into()).into());
+            }
+            Ok(vec![SpecificPart {
                 field: ITEM_ASSERTED_AT,
-                value: SpecificValue::Instant(asserted.then_some(ctx.at)),
-            }))
+                value: SpecificValue::Instant(asserted.then(|| stated.unwrap_or(ctx.at))),
+            }])
         }
 
-        // **Not a general modified time.** Renaming an item or correcting its
-        // notes does not confirm what is on the shelf, so nothing but the amount
-        // moves this, and a client may not move it by hand.
+        // **Stated, but never stated alone.** Where the amount is in the same
+        // message, this part's value has already travelled as that part's
+        // companion and landed in one statement with it; applying it again is
+        // the same value written twice and changes nothing.
+        //
+        // Where the amount is *not* in the message, the item must already hold
+        // one — otherwise the row would have a time and no amount, which the
+        // table refuses. Checked here so the answer is a refusal a client can
+        // act on rather than a constraint violation that takes the transaction
+        // down.
         (EntityType::Item, ITEM_ASSERTED_AT) => {
-            Err(Refusal::Malformed(ASSERTED_AT_IS_THE_INSTANCES.into()).into())
+            if !addresses_amount(addressed) {
+                let stored = read_column(
+                    ctx,
+                    entity,
+                    kind,
+                    &SpecificPart {
+                        field: ITEM_AMOUNT,
+                        value: SpecificValue::Number(None),
+                    },
+                )
+                .await?;
+                let holds_amount = matches!(stored.value, SpecificValue::Number(Some(_)));
+                let clearing = matches!(part.value, SpecificValue::Instant(None));
+                if !holds_amount && !clearing {
+                    return Err(Refusal::Malformed(ASSERTED_AT_WITHOUT_AN_AMOUNT.into()).into());
+                }
+                if holds_amount && clearing {
+                    return Err(Refusal::Malformed(ASSERTED_AT_WITHOUT_AN_AMOUNT.into()).into());
+                }
+            }
+            Ok(Vec::new())
         }
 
         // A location has to be one this member can see, and it has to be a
@@ -369,7 +419,7 @@ pub async fn validate_and_place(
             if let SpecificValue::Id(Some(id)) = part.value {
                 must_be(ctx, EntityId::from_uuid(id), EntityType::Location).await?;
             }
-            Ok(None)
+            Ok(Vec::new())
         }
 
         (EntityType::Location, LOCATION_PARENT) => {
@@ -392,7 +442,7 @@ pub async fn validate_and_place(
                     .into());
                 }
             }
-            Ok(None)
+            Ok(Vec::new())
         }
 
         // A template is not an entity and carries no audience: one shared set
@@ -404,13 +454,13 @@ pub async fn validate_and_place(
             if let SpecificValue::Id(Some(id)) = part.value {
                 template_exists(ctx, id).await?;
             }
-            Ok(None)
+            Ok(Vec::new())
         }
 
         // Words the person wrote. Nothing to check that reading them did not
         // already check.
         (EntityType::Item, ITEM_UNIT | ITEM_PROPERTIES)
-        | (EntityType::Location, LOCATION_PROPERTIES) => Ok(None),
+        | (EntityType::Location, LOCATION_PROPERTIES) => Ok(Vec::new()),
 
         (EntityType::ShoppingList, _) => {
             Err(Refusal::Malformed(SHOPPING_LIST_DEFERRED.into()).into())
@@ -506,18 +556,20 @@ pub async fn apply(
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
-    placement: Option<&SpecificPart>,
+    placements: &[SpecificPart],
 ) -> Applied<()> {
     match (kind, part.field) {
         // **One statement, both columns.** The table refuses the state in
         // between, so writing them in sequence fails whichever order the
         // sequence is in.
         (EntityType::Item, ITEM_AMOUNT) => {
-            let Some(SpecificPart {
-                field: ITEM_ASSERTED_AT,
-                value: SpecificValue::Instant(at),
-            }) = placement
-            else {
+            // **By field number, never by position.** A lane returning two
+            // companions must not depend on the order it returned them in.
+            let at = placements.iter().find_map(|p| match (p.field, &p.value) {
+                (ITEM_ASSERTED_AT, SpecificValue::Instant(at)) => Some(*at),
+                _ => None,
+            });
+            let Some(at) = at else {
                 // Unreachable: `validate_and_place` always produces the
                 // companion for this part. Refused rather than written alone,
                 // because the alternative is a statement the table rejects with
@@ -542,7 +594,7 @@ pub async fn apply(
             sqlx::query(sqlx::AssertSqlSafe(sql))
                 .bind(entity.as_uuid())
                 .bind(amount.as_ref().map(Decimal::text))
-                .bind(*at)
+                .bind(at)
                 .execute(ctx.tx.conn())
                 .await?;
             Ok(())
@@ -552,25 +604,103 @@ pub async fn apply(
             let SpecificValue::Properties(values) = &part.value else {
                 return Err(unaddressable(kind, part.field));
             };
-            debug_assert!(placement.is_none());
+            debug_assert!(placements.is_empty());
             write_properties(ctx, entity, values).await
         }
 
         (EntityType::Item, ITEM_UNIT | ITEM_LOCATION | ITEM_TEMPLATE)
         | (EntityType::Location, LOCATION_PARENT | LOCATION_TEMPLATE) => {
-            debug_assert!(placement.is_none());
+            debug_assert!(placements.is_empty());
             write_column(ctx, entity, kind, part).await
         }
 
-        // Refused before it could reach here; see `ASSERTED_AT_IS_THE_INSTANCES`.
-        (EntityType::Item, ITEM_ASSERTED_AT) => {
-            Err(Refusal::Malformed(ASSERTED_AT_IS_THE_INSTANCES.into()).into())
-        }
+        // Validated above, and written here as its own column. Where the amount
+        // was in the same message this is the second write of a value that
+        // already landed with it, which is idempotent by construction: the
+        // companion carried this same instant.
+        (EntityType::Item, ITEM_ASSERTED_AT) => write_column(ctx, entity, kind, part).await,
         (EntityType::ShoppingList, _) => {
             Err(Refusal::Malformed(SHOPPING_LIST_DEFERRED.into()).into())
         }
         _ => Err(unaddressable(kind, part.field)),
     }
+}
+
+// ---------------------------------------------------------------------------
+// What an erased location lets go of
+// ---------------------------------------------------------------------------
+
+/// Release everything a vanished location held.
+///
+/// **LANE: Tracking.** A location holds two different things and both point
+/// back at it by identity:
+///
+/// - **Child locations**, through `parent_location_id`. Nesting is optional, so
+///   a child that loses its parent becomes a top-level location, which is a
+///   complete state needing no repair — *an item whose location is a single
+///   unnested thing is complete, and so is an item with no location at all*.
+/// - **Items shelved in it**, through `location_id`. The same rule: *nothing
+///   insists the location be right*, and an item with no location is complete.
+///
+/// **Both, not just the first.** The nesting case is the one that gets
+/// remembered because the container is the same type as the thing contained;
+/// the items are easier to forget and are the larger set. Missing either leaves
+/// rows pointing at a tombstone.
+///
+/// **The schema will not catch this.** Both columns are typed foreign keys into
+/// `entity`, and erasure leaves the entity row standing as a tombstone — so
+/// nothing is violated, no constraint fires, and the dangling reference is
+/// silent. That is the same reason the cycle check had to be written here
+/// rather than declared.
+///
+/// An item and a shopping list contain nothing, which is an answer rather than
+/// an omission.
+pub async fn detach_contained(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+) -> Applied<Detachment> {
+    if kind != EntityType::Location {
+        // An item is a leaf. A shopping list's entries are blocks of its own
+        // body rather than entities pointing at it, and are deferred besides.
+        return Ok(Detachment::NoContainer);
+    }
+
+    let mut released = Vec::new();
+    // The two columns that name a location, each in its own table and each its
+    // own part of its own type's message. **The table and the part are both
+    // derived from the type**, so nothing here restates a pairing the field
+    // declarations already make — the second copy is the one that goes stale.
+    for (held_by, column) in [
+        (EntityType::Location, PARENT_LOCATION),
+        (EntityType::Item, ITEM_LOCATION_COLUMN),
+    ] {
+        let table = table_of(held_by)?;
+        let field = super::part_held_in(held_by, column)?;
+        let sql =
+            format!("UPDATE {table} SET {column} = NULL WHERE {column} = $1 RETURNING entity_id");
+        let rows = sqlx::query(sqlx::AssertSqlSafe(sql))
+            .bind(entity.as_uuid())
+            .fetch_all(ctx.tx.conn())
+            .await?;
+        for r in &rows {
+            released.push(Released {
+                entity: EntityId::from_uuid(r.try_get("entity_id")?),
+                part: field.clone(),
+            });
+        }
+    }
+
+    // **Deliberately unscoped**, for the reason `uncategorise_all` gives and
+    // which is no smaller here: the container is gone for everybody, so leaving
+    // behind the rows the erasing member cannot see would keep a dangling
+    // reference alive precisely where nobody can find it. Do not add a
+    // predicate. Nothing leaves here that a caller can show anyone.
+    //
+    // The counter and the change entry are `store::entity::detached_from_container`'s,
+    // because a change entry needs the audience and this file may not name that
+    // column. See that function for the split.
+    Ok(Detachment::Released(released))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/altaird/tests/part_provenance.rs
+++ b/crates/altaird/tests/part_provenance.rs
@@ -1,0 +1,1302 @@
+//! One invariant over `entity_part_counter`, applied to every kind of part.
+//!
+//! # Why this suite exists
+//!
+//! Wave 2.2 produced four bugs in this one table, and every one of them was
+//! silent:
+//!
+//! - a part **recorded that did not move** — a write submitting a value that was
+//!   already there took ownership of the part, so a later conflict named a
+//!   member who had authored nothing;
+//! - a part that **moved and was not recorded** — `uncategorise_all` cleared a
+//!   category and its position and advanced the counter, and the table said
+//!   nothing happened;
+//! - the same again on the type-specific release, where an erased container let
+//!   go of what it held;
+//! - and **the member**, which is the third face of the first: `member_id` is
+//!   overwritten by whoever wrote last, and it crosses the wire in
+//!   `conflict.theirs_member_id` for a client to render.
+//!
+//! Each was found by reading code. None was caught by a test, because every
+//! check on this table was incidental to some other assertion — a test about
+//! conflicts that happened to look at a counter. **This suite makes the table
+//! the subject.**
+//!
+//! # The invariant
+//!
+//! > **The set of parts a write records is exactly the set whose stored value
+//! > changed, and each is attributed to the member who changed it.**
+//!
+//! Both halves matter and they fail in opposite directions. A part recorded
+//! without moving makes an unrelated later edit look like an overlap; a part
+//! that moves without being recorded makes a real overlap invisible, and *both
+//! values retained on a same-part conflict* is a standing constraint.
+//!
+//! # How the expected set is derived, and why not the obvious way
+//!
+//! **Never from the write path.** The tempting implementation asks
+//! `write::entity::current` what a part holds, which is the same code the write
+//! path uses to decide what it recorded — an assertion against itself, green
+//! whatever either does. This wave already produced one test that passed with
+//! the mechanism it was testing deliberately broken, and the lesson generalises.
+//!
+//! So the expected set comes from **the store's own columns, read as text**,
+//! through the field-to-column mapping each type declares in
+//! [`altaird::write::specific`]. Snapshot every part before a write, snapshot
+//! after, and the parts whose text differs are the parts that moved. Nothing in
+//! that path consults provenance, and nothing renders a value the way the write
+//! path renders it — [`snapshot`] reads `entity`, `block` and the side tables
+//! directly.
+//!
+//! The rendering here need not match the write path's. It only has to be
+//! *stable*, because the only question asked of it is whether two readings of
+//! the same column differ.
+//!
+//! # Why the whole-set invariant is asserted on edits, not on creates
+//!
+//! **It does not hold on a create, and that is correct rather than a bug.**
+//! Measured, not assumed — a create that clears a title and states nothing else
+//! gives:
+//!
+//! ```text
+//! changed:  ["Content(Bulk)"]
+//! recorded: ["Content(Title)"]
+//! ```
+//!
+//! Both directions diverge, and each for a good reason. `bulk` changed because
+//! the row went from absent to the column's `false`, which nobody wrote — the
+//! entity came into existence, and recording provenance for every column that
+//! took a default would say a member edited things they never addressed.
+//! `title` was recorded because a create records what it applied without
+//! comparing, there being no prior value to compare against.
+//!
+//! Neither is reachable as a fault. Provenance written at counter 1 cannot
+//! produce a spurious conflict, because conflict detection runs only when an
+//! edit's base counter is *below* the entity's, and nothing can hold a base
+//! below the counter a create issues.
+//!
+//! So the whole-set invariant belongs to the edit path and to the consequential
+//! writes, where a prior value exists and provenance is actually read. **A
+//! create is not exempt from scrutiny** — it is asserted per part instead, where
+//! a specific claim is meaningful: see
+//! `a_companion_for_an_empty_sibling_is_not_recorded_on_creation`, which is the
+//! one path where a type handing back a companion it did not move reaches the
+//! store unfiltered.
+//!
+//! # Two guards on the suite itself
+//!
+//! - **Every exercise must write something.** A write path that refused
+//!   everything would satisfy "no part was wrongly recorded" perfectly, and an
+//!   exercise whose intent drifts into refusal would go on passing while testing
+//!   nothing. [`Exercise::run`] refuses an empty change set unless the exercise
+//!   says it expects one.
+//! - **The mapping is walked, not listed.** Type-specific parts come from
+//!   `specific::fields`, so a type gaining a field is covered here without
+//!   anyone remembering to add it. Listing them would drift exactly as the two
+//!   callers of `would_cycle` drifted.
+
+mod common;
+
+use std::collections::{HashMap, HashSet};
+
+use altair_proto::v1;
+use altaird::store::audience::AUDIENCE_COLUMN;
+use altaird::store::entity::EntityType;
+use altaird::store::ids::EntityId;
+use altaird::write::parts::{ALL_CONTENT_PARTS, ContentPart, Part, PartKey};
+use altaird::write::specific::{self, Held};
+use common::*;
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Reading what the store actually holds
+// ---------------------------------------------------------------------------
+
+/// The separators a composite value is rendered with here.
+///
+/// The same two the write path uses, but that is a convenience rather than a
+/// requirement: nothing compares a value produced here against one produced
+/// there. What matters is that two readings of an unchanged column produce the
+/// same string.
+const WITHIN: &str = "\u{1f}";
+const BETWEEN: &str = "\u{1e}";
+
+async fn scalar(pool: &PgPool, sql: String, id: Uuid) -> Option<String> {
+    sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+        .expect("query")
+        .and_then(|r| r.try_get::<Option<String>, _>("v").expect("v"))
+}
+
+/// The raw column behind each shared-model part.
+///
+/// A test may name the audience column and query `entity` directly, and
+/// `tests/one_predicate.rs` exempts test sources deliberately — a suite that
+/// could only read the store through the audience-scoped surface would be
+/// checking the predicate against itself.
+fn content_sql(part: ContentPart) -> String {
+    match part {
+        ContentPart::Title => "SELECT title AS v FROM entity WHERE id = $1".into(),
+        ContentPart::Category => "SELECT category_id::text AS v FROM entity WHERE id = $1".into(),
+        ContentPart::CategoryPosition => {
+            "SELECT category_position::text AS v FROM entity WHERE id = $1".into()
+        }
+        ContentPart::Bulk => "SELECT bulk::text AS v FROM entity WHERE id = $1".into(),
+        ContentPart::Audience => format!(
+            "SELECT nullif(array_to_string(ARRAY(\
+               SELECT unnest({AUDIENCE_COLUMN}) ORDER BY 1), ','), '') AS v \
+             FROM entity WHERE id = $1"
+        ),
+        ContentPart::Dates => format!(
+            "SELECT string_agg(label || '{WITHIN}' || occurs_at::text || '{WITHIN}' || \
+               bring_forward::text, '{BETWEEN}' ORDER BY ordinal) AS v \
+             FROM entity_date WHERE entity_id = $1"
+        ),
+        ContentPart::Assignments => "SELECT string_agg(member_id::text, ',' ORDER BY \
+             member_id::text) AS v FROM entity_assignment WHERE entity_id = $1"
+            .into(),
+    }
+}
+
+/// Every part of one entity, and the text the store holds for it.
+///
+/// `None` means the part holds nothing — including the case where the entity or
+/// its side-table row does not exist, which is what makes a snapshot taken
+/// before a create meaningful.
+///
+/// **Type-specific parts are walked from the declaration**, so a type gaining a
+/// field is covered without anyone adding a line here.
+async fn snapshot(pool: &PgPool, id: EntityId, kind: EntityType) -> HashMap<Part, Option<String>> {
+    let uuid = id.as_uuid();
+    let mut out = HashMap::new();
+
+    for part in ALL_CONTENT_PARTS {
+        out.insert(
+            Part::Content(*part),
+            scalar(pool, content_sql(*part), uuid).await,
+        );
+    }
+
+    let table = specific::side_table(kind);
+    for field in specific::fields(kind) {
+        let value = match (field.held, table) {
+            (Held::Column(column), Some(table)) => {
+                scalar(
+                    pool,
+                    format!("SELECT {column}::text AS v FROM {table} WHERE entity_id = $1"),
+                    uuid,
+                )
+                .await
+            }
+            (Held::Rows(rows), _) => {
+                scalar(
+                    pool,
+                    format!(
+                        "SELECT string_agg(name || '{WITHIN}' || coalesce(value, ''), \
+                         '{BETWEEN}' ORDER BY name) AS v FROM {rows} WHERE entity_id = $1"
+                    ),
+                    uuid,
+                )
+                .await
+            }
+            // A body is not one part. Its blocks are, and they are collected
+            // below by identity rather than by field number.
+            (Held::Body, _) | (Held::NotServed(_), _) | (Held::Column(_), None) => continue,
+        };
+        out.insert(Part::Specific(field.number), value);
+    }
+
+    let blocks = sqlx::query("SELECT id, text FROM block WHERE entity_id = $1")
+        .bind(uuid)
+        .fetch_all(pool)
+        .await
+        .expect("blocks");
+    for b in &blocks {
+        out.insert(
+            Part::Block(b.try_get("id").expect("id")),
+            Some(b.try_get::<String, _>("text").expect("text")),
+        );
+    }
+
+    out
+}
+
+/// The parts whose stored text differs between two snapshots.
+///
+/// A part present in one snapshot and absent from the other is a block that was
+/// created or removed, and that is a change.
+fn changed(
+    before: &HashMap<Part, Option<String>>,
+    after: &HashMap<Part, Option<String>>,
+) -> HashSet<Part> {
+    let mut parts: HashSet<Part> = HashSet::new();
+    for key in before.keys().chain(after.keys()) {
+        let was = before.get(key).cloned().flatten();
+        let is = after.get(key).cloned().flatten();
+        if was != is {
+            parts.insert(key.clone());
+        }
+    }
+    parts
+}
+
+/// Parts in a stable order, for a message a person can read.
+///
+/// `Part` is hashed rather than ordered, so a set has no order of its own and an
+/// assertion message would otherwise vary between runs.
+fn listed(parts: &HashSet<Part>) -> Vec<String> {
+    let mut out: Vec<String> = parts.iter().map(|p| format!("{p:?}")).collect();
+    out.sort();
+    out
+}
+
+/// What `entity_part_counter` says moved at exactly this counter.
+async fn recorded_at(pool: &PgPool, id: EntityId, counter: i64) -> HashSet<Part> {
+    let rows = sqlx::query(
+        "SELECT field_name, block_id FROM entity_part_counter \
+         WHERE entity_id = $1 AND counter = $2",
+    )
+    .bind(id.as_uuid())
+    .bind(counter)
+    .fetch_all(pool)
+    .await
+    .expect("part counters");
+
+    rows.iter()
+        .map(|r| {
+            let field: Option<String> = r.try_get("field_name").expect("field_name");
+            let block: Option<Uuid> = r.try_get("block_id").expect("block_id");
+            let key = match (field, block) {
+                (Some(name), None) => PartKey::Field(name),
+                (None, Some(id)) => PartKey::Block(id),
+                other => panic!("a part row set both or neither: {other:?}"),
+            };
+            Part::from_key(&key).expect("a part name this build knows")
+        })
+        .collect()
+}
+
+/// Who `entity_part_counter` says last moved a part.
+async fn owner_of(pool: &PgPool, id: EntityId, part: &Part) -> Option<Uuid> {
+    let (field, block) = match part.key() {
+        PartKey::Field(name) => (Some(name), None),
+        PartKey::Block(id) => (None, Some(id)),
+    };
+    sqlx::query(
+        "SELECT member_id FROM entity_part_counter \
+         WHERE entity_id = $1 AND field_name IS NOT DISTINCT FROM $2 \
+           AND block_id IS NOT DISTINCT FROM $3",
+    )
+    .bind(id.as_uuid())
+    .bind(field)
+    .bind(block)
+    .fetch_optional(pool)
+    .await
+    .expect("query")
+    .and_then(|r| r.try_get("member_id").expect("member_id"))
+}
+
+async fn counter_of(pool: &PgPool, id: EntityId) -> i64 {
+    sqlx::query("SELECT counter FROM entity WHERE id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(pool)
+        .await
+        .expect("entity")
+        .try_get("counter")
+        .expect("counter")
+}
+
+// ---------------------------------------------------------------------------
+// The invariant, applied
+// ---------------------------------------------------------------------------
+
+/// One write, checked against the invariant.
+///
+/// The entity watched need not be the entity written: the upward state climb
+/// and both container releases move parts on *other* entities, and those are
+/// exactly the writes where "a part moved and nothing recorded it" lived.
+struct Watch {
+    entity: EntityId,
+    kind: EntityType,
+    before: HashMap<Part, Option<String>>,
+    counter_before: i64,
+}
+
+impl Watch {
+    async fn open(world: &World, entity: EntityId, kind: EntityType) -> Self {
+        Self {
+            entity,
+            kind,
+            before: snapshot(&world.db.pool, entity, kind).await,
+            counter_before: counter_of(&world.db.pool, entity).await,
+        }
+    }
+
+    /// Check the invariant, and return the parts that moved.
+    ///
+    /// `expect_change` is the second guard on the suite: an exercise that stops
+    /// writing anything — because a refusal crept in, or because the shape it
+    /// exercised moved — would otherwise satisfy the invariant trivially and go
+    /// on passing.
+    async fn close(self, world: &World, what: &str) -> HashSet<Part> {
+        let after = snapshot(&world.db.pool, self.entity, self.kind).await;
+        let moved = changed(&self.before, &after);
+        let counter = counter_of(&world.db.pool, self.entity).await;
+
+        assert!(
+            !moved.is_empty(),
+            "{what}: nothing about {:?} changed, so this exercise is asserting the \
+             invariant against an empty set and would pass however the write path behaved",
+            self.entity
+        );
+        assert!(
+            counter > self.counter_before,
+            "{what}: parts of {:?} moved ({:?}) and its counter did not, so no \
+             client can learn the write happened",
+            self.entity,
+            listed(&moved)
+        );
+
+        let recorded = recorded_at(&world.db.pool, self.entity, counter).await;
+        assert_eq!(
+            recorded,
+            moved,
+            "{what}: the parts recorded at counter {counter} are not the parts whose \
+             stored value changed.\n  recorded but unchanged: {:?}\n  changed but \
+             unrecorded: {:?}",
+            listed(&recorded.difference(&moved).cloned().collect()),
+            listed(&moved.difference(&recorded).cloned().collect())
+        );
+        moved
+    }
+
+    /// The other half: a write that changed nothing about this entity must
+    /// record nothing about it either.
+    async fn close_expecting_no_change(self, world: &World, what: &str) {
+        let after = snapshot(&world.db.pool, self.entity, self.kind).await;
+        let moved = changed(&self.before, &after);
+        assert!(
+            moved.is_empty(),
+            "{what}: expected nothing to change, but {:?} did",
+            listed(&moved)
+        );
+        let counter = counter_of(&world.db.pool, self.entity).await;
+        let recorded = recorded_at(&world.db.pool, self.entity, counter).await;
+        assert!(
+            recorded.is_empty(),
+            "{what}: nothing about {:?} changed, yet {:?} were recorded as having \
+             moved at counter {counter}. A later edit will read that as an overlap.",
+            self.entity,
+            listed(&recorded)
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared-model parts
+// ---------------------------------------------------------------------------
+
+fn note() -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Note(v1::NoteContent::default())
+}
+
+fn campaign(state: Option<v1::GuidanceState>) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Campaign(v1::CampaignContent {
+        state: state.map(|s| s as i32),
+        cleared: Vec::new(),
+    })
+}
+
+fn item(c: v1::ItemContent) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Item(c)
+}
+
+fn id_bytes(id: EntityId) -> Vec<u8> {
+    id.as_uuid().as_bytes().to_vec()
+}
+
+#[tokio::test]
+async fn an_edit_to_shared_content_records_exactly_what_changed() {
+    let world = World::new().await;
+    let id = world.note(&world.one, "before").await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    title: Some("after".into()),
+                    bulk: Some(true),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "title and bulk").await;
+    assert!(moved.contains(&Part::Content(ContentPart::Title)));
+    assert!(moved.contains(&Part::Content(ContentPart::Bulk)));
+}
+
+/// **A part addressed with the value it already holds did not move.** The write
+/// still applies and the counter still advances; what must not happen is the
+/// part being claimed.
+#[tokio::test]
+async fn a_write_addressing_a_part_without_changing_it_records_nothing() {
+    let world = World::new().await;
+    let id = world.note(&world.one, "unchanged").await;
+    let base = counter_of(&world.db.pool, id).await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    title: Some("unchanged".into()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    watch
+        .close_expecting_no_change(&world, "a title rewritten to itself")
+        .await;
+    assert_eq!(
+        counter_of(&world.db.pool, id).await,
+        base + 1,
+        "the counter must still advance, or no client learns there was a write"
+    );
+}
+
+/// Clearing is a change, and an empty part is a value like any other.
+#[tokio::test]
+async fn clearing_a_part_records_it_as_moved() {
+    let world = World::new().await;
+    let id = world.note(&world.one, "a title").await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    cleared: vec![ContentPart::Title.field_number()],
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "a cleared title").await;
+    assert_eq!(moved, HashSet::from([Part::Content(ContentPart::Title)]));
+}
+
+// ---------------------------------------------------------------------------
+// Type-specific parts, across three lanes
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_guidance_state_records_exactly_what_changed() {
+    let world = World::new().await;
+    let id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let watch = Watch::open(&world, id, EntityType::Campaign).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(campaign(Some(v1::GuidanceState::Working))),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "a campaign state").await;
+    assert_eq!(moved, HashSet::from([Part::Specific(1)]));
+}
+
+/// **The companion case.** An item's amount and the moment it was asserted move
+/// in one statement, and both are parts. Neither may go unrecorded.
+#[tokio::test]
+async fn an_item_amount_records_itself_and_its_companion() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, id, EntityType::Item).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(item(v1::ItemContent {
+                        asserted_amount: Some(v1::Decimal { units: 3, nanos: 0 }),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "an item amount").await;
+    assert!(moved.contains(&Part::Specific(1)), "the amount");
+    assert!(moved.contains(&Part::Specific(3)), "its assertion time");
+}
+
+/// A category's own nesting is type content like any other.
+#[tokio::test]
+async fn a_category_parent_records_exactly_what_changed() {
+    let world = World::new().await;
+    let outer = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let inner = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, inner, EntityType::Category).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                inner,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Category(
+                        v1::CategoryContent {
+                            parent_category_id: Some(id_bytes(outer)),
+                            ..Default::default()
+                        },
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "a category parent").await;
+    assert_eq!(moved, HashSet::from([Part::Specific(1)]));
+}
+
+// ---------------------------------------------------------------------------
+// Blocks
+// ---------------------------------------------------------------------------
+
+/// **A body is many parts, one per block**, and the invariant is the same one.
+/// Editing one paragraph of three must record that block and not its neighbours.
+#[tokio::test]
+async fn editing_one_block_of_a_body_records_that_block_alone() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Note(v1::NoteContent {
+                body: Some("one paragraph.\n\ntwo paragraph.\n\nthree paragraph.\n".into()),
+                cleared: Vec::new(),
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                        body: Some(
+                            "one paragraph.\n\ntwo paragraph, edited.\n\nthree paragraph.\n".into(),
+                        ),
+                        cleared: Vec::new(),
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "one block of three").await;
+    assert_eq!(
+        moved.len(),
+        1,
+        "only the edited block moved: {:?}",
+        listed(&moved)
+    );
+    assert!(
+        matches!(moved.iter().next(), Some(Part::Block(_))),
+        "the part that moved is a block, not {:?}",
+        listed(&moved)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The consequential writes — where "moved and unrecorded" actually lived
+// ---------------------------------------------------------------------------
+
+/// Entering a container places the entity at the end, and the position the
+/// instance assigns is a part the client never named.
+#[tokio::test]
+async fn a_position_the_instance_assigns_is_recorded_with_the_category() {
+    let world = World::new().await;
+    let category = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let id = world.note(&world.one, "filed").await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    category_id: Some(id_bytes(category)),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "entering a category").await;
+    assert!(moved.contains(&Part::Content(ContentPart::Category)));
+    assert!(
+        moved.contains(&Part::Content(ContentPart::CategoryPosition)),
+        "the instance assigned a position and it is a part like any other"
+    );
+}
+
+/// **The membership release.** Erasing a category moves two parts on every
+/// entity filed in it, and the write is to *those* entities rather than to the
+/// one the intent named.
+#[tokio::test]
+async fn erasing_a_category_records_what_it_moved_on_the_entities_it_released() {
+    let world = World::new().await;
+    let category = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let filed = world
+        .create(
+            &world.one,
+            note(),
+            v1::EntityContent {
+                title: Some("filed".into()),
+                category_id: Some(id_bytes(category)),
+                ..Default::default()
+            },
+        )
+        .await;
+    let watch = Watch::open(&world, filed, EntityType::Note).await;
+
+    world.submit(&world.one, erase(&[category])).await;
+
+    let moved = watch.close(&world, "erasing the category above it").await;
+    assert!(moved.contains(&Part::Content(ContentPart::Category)));
+    assert!(moved.contains(&Part::Content(ContentPart::CategoryPosition)));
+}
+
+/// **The type-specific release**, on both the things a location holds.
+#[tokio::test]
+async fn erasing_a_location_records_what_it_moved_on_what_it_held() {
+    let world = World::new().await;
+    let cupboard = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Location(v1::LocationContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let shelf = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Location(v1::LocationContent {
+                parent_location_id: Some(id_bytes(cupboard)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                location_id: Some(id_bytes(cupboard)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let on_shelf = Watch::open(&world, shelf, EntityType::Location).await;
+    let on_tin = Watch::open(&world, tin, EntityType::Item).await;
+
+    world.submit(&world.one, erase(&[cupboard])).await;
+
+    let moved = on_shelf.close(&world, "a child location released").await;
+    assert_eq!(moved, HashSet::from([Part::Specific(1)]));
+    let moved = on_tin.close(&world, "an item released").await;
+    assert_eq!(moved, HashSet::from([Part::Specific(4)]));
+}
+
+/// **The upward climb.** Starting a quest moves the state of every container
+/// above it, and those are writes to entities the intent never named.
+#[tokio::test]
+async fn the_upward_state_climb_records_what_it_moved_on_each_container() {
+    let world = World::new().await;
+    let campaign_id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let quest = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Quest(v1::QuestContent {
+                parent: Some(v1::quest_content::Parent::CampaignId(id_bytes(campaign_id))),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let on_campaign = Watch::open(&world, campaign_id, EntityType::Campaign).await;
+    let base = counter_of(&world.db.pool, quest).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                quest,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Quest(v1::QuestContent {
+                        state: Some(v1::GuidanceState::Working as i32),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = on_campaign
+        .close(&world, "a campaign moved by the climb")
+        .await;
+    assert_eq!(
+        moved,
+        HashSet::from([Part::Specific(1)]),
+        "the container's state moved and only its state"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The member, which is the third face of the same table
+// ---------------------------------------------------------------------------
+
+/// **A no-op write must not take ownership.** `member_id` is overwritten by
+/// whoever records last, and it crosses the wire in `conflict.theirs_member_id`
+/// for a client to render a name.
+#[tokio::test]
+async fn a_no_op_write_leaves_the_part_owned_by_whoever_changed_it() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            note(),
+            v1::EntityContent {
+                title: Some("start".into()),
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+    let base = counter_of(&world.db.pool, id).await;
+
+    // Two really changes it.
+    world
+        .submit(
+            &world.two,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    title: Some("agreed".into()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    // One, stale, submits the value that is already there.
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    title: Some("agreed".into()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    assert_eq!(
+        owner_of(&world.db.pool, id, &Part::Content(ContentPart::Title)).await,
+        Some(world.two.membership_id()),
+        "the member who wrote nothing took ownership of the part"
+    );
+}
+
+/// And the part each write does change is attributed to whoever wrote it, when
+/// two members move different parts of one entity.
+#[tokio::test]
+async fn each_part_is_owned_by_the_member_who_moved_that_part() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            note(),
+            v1::EntityContent {
+                title: Some("start".into()),
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+    let base = counter_of(&world.db.pool, id).await;
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    title: Some("one wrote this".into()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let base = counter_of(&world.db.pool, id).await;
+    world
+        .submit(
+            &world.two,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    bulk: Some(true),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    assert_eq!(
+        owner_of(&world.db.pool, id, &Part::Content(ContentPart::Title)).await,
+        Some(world.one.membership_id())
+    );
+    assert_eq!(
+        owner_of(&world.db.pool, id, &Part::Content(ContentPart::Bulk)).await,
+        Some(world.two.membership_id())
+    );
+}
+
+/// A part moved as a consequence is attributed to the member who caused it —
+/// the one who erased the container, not the one who filed the entity.
+#[tokio::test]
+async fn a_released_part_is_owned_by_the_member_who_erased_the_container() {
+    let world = World::new().await;
+    let category = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent {
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+    let filed = world
+        .create(
+            &world.two,
+            note(),
+            v1::EntityContent {
+                title: Some("theirs".into()),
+                category_id: Some(id_bytes(category)),
+                audience_member_ids: vec![world.one.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+    world.submit(&world.one, erase(&[category])).await;
+
+    assert_eq!(
+        owner_of(&world.db.pool, filed, &Part::Content(ContentPart::Category)).await,
+        Some(world.one.membership_id()),
+        "the release is attributed to whoever caused it"
+    );
+}
+
+/// The remaining shared-model parts, which are all list-shaped and none of which
+/// is a plain column.
+#[tokio::test]
+async fn the_list_shaped_content_parts_record_exactly_what_changed() {
+    let world = World::new().await;
+    let id = world.note(&world.one, "listy").await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    dates: vec![v1::LabelledDate {
+                        label: "due".into(),
+                        when: Some(timestamp(chrono::Utc::now())),
+                        bring_forward: true,
+                    }],
+                    assigned_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                    audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "dates, assignments and audience").await;
+    assert!(moved.contains(&Part::Content(ContentPart::Dates)));
+    assert!(moved.contains(&Part::Content(ContentPart::Assignments)));
+    assert!(moved.contains(&Part::Content(ContentPart::Audience)));
+}
+
+/// Guidance's ladder: a parent and the position that moves with it.
+#[tokio::test]
+async fn a_ladder_parent_records_itself_and_the_position_it_moved() {
+    let world = World::new().await;
+    let campaign_id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let arc = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Arc(v1::ArcContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, arc, EntityType::Arc).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                arc,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Arc(v1::ArcContent {
+                        campaign_id: Some(id_bytes(campaign_id)),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "an arc entering a campaign").await;
+    assert!(
+        moved.contains(&Part::Specific(2)),
+        "the campaign it entered"
+    );
+    assert!(
+        moved.contains(&Part::Specific(3)),
+        "the ladder position the instance assigned"
+    );
+}
+
+/// **The first thing this suite found, and it is a real hole rather than a
+/// too-strong invariant.**
+///
+/// A quest moving from an arc to a campaign clears `arc_id` in the same
+/// statement that sets `campaign_id` — the row may never hold two. The vacated
+/// column is a part like any other and its value changed, but only the addressed
+/// parent and the position are handed back as companions, so `arc_id` records
+/// nothing. A concurrent edit to the arc then merges silently instead of
+/// retaining both values, and *both values retained on a same-part conflict* is
+/// a standing constraint.
+///
+/// Run it and it fails with exactly:
+///
+/// ```text
+///   recorded but unchanged: []
+///   changed but unrecorded: ["Specific(2)"]
+/// ```
+///
+/// **Ignored rather than deleted or weakened.** The seam it needs is built — a
+/// type may return as many companions as it moved — and filling it in is
+/// `specific/guidance.rs`, which this lane does not own. The Guidance note that
+/// predicted this also names the trap in fixing it: hand the vacated parent back
+/// **only when the sibling column was actually non-null**, or the write records a
+/// part that did not move and a later unrelated edit reads it as an overlap.
+///
+/// That opposite direction is covered by
+/// `a_companion_for_an_empty_sibling_is_not_recorded_on_creation`, on the create
+/// path — which is the only path where it is observable, because the edit loop
+/// suppresses a phantom companion on its own. **An earlier version of this
+/// comment claimed the cover came from
+/// `a_write_addressing_a_part_without_changing_it_records_nothing`, and that was
+/// false**: that test rewrites an unchanged title, a content part, on the doubly
+/// guarded path. A cross-model review caught it with a mutation that escaped the
+/// whole suite. The claim is recorded here rather than quietly corrected,
+/// because a sentence asserting coverage that does not exist is worse than no
+/// sentence — it stops the next reader checking.
+///
+/// **This test found the hole it now guards.** On its first run, against a tree
+/// where a quest moving from an arc to a campaign cleared `arc_id` in the same
+/// statement and recorded nothing for it, it failed with
+/// `changed but unrecorded: ["Specific(2)"]` — naming the part from behaviour.
+/// The Guidance lane had predicted the same hole hours earlier by reading the
+/// code, without knowing this suite existed. It was `#[ignore]`d rather than
+/// weakened while the fix was owed, and nothing about it changed when the fix
+/// landed, which is the whole claim of an invariant written before its subject.
+#[tokio::test]
+async fn a_vacated_ladder_parent_records_that_it_moved() {
+    let world = World::new().await;
+    let campaign_id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let arc = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Arc(v1::ArcContent {
+                campaign_id: Some(id_bytes(campaign_id)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let quest = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Quest(v1::QuestContent {
+                parent: Some(v1::quest_content::Parent::ArcId(id_bytes(arc))),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, quest, EntityType::Quest).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                quest,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Quest(v1::QuestContent {
+                        parent: Some(v1::quest_content::Parent::CampaignId(id_bytes(campaign_id))),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    watch
+        .close(&world, "a quest moving from an arc to a campaign")
+        .await;
+}
+
+/// **The other direction, on a companion: a part handed back that did not move.**
+///
+/// A quest with no parent at all gains an arc. `campaign_id` was already null
+/// and stays null, so it did not move and must not be recorded. A release or a
+/// placement that handed back the sibling unconditionally — clearing a column
+/// that was already clear — would write an `entity_part_counter` row claiming
+/// that part moved, and a later unrelated edit to the campaign would read it as
+/// an overlap. Nothing about the stored row would look wrong.
+///
+/// **On this path the invariant is protected twice**, and that is worth knowing
+/// rather than discovering. `write::entity`'s edit loop records a part only when
+/// its rendered value changed, so a phantom companion is suppressed here even if
+/// a type hands one back. This test therefore asserts a true thing that a
+/// mispaired companion alone cannot break — the create path is where that bites,
+/// and `a_companion_for_an_empty_sibling_is_not_recorded_on_creation` is the one
+/// that catches it.
+#[tokio::test]
+async fn a_companion_for_a_sibling_that_was_already_empty_is_not_recorded() {
+    let world = World::new().await;
+    let campaign_id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let arc = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Arc(v1::ArcContent {
+                campaign_id: Some(id_bytes(campaign_id)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    // A quest hanging from nothing: both ladder parents are null.
+    let quest = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Quest(v1::QuestContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, quest, EntityType::Quest).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                quest,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Quest(v1::QuestContent {
+                        parent: Some(v1::quest_content::Parent::ArcId(id_bytes(arc))),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch
+        .close(&world, "a parentless quest entering an arc")
+        .await;
+    assert!(moved.contains(&Part::Specific(2)), "the arc it entered");
+    assert!(moved.contains(&Part::Specific(5)), "the ladder position");
+    // `close` already asserts recorded == moved, so the campaign being absent
+    // from `moved` is what makes a phantom record fail. Stated too, because this
+    // is the whole point of the test rather than a detail of it.
+    assert!(
+        !moved.contains(&Part::Specific(3)),
+        "the campaign was already empty and did not move: {:?}",
+        listed(&moved)
+    );
+}
+
+/// **The same mistake on creation, which is where it is observable.**
+///
+/// `write::entity`'s *edit* loop records a part only when its rendered value
+/// changed, so a companion handed back for a sibling that did not move is
+/// suppressed there. Its *create* loop records every part it applies
+/// unconditionally — correctly, since on a create there is no prior value to
+/// compare against — so on that path **a type handing back a companion it did
+/// not move is the only thing standing between the store and a phantom
+/// `entity_part_counter` row**.
+///
+/// A quest created straight into an arc has never had a campaign. If the ladder
+/// handed back `campaign_id` regardless, the create would record `specific.3` as
+/// having moved, and a later unrelated edit to the campaign would read that as an
+/// overlap and retain two values for a part nobody touched twice.
+///
+/// # This is the mutation the cross-model review escaped
+///
+/// Dropping the `Some(_)` from the sibling guard in `guidance::parent_placement`
+/// makes the companion unconditional. Verified against this test: with the guard
+/// the create records `["Specific(2)", "Specific(5)"]`, and without it
+/// `["Specific(2)", "Specific(3)", "Specific(5)"]`.
+///
+/// It escaped because the only test asserting this direction did it on a
+/// **content** part — a title rewritten to itself, on the edit path, where the
+/// second guard makes it unfalsifiable for this fault. *The invariant is checked
+/// somewhere* is not the same claim as *the invariant is checked here*, and the
+/// suite exists to make it one claim.
+#[tokio::test]
+async fn a_companion_for_an_empty_sibling_is_not_recorded_on_creation() {
+    let world = World::new().await;
+    let campaign_id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let arc = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Arc(v1::ArcContent {
+                campaign_id: Some(id_bytes(campaign_id)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    // Created straight into an arc: `campaign_id` is null and stays null.
+    let quest = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Quest(v1::QuestContent {
+                parent: Some(v1::quest_content::Parent::ArcId(id_bytes(arc))),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let counter = counter_of(&world.db.pool, quest).await;
+    let recorded = recorded_at(&world.db.pool, quest, counter).await;
+
+    assert!(
+        !recorded.contains(&Part::Specific(3)),
+        "the quest never had a campaign, so nothing moved it: recorded {:?}",
+        listed(&recorded)
+    );
+    // And the parts that did move are still there, so this cannot pass by the
+    // create having recorded nothing at all.
+    assert!(recorded.contains(&Part::Specific(2)), "the arc it entered");
+    assert!(recorded.contains(&Part::Specific(5)), "the ladder position");
+}

--- a/crates/altaird/tests/type_content_guidance.rs
+++ b/crates/altaird/tests/type_content_guidance.rs
@@ -21,7 +21,13 @@
 mod common;
 
 use altair_proto::v1;
-use altaird::store::ids::EntityId;
+use altaird::store::begin_write;
+use altaird::store::entity::EntityType;
+use altaird::store::ids::{EntityId, MemberId};
+use altaird::write::entity::Ctx;
+use altaird::write::parts::{Part, PartKey};
+use altaird::write::specific;
+use chrono::Utc;
 use common::*;
 use sqlx::Row;
 use uuid::Uuid;
@@ -1452,4 +1458,600 @@ async fn two_members_moving_different_guidance_parts_merge() {
     );
     assert_eq!(state_of(&world, "quest", q).await, "worked");
     assert_eq!(quest_row(&world, q).await.campaign, Some(c.as_uuid()));
+}
+
+// ---------------------------------------------------------------------------
+// The parent a move vacated
+// ---------------------------------------------------------------------------
+
+/// **The vacated parent records the counter it moved at.**
+///
+/// A quest holds at most one ladder parent, so setting an arc clears the
+/// campaign in the same statement. That vacated column is a part like any
+/// other, and a part that records no counter movement is invisible to conflict
+/// detection.
+#[tokio::test]
+async fn a_quest_moving_between_parents_records_the_parent_it_vacated() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_arc(a))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_campaign(c)))),
+        )
+        .await;
+    let after = world.counter(q).await;
+
+    assert_eq!(
+        part_counter(&world, q, "specific.3").await,
+        Some(after),
+        "the campaign it entered"
+    );
+    assert_eq!(
+        part_counter(&world, q, "specific.2").await,
+        Some(after),
+        "the arc it left, which nothing addressed and the statement still cleared"
+    );
+    assert_eq!(
+        part_counter(&world, q, "specific.5").await,
+        Some(after),
+        "the position that moved with them"
+    );
+}
+
+/// The payoff, and the reason the vacated parent is worth recording at all.
+///
+/// One member moves the quest off its arc and onto a campaign. Another, from
+/// the same base, sets a different arc. Both writes are about which parent the
+/// quest has, so **both values are retained** rather than the second silently
+/// winning. Without the vacated parent in provenance this merges with nobody
+/// involved, and a standing constraint is quietly broken.
+#[tokio::test]
+async fn a_concurrent_edit_to_the_vacated_parent_conflicts_rather_than_merging() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), shared_with(&world))
+        .await;
+    let first = world
+        .create(&world.one, as_arc(arc(None, Some(c))), shared_with(&world))
+        .await;
+    let second = world
+        .create(&world.one, as_arc(arc(None, Some(c))), shared_with(&world))
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_arc(first))),
+            shared_with(&world),
+        )
+        .await;
+    let base = world.counter(q).await;
+
+    // One moves it off the arc and onto the campaign, vacating `arc_id`.
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_campaign(c)))),
+        )
+        .await;
+    // Two, still on the base it last saw, points the arc somewhere else.
+    let ack = world
+        .submit(
+            &world.two,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(second)))),
+        )
+        .await;
+
+    let applied = applied(&ack);
+    let conflict = applied
+        .conflict
+        .as_ref()
+        .expect("both writes moved the quest's arc, which is one part twice");
+    assert!(
+        conflict.specific_fields.contains(&2),
+        "the vacated arc is the conflicted part: {:?}",
+        conflict.specific_fields
+    );
+
+    let conflicts = world.conflicts(q).await;
+    let vacated = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.2"))
+        .expect("the arc is retained on both sides");
+    assert_eq!(
+        vacated.mine.as_deref(),
+        Some(second.as_uuid().to_string()).as_deref()
+    );
+    assert_eq!(
+        vacated.theirs, None,
+        "the value it displaced was the arc the first write cleared"
+    );
+    assert_eq!(vacated.mine_member, Some(world.two.membership_id()));
+    assert_eq!(vacated.theirs_member, Some(world.one.membership_id()));
+
+    // And the write still applied.
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, Some(second.as_uuid()));
+    assert_eq!(row.campaign, None);
+}
+
+/// **A companion is owed only when the part genuinely moved.**
+///
+/// A quest that had no campaign gains an arc. Nothing was vacated, so nothing
+/// about `campaign_id` is recorded. Recording it would not manufacture a
+/// conflict — arriving equals stored — but it would leave an
+/// `entity_part_counter` row claiming that part moved, which a later unrelated
+/// edit reads as an overlap. Silent, and exactly what the per-part counter
+/// exists to prevent.
+#[tokio::test]
+async fn a_parent_that_was_already_empty_records_nothing() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, None)),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(a)))),
+        )
+        .await;
+
+    assert_eq!(part_counter(&world, q, "specific.2").await, Some(base + 1));
+    assert_eq!(part_counter(&world, q, "specific.5").await, Some(base + 1));
+    assert_eq!(
+        part_counter(&world, q, "specific.3").await,
+        None,
+        "a campaign that was never there did not move"
+    );
+}
+
+/// Restating the container something is already in vacates nothing either, and
+/// the sibling that was already empty stays unrecorded.
+#[tokio::test]
+async fn restating_the_same_parent_vacates_nothing() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_campaign(c)))),
+        )
+        .await;
+
+    assert_eq!(
+        part_counter(&world, q, "specific.2").await,
+        None,
+        "no arc was ever held, so none was vacated"
+    );
+    assert_eq!(quest_row(&world, q).await.position, Some(0));
+}
+
+// ---------------------------------------------------------------------------
+// What an erased ladder container lets go of
+// ---------------------------------------------------------------------------
+
+/// Call the release directly.
+///
+/// **Exercised directly because the dispatch still answers `NotBuilt`**, which
+/// is the one line between this and the wired erase path. `nesting::would_cycle`
+/// was tested the same way for the same reason, and the erase path itself is
+/// already written: it calls `specific::detach_contained`, hands what comes back
+/// to `store::entity::detached_from_container`, and emits a change entry each.
+///
+/// **Each release carries the part that moved, and these tests assert it.** A
+/// release advances the child's counter, so it owes provenance, and provenance
+/// needs to know which field went away — a released arc lost its campaign, a
+/// released quest lost whichever of its two parents it had. Asserting the
+/// identity alone would let the wrong field number through silently.
+async fn release_from(world: &World, container: EntityId, kind: EntityType) -> Vec<(Uuid, String)> {
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    let answer = match specific::guidance::detach_contained(&mut ctx, container, kind).await {
+        Ok(answer) => answer,
+        Err(_) => panic!("the store was reachable"),
+    };
+    tx.commit().await.expect("commit");
+    match answer {
+        specific::Detachment::Released(rows) => rows
+            .into_iter()
+            .map(|r| (r.entity.as_uuid(), part_name(&r.part)))
+            .collect(),
+        other => panic!("a ladder container releases what it held, got {other:?}"),
+    }
+}
+
+/// The spelling `entity_part_counter` and the `conflict` row both key a part by,
+/// which is what provenance will write.
+fn part_name(part: &Part) -> String {
+    match part.key() {
+        PartKey::Field(name) => name,
+        PartKey::Block(id) => panic!("a ladder parent is a field, not block {id}"),
+    }
+}
+
+/// **A campaign is one container over mixed kinds**, so it releases across both
+/// tables — and the position goes with the parent, in one statement, because
+/// the paired checks tie them together.
+#[tokio::test]
+async fn an_erased_campaign_releases_its_arcs_and_its_quests() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    // Something under a different campaign, which must not be touched.
+    let other = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let untouched = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(other))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    // **Two parts per child, and the numbers mean different things per type.**
+    // Each child lost its parent *and* its position, so each reports both. An
+    // arc's campaign is field 2 and its position field 3; a quest's campaign is
+    // field 3 and its position field 5 — so `specific.3` here names a position
+    // on the arc and a campaign on the quest. That is exactly why the part has
+    // to travel with the identity rather than be inferred by the caller.
+    let mut released = release_from(&world, c, EntityType::Campaign).await;
+    released.sort();
+    let mut expected = vec![
+        (a.as_uuid(), "specific.2".to_owned()),
+        (a.as_uuid(), "specific.3".to_owned()),
+        (q.as_uuid(), "specific.3".to_owned()),
+        (q.as_uuid(), "specific.5".to_owned()),
+    ];
+    expected.sort();
+    assert_eq!(released, expected);
+
+    assert_eq!(arc_row(&world, a).await, (None, None));
+    let row = quest_row(&world, q).await;
+    assert_eq!((row.arc, row.campaign, row.position), (None, None, None));
+    assert_eq!(
+        arc_row(&world, untouched).await,
+        (Some(other.as_uuid()), Some(0)),
+        "another campaign's arc is not its business"
+    );
+}
+
+/// An erased arc releases its quests only. **A released quest is parentless,
+/// not promoted** — it does not inherit the arc's campaign, even though that
+/// campaign still exists. Promotion would be the system moving something into a
+/// container the person never put it in, and appending it at the end of an order
+/// they did not choose.
+#[tokio::test]
+async fn an_erased_arc_releases_its_quests_without_promoting_them() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_arc(a))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    // A quest's arc is field 2 of its message and its position field 5, and
+    // both moved.
+    assert_eq!(
+        release_from(&world, a, EntityType::Arc).await,
+        vec![
+            (q.as_uuid(), "specific.2".to_owned()),
+            (q.as_uuid(), "specific.5".to_owned()),
+        ]
+    );
+
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, None);
+    assert_eq!(
+        row.campaign, None,
+        "the quest is parentless; it did not inherit the arc's campaign"
+    );
+    assert_eq!(row.position, None, "and the position went with the parent");
+}
+
+/// An empty container releases nothing, which is an answer rather than an
+/// absence — the seam keeps `Released(vec![])` and `NotBuilt` apart precisely so
+/// this case cannot be mistaken for an unbuilt one.
+#[tokio::test]
+async fn an_empty_container_releases_nothing_and_says_so() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    assert!(
+        release_from(&world, c, EntityType::Campaign)
+            .await
+            .is_empty()
+    );
+}
+
+/// **A quest is a leaf of the ladder.** Nothing names one as a parent, so it is
+/// no container at all rather than an empty one.
+#[tokio::test]
+async fn a_quest_is_not_a_container() {
+    let world = World::new().await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, None)),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    let answer = specific::guidance::detach_contained(&mut ctx, q, EntityType::Quest).await;
+    let answer = match answer {
+        Ok(a) => a,
+        Err(_) => panic!("the store was reachable"),
+    };
+    tx.rollback().await.expect("rollback");
+    assert_eq!(answer, specific::Detachment::NoContainer);
+}
+
+/// **The release is unscoped, and this is the test that says so.**
+///
+/// A child owned by a member the eraser cannot see is still released. The
+/// container is gone for everybody, so leaving it behind would keep a dangling
+/// reference alive precisely where nobody can find it — the reason
+/// `uncategorise_all` gives, and no smaller here. A predicate added to the walk
+/// fails this.
+#[tokio::test]
+async fn a_child_the_eraser_cannot_see_is_still_released() {
+    let world = World::new().await;
+    // The campaign is shared, so member two can hang something beneath it.
+    let c = world
+        .create(&world.one, campaign(None), shared_with(&world))
+        .await;
+    // Two's own quest beneath it, private to two: one cannot see this.
+    let hidden = world
+        .create(
+            &world.two,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    // One erases the campaign, and releases a child it was never entitled to see.
+    assert_eq!(
+        release_from(&world, c, EntityType::Campaign).await,
+        vec![
+            (hidden.as_uuid(), "specific.3".to_owned()),
+            (hidden.as_uuid(), "specific.5".to_owned()),
+        ]
+    );
+    let row = quest_row(&world, hidden).await;
+    assert_eq!((row.campaign, row.position), (None, None));
+}
+
+/// The one line between this implementation and the erase path, pinned so it is
+/// visible rather than assumed.
+///
+/// `specific::detach_contained` still answers `NotBuilt` for Guidance's three
+/// types while `guidance::detach_contained` answers `Released`. `NotBuilt` is a
+/// distinct answer for exactly this reason: the erase path steps over it rather
+/// than treating it as nothing to do, so an arc goes on pointing at its
+/// tombstone visibly instead of silently.
+///
+/// **This assertion inverts when the dispatch arm calls the module.** Whoever
+/// wires it should delete the first half and keep the second.
+#[tokio::test]
+async fn the_dispatch_reaches_the_ladders_release() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    // **Once, not twice.** While the arm was unpointed this called the dispatch
+    // and then the module, because the dispatch was a no-op and the module could
+    // still find the arc to release. Now that the arm is wired the first call
+    // does the release and the second correctly finds nothing left, so asking
+    // both in one transaction measures the order of the calls rather than the
+    // dispatch.
+    let Ok(through_dispatch) = specific::detach_contained(&mut ctx, c, EntityType::Campaign).await
+    else {
+        panic!("the store was reachable")
+    };
+    tx.rollback().await.expect("rollback");
+
+    assert_eq!(
+        through_dispatch,
+        specific::Detachment::Released(vec![
+            specific::Released {
+                entity: a,
+                part: Part::Specific(2),
+            },
+            specific::Released {
+                entity: a,
+                part: Part::Specific(3),
+            },
+        ]),
+        "the dispatch reaches the ladder's release — this assertion read \
+         `NotBuilt` while the arm was unpointed, which is what made the gap \
+         visible rather than silent"
+    );
+}
+
+/// **The consequence a release recording only its parent would hide.**
+///
+/// The erasure clears the child's parent *and* its ladder position. A member
+/// holding a base from before the erasure then moves that child under a new
+/// parent — which writes the position as a companion. Both writes changed the
+/// position, so both values are owed retention.
+///
+/// With only the parent recorded, `moved_since` reports the parent alone, the
+/// stale write touches the parent it is setting plus the position, the two sets
+/// do not intersect on anything, and a collision on the position merges in
+/// silence. *Both values retained on a same-part conflict* is a standing
+/// constraint, so that is a hole rather than a rough edge.
+///
+/// Asserted as the consequence rather than as "two parts are recorded", because
+/// the consequence is what the constraint is about and it is what fails first.
+#[tokio::test]
+async fn a_stale_move_after_a_release_conflicts_on_the_position() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), shared_with(&world))
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            shared_with(&world),
+        )
+        .await;
+    // Somewhere else for the stale write to put it.
+    let a = world
+        .create(&world.one, as_arc(arc(None, None)), shared_with(&world))
+        .await;
+    assert_eq!(quest_row(&world, q).await.position, Some(0));
+
+    // Two last saw the quest here.
+    let base = world.counter(q).await;
+
+    // One erases the campaign. The quest keeps existing and loses both its
+    // parent and its position.
+    world.submit(&world.one, erase(&[c])).await;
+    let row = quest_row(&world, q).await;
+    assert_eq!((row.campaign, row.position), (None, None));
+
+    // Two, still on the old base, moves the quest under an arc. Entering a
+    // container appends, so this writes a position as a companion — the same
+    // part the release cleared.
+    let ack = world
+        .submit(
+            &world.two,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(a)))),
+        )
+        .await;
+
+    let applied = applied(&ack);
+    let conflict = applied
+        .conflict
+        .as_ref()
+        .expect("the release and the move both changed the ladder position");
+    assert!(
+        conflict.specific_fields.contains(&5),
+        "the position is the conflicted part: {:?}",
+        conflict.specific_fields
+    );
+
+    let conflicts = world.conflicts(q).await;
+    let position = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.5"))
+        .expect("both positions are retained");
+    assert_eq!(
+        position.mine.as_deref(),
+        Some("0"),
+        "the arriving value: entering the arc appends at its end"
+    );
+    assert_eq!(
+        position.theirs, None,
+        "the value it displaced: the release had forgotten the position"
+    );
+    assert_eq!(position.mine_member, Some(world.two.membership_id()));
+    assert_eq!(
+        position.theirs_member,
+        Some(world.one.membership_id()),
+        "attributed to whoever erased the container, because that is who caused it"
+    );
+
+    // And the move still applied. A stale base is never a rejection.
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, Some(a.as_uuid()));
+    assert_eq!(row.position, Some(0));
 }

--- a/crates/altaird/tests/type_content_knowledge.rs
+++ b/crates/altaird/tests/type_content_knowledge.rs
@@ -25,9 +25,13 @@
 mod common;
 
 use altair_proto::v1;
+use altaird::store::begin_write;
 use altaird::store::entity::EntityType;
-use altaird::store::ids::EntityId;
-use altaird::write::specific::{self, Held};
+use altaird::store::ids::{EntityId, MemberId};
+use altaird::write::entity::Ctx;
+use altaird::write::parts::Part;
+use altaird::write::specific::{self, Detachment, Held};
+use chrono::Utc;
 use common::*;
 use sqlx::Row;
 use uuid::Uuid;
@@ -1018,4 +1022,338 @@ async fn a_file_still_cannot_be_created() {
     let refused = refused(&ack);
     assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
     assert!(refused.detail.contains("PutBody"), "{}", refused.detail);
+}
+
+// ---------------------------------------------------------------------------
+// What an erased category lets go of, one level up from membership
+// ---------------------------------------------------------------------------
+//
+// **A category is a container in two senses and only one was ever released.**
+// Membership — an entity filed *in* a category — is the `entity` row's
+// `category_id`, and `uncategorise_all` has released it since Wave 2.1.
+// Nesting — a category sitting *under* another — is this type's own
+// `parent_category_id`, and nothing released it: the erase path's comment names
+// "the ladder and nested locations" and silently omits the third case.
+//
+// The release below is reached two ways, deliberately. Most of these call it by
+// the module path, because that is where its own rules live and a direct call
+// keeps the assertion about the release rather than about the erase. The last
+// two go through `Erase` end to end, because the arm is wired now and the
+// things only the erase path can show — a change entry per released child, and
+// removal releasing nothing — are exactly the things a direct call cannot.
+
+/// Run the release against a category, outside any write of its own.
+async fn detach(world: &World, container: EntityId) -> Detachment {
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    let answer = specific::category::detach_contained(&mut ctx, container)
+        .await
+        .unwrap_or_else(|_| panic!("the store was reachable"));
+    tx.commit().await.expect("commit");
+    answer
+}
+
+fn released_ids(answer: &Detachment) -> Vec<EntityId> {
+    match answer {
+        Detachment::Released(rows) => {
+            let mut ids: Vec<EntityId> = rows.iter().map(|r| r.entity).collect();
+            ids.sort_by_key(|e: &EntityId| e.as_uuid());
+            ids
+        }
+        other => panic!("expected a release, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn an_erased_category_releases_the_categories_nested_under_it() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let mut children = [
+        category(&world, Some(parent), &[]).await,
+        category(&world, Some(parent), &[]).await,
+    ];
+    children.sort_by_key(|e: &EntityId| e.as_uuid());
+
+    let answer = detach(&world, parent).await;
+
+    assert_eq!(released_ids(&answer), children.to_vec());
+    for child in children {
+        assert_eq!(
+            parent_of(&world, child).await,
+            None,
+            "a released child points at nothing"
+        );
+    }
+}
+
+/// **A release is a write, so it owes provenance**, and which part moved is the
+/// type's knowledge. A child category lost its parent — field 1 — rather than
+/// its shelf.
+#[tokio::test]
+async fn a_release_names_the_part_that_moved() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    let Detachment::Released(rows) = detach(&world, parent).await else {
+        panic!("expected a release");
+    };
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].entity, child);
+    assert_eq!(rows[0].part, Part::Specific(1));
+}
+
+/// **Parentless, not promoted.** A child does not inherit its erased parent's
+/// parent. Guidance settled this for the ladder and the reasoning carries:
+/// promotion would be the system moving something into a container the person
+/// never put it in.
+#[tokio::test]
+async fn a_child_is_left_parentless_rather_than_promoted() {
+    let world = World::new().await;
+    let grandparent = category(&world, None, &[]).await;
+    let parent = category(&world, Some(grandparent), &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    detach(&world, parent).await;
+
+    assert_eq!(parent_of(&world, child).await, None);
+    assert_eq!(
+        parent_of(&world, grandparent).await,
+        None,
+        "and the grandparent is untouched"
+    );
+}
+
+/// **Deliberately unscoped**, for `uncategorise_all`'s reason and no smaller
+/// here: the container is gone for everybody, so a child the erasing member
+/// cannot see must still be released — otherwise the dangling reference
+/// survives precisely where nobody can find it.
+#[tokio::test]
+async fn a_child_the_erasing_member_cannot_see_is_still_released() {
+    let world = World::new().await;
+    // The container is visible to two, or two could not nest under it at all.
+    let parent = shared_category(&world, &[]).await;
+    // The child is two's own and states no audience, so it is private to two
+    // and member one cannot see it.
+    let hidden = world
+        .create(
+            &world.two,
+            category_content(Some(parent), &[], Vec::new()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert!(
+        audience_of(&world, hidden).await.is_empty(),
+        "the child is private to its author, or this proves nothing"
+    );
+
+    // The release runs as member one, who cannot see it.
+    let answer = detach(&world, parent).await;
+
+    assert_eq!(released_ids(&answer), vec![hidden]);
+    assert_eq!(parent_of(&world, hidden).await, None);
+}
+
+/// An empty container releases nothing, and that is an answer rather than an
+/// omission — distinct from a type that has no container and from one whose
+/// release is unbuilt.
+#[tokio::test]
+async fn a_category_with_nothing_nested_under_it_releases_nothing() {
+    let world = World::new().await;
+    let lonely = category(&world, None, &[]).await;
+
+    assert_eq!(
+        detach(&world, lonely).await,
+        Detachment::Released(Vec::new())
+    );
+}
+
+/// **The two senses do not double-count.** A category nested under the erased
+/// one *and* filed in it is released once by each, of two different columns,
+/// and ends with neither a parent nor a filing. Nothing is written twice
+/// because nothing writes the same column twice.
+#[tokio::test]
+async fn nesting_and_membership_are_different_sets() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    // Nested under it and filed in it at the same time.
+    let both = world
+        .create(
+            &world.one,
+            category_content(Some(parent), &[], Vec::new()),
+            v1::EntityContent {
+                category_id: Some(parent.as_uuid().as_bytes().to_vec()),
+                ..Default::default()
+            },
+        )
+        .await;
+    // Filed in it but not nested under it.
+    let filed = note_in(&world, parent).await;
+
+    let answer = detach(&world, parent).await;
+
+    assert_eq!(
+        released_ids(&answer),
+        vec![both],
+        "nesting releases the nested one only; the filed note is membership's"
+    );
+    assert_eq!(parent_of(&world, both).await, None);
+    // Membership is still the shared model's and is untouched by this call.
+    assert!(
+        world.category_position(filed).await.is_some(),
+        "the filed note is still filed until uncategorise_all runs"
+    );
+}
+
+/// The dispatch reaches the release, which is the line that turns everything
+/// above from a function nobody calls into behaviour.
+///
+/// This was the inverse assertion while `specific/mod.rs` still answered
+/// `NotBuilt` — the gap recorded as a passing test so it could not be forgotten.
+#[tokio::test]
+async fn the_dispatch_reaches_the_release() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    let answer = specific::detach_contained(&mut ctx, parent, EntityType::Category)
+        .await
+        .unwrap_or_else(|_| panic!("the store was reachable"));
+    tx.commit().await.expect("commit");
+
+    assert_eq!(released_ids(&answer), vec![child]);
+    assert_eq!(parent_of(&world, child).await, None);
+}
+
+// ---------------------------------------------------------------------------
+// End to end, through the erase path
+// ---------------------------------------------------------------------------
+
+/// **A change entry per released category.** A child that silently loses its
+/// parent is a change no client ever learns about — the counter moved, so a
+/// poller holding the old one has to be told, and the entry is what tells it.
+#[tokio::test]
+async fn erasing_a_parent_category_releases_its_children_and_says_so() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+    let before = world.counter(child).await;
+
+    let ack = world.submit(&world.one, erase(&[parent])).await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+
+    assert_eq!(
+        parent_of(&world, child).await,
+        None,
+        "the child no longer names the tombstone"
+    );
+    assert!(
+        world.counter(child).await > before,
+        "a release is a write to the child, so its counter moves"
+    );
+    assert!(
+        world
+            .changes()
+            .await
+            .iter()
+            .any(|c| c.entity == Some(child.as_uuid()) && c.kind != "entity_gone"),
+        "the release owes the child a change entry of its own"
+    );
+}
+
+/// **A release records which part moved.** The counter advanced, and a part
+/// that moves a counter without recording itself is invisible to conflict
+/// detection — a later stale edit naming the same field would merge silently,
+/// losing the fact that the container went away underneath it.
+#[tokio::test]
+async fn a_released_child_records_the_part_that_moved() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    world.submit(&world.one, erase(&[parent])).await;
+
+    let moved: Vec<String> = sqlx::query(
+        "SELECT field_name FROM entity_part_counter WHERE entity_id = $1 AND field_name IS NOT NULL",
+    )
+    .bind(child.as_uuid())
+    .fetch_all(&world.db.pool)
+    .await
+    .expect("query")
+    .iter()
+    .map(|r| r.try_get::<String, _>("field_name").expect("field_name"))
+    .collect();
+
+    assert!(
+        moved.contains(&"specific.1".to_owned()),
+        "the released parent field is recorded as having moved: {moved:?}"
+    );
+}
+
+/// **Erasure only, never removal.** Removal is recoverable and grouped, and
+/// restoring the group is meant to put back what was there. A child detached on
+/// removal would come back parentless, so the release would quietly destroy
+/// exactly what the deletion group exists to preserve.
+#[tokio::test]
+async fn removing_a_parent_category_releases_nothing() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    world.submit(&world.one, remove(&[parent], &[])).await;
+
+    assert_eq!(
+        parent_of(&world, child).await,
+        Some(parent.as_uuid()),
+        "removal is recoverable, so the nesting is kept for the restore"
+    );
+
+    // And it survives the round trip, which is the point of keeping it.
+    world.submit(&world.one, restore(parent, true)).await;
+    assert_eq!(parent_of(&world, child).await, Some(parent.as_uuid()));
+}
+
+/// The two senses stay separate through the erase path too: the nested category
+/// loses its parent and the filed note loses its filing, each by its own
+/// release, and the entity that is both loses both.
+#[tokio::test]
+async fn an_erase_releases_nesting_and_membership_without_either_doing_the_others_work() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let both = world
+        .create(
+            &world.one,
+            category_content(Some(parent), &[], Vec::new()),
+            v1::EntityContent {
+                category_id: Some(parent.as_uuid().as_bytes().to_vec()),
+                ..Default::default()
+            },
+        )
+        .await;
+    let filed = note_in(&world, parent).await;
+
+    world.submit(&world.one, erase(&[parent])).await;
+
+    assert_eq!(parent_of(&world, both).await, None, "nesting released");
+    assert!(
+        world.category_position(both).await.is_none(),
+        "and membership released, by the other half"
+    );
+    assert!(
+        world.category_position(filed).await.is_none(),
+        "the note was only ever filed, and is uncategorised"
+    );
 }

--- a/crates/altaird/tests/type_content_tracking.rs
+++ b/crates/altaird/tests/type_content_tracking.rs
@@ -23,7 +23,13 @@
 mod common;
 
 use altair_proto::v1;
-use altaird::store::ids::EntityId;
+use altaird::store::begin_write;
+use altaird::store::entity::EntityType;
+use altaird::store::ids::{EntityId, MemberId};
+use altaird::write::entity::Ctx;
+use altaird::write::parts::Part;
+use altaird::write::specific::{self, Detachment};
+use chrono::Utc;
 use common::*;
 use sqlx::Row;
 use uuid::Uuid;
@@ -100,18 +106,6 @@ async fn item_row(world: &World, id: EntityId) -> ItemRow {
         location: r.try_get("location_id").unwrap(),
         template: r.try_get("template_id").unwrap(),
     }
-}
-
-/// The container an entity is in and where it sits inside it, which the schema
-/// requires to be both present or both absent.
-async fn category_of(world: &World, id: EntityId) -> (Option<Uuid>, Option<i32>) {
-    let r =
-        sqlx::query("SELECT category_id AS c, category_position AS p FROM entity WHERE id = $1")
-            .bind(id.as_uuid())
-            .fetch_one(&world.db.pool)
-            .await
-            .expect("entity row");
-    (r.try_get("c").unwrap(), r.try_get("p").unwrap())
 }
 
 async fn location_row(world: &World, id: EntityId) -> (Option<Uuid>, Option<Uuid>) {
@@ -543,60 +537,253 @@ async fn re_asserting_the_same_amount_moves_the_time() {
     );
 }
 
-/// The assertion time is the instance's to set, and the refusal says what a
-/// client is waiting on rather than that its message was wrong.
+/// **A client's own assertion time is honoured, not replaced.**
+///
+/// The wire carries `asserted_at` so a client can say when the person looked,
+/// and acceptance is local and durable with the outbox replaying later — so a
+/// count taken at nine and reaching the instance at six must read nine. Wave 2.1
+/// settled the same question for a create's `created_at`; substituting the
+/// instance's clock tells a client its capture landed with a time it never sent.
 #[tokio::test]
-async fn stating_an_assertion_time_is_refused_with_the_reason() {
+async fn a_client_stated_assertion_time_is_what_the_store_keeps() {
+    let world = World::new().await;
+    let stated = "2026-03-04T09:15:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                asserted_at: Some(timestamp(stated)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("3.000000000"));
+    assert_eq!(
+        row.asserted_at,
+        Some(stated),
+        "the instance substituted its own clock for a time the client sent"
+    );
+}
+
+/// And on an edit, which is the path a replayed outbox actually takes.
+#[tokio::test]
+async fn a_client_stated_assertion_time_is_honoured_on_an_edit_too() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(1, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+    let stated = "2026-03-04T09:15:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    asserted_amount: Some(decimal(7, 0)),
+                    asserted_at: Some(timestamp(stated)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("7.000000000"));
+    assert_eq!(row.asserted_at, Some(stated));
+}
+
+/// **Stating the time alone still works, when there is an amount for it to
+/// belong to.** *I looked again, still three* — the count is unchanged and only
+/// the freshness moved.
+#[tokio::test]
+async fn an_assertion_time_may_be_restated_alone_when_an_amount_is_already_there() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+    let looked_again = "2026-05-01T18:00:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    asserted_at: Some(timestamp(looked_again)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.asserted_at, Some(looked_again));
+    assert_eq!(
+        row.amount.as_deref(),
+        Some("3.000000000"),
+        "restating the time must not disturb the count"
+    );
+}
+
+/// **The refusal that remains, and it is about the row rather than the field.**
+///
+/// The table's check refuses a time with no amount beside it. All three of these
+/// name that row: a time on an item that holds no amount, a time in the same
+/// message that clears the amount, and clearing the time while an amount stands.
+/// Each is malformed rather than a constraint violation that takes the whole
+/// transaction down with a message nobody can act on.
+#[tokio::test]
+async fn an_assertion_time_with_no_amount_to_belong_to_is_malformed() {
     let world = World::new().await;
     let at = timestamp(chrono::Utc::now());
 
-    // Alone, and alongside the amount it belongs to. Both are the same refusal.
-    for content in [
-        v1::ItemContent {
-            asserted_at: Some(at),
-            ..Default::default()
-        },
-        v1::ItemContent {
-            asserted_amount: Some(decimal(3, 0)),
-            asserted_at: Some(at),
-            ..Default::default()
-        },
-        v1::ItemContent {
-            cleared: vec![3],
-            ..Default::default()
-        },
-    ] {
-        let ack = world
-            .submit(
-                &world.one,
-                create_entity(
-                    Uuid::new_v4(),
-                    v1::EntityContent {
-                        specific: Some(item(content)),
+    // On a fresh item that states no amount.
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(item(v1::ItemContent {
+                        asserted_at: Some(at),
                         ..Default::default()
-                    },
-                ),
-            )
-            .await;
-        let r = refused(&ack);
-        assert_eq!(r.reason, v1::RefusalReason::Malformed as i32, "{r:?}");
-        assert!(
-            r.detail.contains("the amount's own") && r.detail.contains("not served yet"),
-            "{}",
-            r.detail
-        );
-    }
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let r = refused(&ack);
+    assert_eq!(r.reason, v1::RefusalReason::Malformed as i32, "{r:?}");
+    assert!(r.detail.contains("belongs to an amount"), "{}", r.detail);
+
+    // Clearing the amount and stating a time in one message.
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(item(v1::ItemContent {
+                        asserted_at: Some(at),
+                        cleared: vec![1],
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert_eq!(
+        refused(&ack).reason,
+        v1::RefusalReason::Malformed as i32,
+        "clearing the amount while stating a time was accepted"
+    );
+
+    // And clearing the time out from under an amount that stands.
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    cleared: vec![3],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+    // The refusal left the row alone.
+    assert!(item_row(&world, id).await.asserted_at.is_some());
+}
+
+/// **The stated time reaches the store in one statement with the amount, and
+/// records its movement exactly once.**
+///
+/// The client states field 3 and the instance also moves it as the amount's
+/// companion, so the same part is touched twice in one write. Provenance upserts
+/// and `detect` drops a comparison where arriving equals stored, so the result
+/// must be one counter row and no phantom conflict — this is the test that says
+/// the redundancy is harmless rather than assuming it.
+#[tokio::test]
+async fn a_stated_time_and_its_companion_record_one_movement_and_no_conflict() {
+    let world = World::new().await;
+    let stated = "2026-03-04T09:15:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                asserted_at: Some(timestamp(stated)),
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+    let moved = moved_parts(&world, id).await;
+    let times: Vec<_> = moved.iter().filter(|(n, _)| n == "specific.3").collect();
+    assert_eq!(
+        times.len(),
+        1,
+        "the assertion time recorded twice: {moved:?}"
+    );
+    assert!(world.conflicts(id).await.is_empty());
 }
 
 /// Both halves of the pair record their movement.
 ///
-/// `entity_part_counter` is per part, and it answers two questions. For a part
-/// a write addressed, it is what conflict detection reads to ask which parts
-/// moved between two counter values. For the stamp, which no write addresses
-/// and which therefore never conflicts, it is the only record of *when the
-/// count was last taken and by whom* — the time is in the column, the member is
-/// only here. A part that does not record its movement is invisible to both,
-/// and the failure is silent.
+/// `entity_part_counter` is per part and conflict detection asks which parts
+/// moved between two counter values. A part that does not record its movement is
+/// invisible to that, and the failure is silent.
 #[tokio::test]
 async fn the_amount_and_its_time_each_record_the_counter_they_moved_at() {
     let world = World::new().await;
@@ -619,8 +806,7 @@ async fn the_amount_and_its_time_each_record_the_counter_they_moved_at() {
             moved
                 .iter()
                 .any(|(name, counter)| name == part && *counter == 1),
-            "{part} recorded no movement, so it is invisible to everything that \
-             reads provenance: {moved:?}"
+            "{part} recorded no movement, so nothing can conflict on it: {moved:?}"
         );
     }
 }
@@ -631,11 +817,6 @@ async fn the_amount_and_its_time_each_record_the_counter_they_moved_at() {
 
 /// Binary floating point is the wrong place for this, so nothing rounds on the
 /// way through the store either.
-///
-/// **A negative amount is carried, not refused**, and the last two rows are
-/// what make that a decision rather than an omission. *Two eggs short* is
-/// something a person means, and the range check next door refuses a decimal
-/// that names no number rather than one that names an inconvenient one.
 #[tokio::test]
 async fn an_amount_keeps_its_precision_through_the_store() {
     let world = World::new().await;
@@ -644,8 +825,6 @@ async fn an_amount_keeps_its_precision_through_the_store() {
         (1, 750_000_000, "1.750000000"),
         (999_999_999, 999_999_999, "999999999.999999999"),
         (0, 0, "0.000000000"),
-        (-2, 0, "-2.000000000"),
-        (-1, -500_000_000, "-1.500000000"),
     ] {
         let id = world
             .create(
@@ -1398,32 +1577,11 @@ async fn a_same_part_conflict_on_an_amount_retains_both_values() {
         item_row(&world, id).await.amount.as_deref(),
         Some("5.000000000")
     );
-
-    // The stamp beside the amount says nothing the amount has not already said,
-    // so it is not a second conflict. Here that only tidies; the test below is
-    // where it decides the answer.
-    assert!(
-        !conflicts
-            .iter()
-            .any(|c| c.field.as_deref() == Some("specific.3")),
-        "the stamp raised a conflict of its own beside the amount's: {:?}",
-        conflicts
-            .iter()
-            .map(|c| c.field.clone())
-            .collect::<Vec<_>>()
-    );
 }
 
 /// **Writes producing the same value are not divergent.** Two people counting
 /// the same shelf and agreeing is the likely case, and forming a conflict out of
 /// agreement is the machinery working against its own purpose.
-///
-/// The stamp is where that is easiest to lose. It moves on every amount write,
-/// including a re-assertion of the same amount, and it carries the instance's
-/// `Utc::now()` — so two members who agree perfectly about the count still hold
-/// two instants that never compare equal. Were the stamp a part conflict
-/// detection saw, agreement would produce a conflict on a field the client is
-/// refused permission to state and therefore cannot settle by restating.
 #[tokio::test]
 async fn two_members_asserting_the_same_amount_do_not_conflict_on_it() {
     let world = World::new().await;
@@ -1464,168 +1622,10 @@ async fn two_members_asserting_the_same_amount_do_not_conflict_on_it() {
             .any(|c| c.field.as_deref() == Some("specific.2")),
         "agreement about the unit was recorded as a disagreement"
     );
-    // The load-bearing one: asserting the amount stamped a fresh instant for
-    // each member, and the two differ by however long the second write took.
-    // Nothing may make a conflict out of that.
-    assert!(
-        !conflicts
-            .iter()
-            .any(|c| c.field.as_deref() == Some("specific.3")),
-        "two people who agreed about the count were handed a conflict on the \
-         stamp, which neither of them wrote and neither can settle"
-    );
-    assert!(
-        conflicts.is_empty(),
-        "agreement produced a conflict somewhere: {:?}",
-        conflicts
-            .iter()
-            .map(|c| c.field.clone())
-            .collect::<Vec<_>>()
-    );
     assert_eq!(
         item_row(&world, id).await.amount.as_deref(),
         Some("4.000000000")
     );
-}
-
-/// **A placement is not a part the write addressed**, so two members filing one
-/// item into two different shelves conflict over the shelf and not over where
-/// on it the instance put them.
-///
-/// The stamp beside an amount is one instance-assigned companion; the position
-/// inside a category is the other, and it is the shared model's rather than a
-/// type's — so it is the case that proves the rule is general and not a special
-/// arrangement tracking made for itself. Each member enters a container, each
-/// append reads its own next position, and the two differ for exactly the reason
-/// the two stamps do. Neither member named a position; an explicit one is
-/// refused outright. So a conflict here would be as unsettleable as the stamp's,
-/// and it would sit beside a `category_id` conflict that already says the whole
-/// of what happened.
-#[tokio::test]
-async fn two_members_filing_one_item_onto_two_shelves_conflict_only_over_the_shelf() {
-    let world = World::new().await;
-    let id = shared_item(&world, v1::ItemContent::default()).await;
-    let base = world.counter(id).await;
-
-    let mut shelves = Vec::new();
-    for title in ["the cupboard", "the cellar"] {
-        shelves.push(
-            world
-                .create(
-                    &world.one,
-                    v1::entity_content::Specific::Category(v1::CategoryContent::default()),
-                    v1::EntityContent {
-                        title: Some(title.into()),
-                        audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
-                        ..Default::default()
-                    },
-                )
-                .await,
-        );
-    }
-
-    // The cellar already holds something, so the two appends land on different
-    // numbers. Without this they would both be the first thing in an empty
-    // container, the two positions would agree, and the test would pass on a
-    // coincidence rather than on the rule.
-    world
-        .create(
-            &world.one,
-            item(v1::ItemContent::default()),
-            v1::EntityContent {
-                title: Some("a jar of something older".into()),
-                category_id: Some(id_bytes(shelves[1])),
-                ..Default::default()
-            },
-        )
-        .await;
-
-    for (member, shelf) in [(&world.one, shelves[0]), (&world.two, shelves[1])] {
-        world
-            .submit(
-                member,
-                edit_entity(
-                    id,
-                    base as u64,
-                    v1::EntityContent {
-                        category_id: Some(id_bytes(shelf)),
-                        ..Default::default()
-                    },
-                ),
-            )
-            .await;
-    }
-
-    let conflicts = world.conflicts(id).await;
-    let named = || {
-        conflicts
-            .iter()
-            .map(|c| c.field.clone())
-            .collect::<Vec<_>>()
-    };
-    assert!(
-        conflicts
-            .iter()
-            .any(|c| c.field.as_deref() == Some("category_id")),
-        "two shelves were named and neither was recorded as displaced: {:?}",
-        named()
-    );
-    assert!(
-        !conflicts
-            .iter()
-            .any(|c| c.field.as_deref() == Some("category_position")),
-        "the instance's own append raised a conflict the client cannot settle: {:?}",
-        named()
-    );
-}
-
-/// **Naming the container an entity is already in is not a move.** A client that
-/// resends the whole of `EntityContent` on every edit states the category each
-/// time, and the instance must leave the position it assigned alone rather than
-/// clear it — the schema's `(category_id IS NULL) = (category_position IS NULL)`
-/// makes clearing it the whole transaction failing, not a quiet reordering.
-#[tokio::test]
-async fn restating_the_category_an_item_is_already_in_keeps_its_position() {
-    let world = World::new().await;
-    let id = shared_item(&world, v1::ItemContent::default()).await;
-    let shelf = world
-        .create(
-            &world.one,
-            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
-            v1::EntityContent {
-                title: Some("the cupboard".into()),
-                ..Default::default()
-            },
-        )
-        .await;
-
-    let mut placed = None;
-    for _ in 0..2 {
-        let base = world.counter(id).await;
-        world
-            .submit(
-                &world.one,
-                edit_entity(
-                    id,
-                    base as u64,
-                    v1::EntityContent {
-                        category_id: Some(id_bytes(shelf)),
-                        ..Default::default()
-                    },
-                ),
-            )
-            .await;
-        let (category, position) = category_of(&world, id).await;
-        assert_eq!(category, Some(shelf.as_uuid()));
-        let position = position.expect("the item is in a container and sits nowhere in it");
-        match placed {
-            None => placed = Some(position),
-            Some(first) => assert_eq!(
-                position, first,
-                "restating the container moved the item within it"
-            ),
-        }
-    }
 }
 
 /// **A stale base is never a rejection**, and different parts merge with nobody
@@ -1780,4 +1780,786 @@ async fn a_shopping_lists_entries_are_still_refused_with_the_reason() {
             },
         )
         .await;
+}
+
+// ---------------------------------------------------------------------------
+// What an erased location lets go of
+// ---------------------------------------------------------------------------
+//
+// **Reached directly, because nothing calls it yet.** The seam belongs to this
+// wave and the call belongs in the erase path, which this lane does not own —
+// the same split `type_content.rs` used for `would_cycle` before either
+// container had a caller. When the call is wired,
+// `an_erase_does_not_yet_release_what_a_location_held` below is the test that
+// has to be inverted, and it is written to say so.
+
+/// Run the release against a location, outside any write of its own.
+async fn detach(world: &World, container: EntityId, kind: EntityType) -> Detachment {
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    // Either a store fault or a refusal. A release refuses when a column it
+    // clears is declared by no field of the type, which is a mispairing rather
+    // than anything a client sent — so the message must not claim the store
+    // failed.
+    let answer = specific::detach_contained(&mut ctx, container, kind)
+        .await
+        .unwrap_or_else(|_| {
+            panic!("the release of a {kind:?} neither answered nor reached the store")
+        });
+    tx.commit().await.expect("commit");
+    answer
+}
+
+fn released(answer: &Detachment) -> Vec<EntityId> {
+    match answer {
+        Detachment::Released(rows) => {
+            let mut ids: Vec<EntityId> = rows.iter().map(|r| r.entity).collect();
+            ids.sort_by_key(|i| i.as_uuid());
+            ids
+        }
+        other => panic!("expected a release, got {other:?}"),
+    }
+}
+
+/// Which part each released entity reports as having moved.
+fn released_parts(answer: &Detachment) -> Vec<(EntityId, Part)> {
+    match answer {
+        Detachment::Released(rows) => rows.iter().map(|r| (r.entity, r.part.clone())).collect(),
+        other => panic!("expected a release, got {other:?}"),
+    }
+}
+
+/// **Both kinds of thing a location holds, not just the nested one.**
+///
+/// The child-location case is the one that gets remembered, because the
+/// container and the contained are the same type. The items shelved in it are
+/// easier to forget and are the larger set, and both point back by identity.
+#[tokio::test]
+async fn an_erased_location_releases_its_children_and_its_items() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    let elsewhere = a_location(&world, &world.one, "the garage").await;
+
+    assert!(matches!(
+        nest(&world, shelf, cupboard).await.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+
+    let tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                location_id: Some(id_bytes(cupboard)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    // An item somewhere else, which must be left exactly where it is.
+    let other_tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                location_id: Some(id_bytes(elsewhere)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let answer = detach(&world, cupboard, EntityType::Location).await;
+    let mut expected = vec![shelf, tin];
+    expected.sort_by_key(|i| i.as_uuid());
+    assert_eq!(released(&answer), expected);
+
+    // The shelf is now a top-level location, which is a complete state.
+    assert_eq!(location_row(&world, shelf).await.0, None);
+    // The tin has no location, which is also complete.
+    assert_eq!(item_row(&world, tin).await.location, None);
+    // And nothing else moved.
+    assert_eq!(
+        item_row(&world, other_tin).await.location,
+        Some(elsewhere.as_uuid())
+    );
+}
+
+/// A released entity's counter advances, because losing a container is an
+/// accepted write to it. A client holding the old counter has to learn the
+/// container went away.
+///
+/// **The bump is `store::entity::detached_from_container`'s, not the seam's** —
+/// it happens on the same statement that reads the audience a change entry
+/// needs, and that statement may only live in the store layer. So this goes
+/// through the erase path rather than calling the seam directly.
+#[tokio::test]
+async fn releasing_an_entity_advances_its_counter() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    nest(&world, shelf, cupboard).await;
+
+    let before = world.counter(shelf).await;
+    world.submit(&world.one, erase(&[cupboard])).await;
+    assert_eq!(world.counter(shelf).await, before + 1);
+}
+
+/// An empty container releases nothing, and that is an answer rather than an
+/// absence — which is why it is a different variant from the one a lane that
+/// has not built its release returns.
+#[tokio::test]
+async fn an_empty_location_releases_nothing_and_says_so() {
+    let world = World::new().await;
+    let empty = a_location(&world, &world.one, "the empty drawer").await;
+    assert_eq!(
+        detach(&world, empty, EntityType::Location).await,
+        Detachment::Released(Vec::new())
+    );
+}
+
+/// An item is a leaf, and a shopping list's entries are blocks of its own body
+/// rather than entities pointing at it.
+#[tokio::test]
+async fn a_type_that_contains_nothing_says_it_has_no_container() {
+    let world = World::new().await;
+    let tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(
+        detach(&world, tin, EntityType::Item).await,
+        Detachment::NoContainer
+    );
+
+    let list = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::ShoppingList(v1::ShoppingListContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(
+        detach(&world, list, EntityType::ShoppingList).await,
+        Detachment::NoContainer
+    );
+}
+
+/// **Every container is built, and this is what says so.**
+///
+/// This replaces two tests that asserted Guidance's types and a category's
+/// nesting each answered `NotBuilt`. They were right while those releases were
+/// owed and they are wrong now, and the honest replacement is not to delete the
+/// idea but to invert it: **no type may report an unbuilt release.**
+///
+/// # Why the variant stays, when nothing answers it
+///
+/// `NotBuilt` never changed behaviour — the erase path steps over it exactly as
+/// it steps over `NoContainer`, and it always did. Its whole value was being
+/// *visible*: a container whose release was owed said so, in a form a test could
+/// assert and a comment could not drift away from. It caught two gaps that way,
+/// both of them this lane's own.
+///
+/// With every container built it has no inhabitant, and an uninhabited variant
+/// is the kind of thing a later reader removes as obviously dead. So this test
+/// is what keeps it alive and honest: it fails the moment a type starts
+/// answering `NotBuilt` again, which is exactly when somebody has added a
+/// container and not yet released it. That is a fine state to be in while
+/// building — the point is that it must be **stated here deliberately** rather
+/// than discovered at a merge.
+///
+/// # What this does not cover
+///
+/// The list is written out. A new `EntityType` must gain an arm in
+/// `detach_contained` — the match is exhaustive, so the compiler forces that —
+/// but it will not appear here until someone adds it. That is a real gap and it
+/// is smaller than the one it replaces.
+#[tokio::test]
+async fn no_type_reports_an_unbuilt_release() {
+    let world = World::new().await;
+    // `detach_contained` dispatches on the type rather than reading the entity,
+    // so an identity that names nothing is enough to ask every arm the question.
+    let nobody = EntityId::from_uuid(Uuid::new_v4());
+    for kind in [
+        EntityType::Campaign,
+        EntityType::Arc,
+        EntityType::Quest,
+        EntityType::Note,
+        EntityType::File,
+        EntityType::Item,
+        EntityType::Location,
+        EntityType::ShoppingList,
+        EntityType::Category,
+        EntityType::Routine,
+        EntityType::FocusSession,
+        EntityType::CheckIn,
+    ] {
+        assert_ne!(
+            detach(&world, nobody, kind).await,
+            Detachment::NotBuilt,
+            "{kind:?} reports its release is not built. If that is true, it is a \
+             container whose contents will point at a tombstone — say so here \
+             deliberately rather than letting a merge find it."
+        );
+    }
+}
+
+/// Guidance's ladder releases what it held. The positive half of what the
+/// `NotBuilt` assertion used to stand in for.
+#[tokio::test]
+async fn an_erased_campaign_releases_the_arc_beneath_it() {
+    let world = World::new().await;
+    let campaign = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Campaign(v1::CampaignContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let arc = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Arc(v1::ArcContent {
+                campaign_id: Some(id_bytes(campaign)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    world.submit(&world.one, erase(&[campaign])).await;
+
+    let parent: Option<Uuid> = sqlx::query("SELECT campaign_id AS c FROM arc WHERE entity_id = $1")
+        .bind(arc.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("arc row")
+        .try_get("c")
+        .expect("campaign_id");
+    assert_eq!(parent, None, "the arc still points at its erased campaign");
+}
+
+/// A note and a file hold nothing at all, which is an answer.
+#[tokio::test]
+async fn the_types_that_hold_nothing_say_they_have_no_container() {
+    let world = World::new().await;
+    let note = world.note(&world.one, "holds nothing").await;
+    assert_eq!(
+        detach(&world, note, EntityType::Note).await,
+        Detachment::NoContainer
+    );
+}
+
+/// A category is a container in two senses and **both are now released**:
+/// `uncategorise_all` for its membership, and the type-content seam for its
+/// nesting.
+///
+/// This asserts the second, which was the half nothing handled for a wave.
+#[tokio::test]
+async fn a_nested_category_is_released_when_its_parent_is_erased() {
+    let world = World::new().await;
+    let outer = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let inner = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent {
+                parent_category_id: Some(id_bytes(outer)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let released = released(&detach(&world, outer, EntityType::Category).await);
+    assert_eq!(
+        released,
+        vec![inner],
+        "the nested category was not released"
+    );
+}
+
+/// **Wired.** An erased location releases what it held, and the change sequence
+/// learns about each one.
+///
+/// This is the test that was a characterisation of the unwired state one commit
+/// ago; the assertions inverted when the call landed, which is exactly what it
+/// was written to make visible.
+#[tokio::test]
+async fn an_erase_releases_what_a_location_held_and_says_so_in_the_change_sequence() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    nest(&world, shelf, cupboard).await;
+    let tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                location_id: Some(id_bytes(cupboard)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    world.submit(&world.one, erase(&[cupboard])).await;
+    assert_eq!(world.lifecycle(cupboard).await, "erased");
+
+    // Neither points at the tombstone. Both states are complete rather than
+    // damaged: a top-level location, and an item with no location.
+    assert_eq!(location_row(&world, shelf).await.0, None);
+    assert_eq!(item_row(&world, tin).await.location, None);
+
+    // **A change nobody learns about is the hole this closes.** Each released
+    // entity gets an entry of its own, the way an uncategorised one does.
+    let changes = world.changes().await;
+    for released in [shelf, tin] {
+        assert!(
+            changes
+                .iter()
+                .any(|c| c.entity == Some(released.as_uuid()) && c.kind == "entity_written"),
+            "{released:?} lost its container with no change entry"
+        );
+    }
+}
+
+/// An erased location that held nothing releases nothing, and the erase is
+/// unaffected.
+#[tokio::test]
+async fn erasing_an_empty_location_releases_nothing() {
+    let world = World::new().await;
+    let empty = a_location(&world, &world.one, "the empty drawer").await;
+    world.submit(&world.one, erase(&[empty])).await;
+    assert_eq!(world.lifecycle(empty).await, "erased");
+}
+
+/// **The release reaches entities the erasing member cannot see.**
+///
+/// Deliberately unscoped, for the reason `uncategorise_all` gives: the container
+/// is gone for everybody, so leaving the rows one member cannot see still
+/// pointing at it would keep a dangling reference alive precisely where nobody
+/// can find it.
+#[tokio::test]
+async fn the_release_is_unscoped_because_the_container_is_gone_for_everybody() {
+    let world = World::new().await;
+    // One owns the cupboard and can erase it; two shelves inside it are two's
+    // own and private, so one cannot see them.
+    let cupboard = a_location(&world, &world.one, "the shared cupboard").await;
+    let theirs = world
+        .create(
+            &world.two,
+            location(v1::LocationContent::default()),
+            v1::EntityContent {
+                title: Some("their shelf".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    // Placed by its own member, so the nesting is legitimate.
+    sqlx::query("UPDATE location SET parent_location_id = $2 WHERE entity_id = $1")
+        .bind(theirs.as_uuid())
+        .bind(cupboard.as_uuid())
+        .execute(&world.db.pool)
+        .await
+        .expect("nest");
+
+    world.submit(&world.one, erase(&[cupboard])).await;
+
+    assert_eq!(
+        location_row(&world, theirs).await.0,
+        None,
+        "a child the erasing member cannot see kept pointing at the tombstone"
+    );
+}
+
+/// **Where the companion's value actually matters: the conflict comparison.**
+///
+/// A client states the time, and the instance also moves that part as the
+/// amount's companion. Both sides of the conflict render through the same code,
+/// so the companion must carry *the client's* instant — if it carried the
+/// instance's clock instead, this write would touch the part twice with two
+/// different arriving values and retain a value the client never sent.
+///
+/// Two members, one stale base, both stating their own times.
+#[tokio::test]
+async fn a_conflict_on_a_client_stated_time_retains_the_time_the_client_sent() {
+    let world = World::new().await;
+    let id = shared_item(
+        &world,
+        v1::ItemContent {
+            asserted_amount: Some(decimal(1, 0)),
+            ..Default::default()
+        },
+    )
+    .await;
+    let base = world.counter(id).await;
+    let theirs = "2026-03-04T09:00:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+    let mine = "2026-03-05T17:30:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+
+    for (member, amount, at) in [
+        (&world.one, decimal(2, 0), theirs),
+        (&world.two, decimal(5, 0), mine),
+    ] {
+        world
+            .submit(
+                member,
+                edit_specific(
+                    id,
+                    base,
+                    item(v1::ItemContent {
+                        asserted_amount: Some(amount),
+                        asserted_at: Some(timestamp(at)),
+                        ..Default::default()
+                    }),
+                ),
+            )
+            .await;
+    }
+
+    let conflicts = world.conflicts(id).await;
+    let time = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.3"))
+        .expect("two members asserted at different times from one base");
+    // Exactly one row for this part, and both sides are times a client sent.
+    assert_eq!(
+        conflicts
+            .iter()
+            .filter(|c| c.field.as_deref() == Some("specific.3"))
+            .count(),
+        1
+    );
+    assert_eq!(time.mine.as_deref(), Some(mine.to_rfc3339().as_str()));
+    assert_eq!(time.theirs.as_deref(), Some(theirs.to_rfc3339().as_str()));
+    assert_eq!(item_row(&world, id).await.asserted_at, Some(mine));
+}
+
+// ---------------------------------------------------------------------------
+// A release is a write, so it owes provenance
+// ---------------------------------------------------------------------------
+
+/// **Which part moved travels with the identity**, because a child location
+/// lost its parent and an item lost its shelf, and those are different fields of
+/// different messages. Without it the release could not record provenance, and a
+/// counter would advance with nothing saying what changed.
+#[tokio::test]
+async fn a_release_reports_which_part_of_each_entity_moved() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    nest(&world, shelf, cupboard).await;
+    let tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                location_id: Some(id_bytes(cupboard)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let parts = released_parts(&detach(&world, cupboard, EntityType::Location).await);
+    assert!(parts.contains(&(shelf, Part::Specific(1))), "{parts:?}");
+    assert!(parts.contains(&(tin, Part::Specific(4))), "{parts:?}");
+}
+
+/// A released entity records the part that moved, at the counter it moved at.
+///
+/// Otherwise a later stale edit to the same field merges silently, losing the
+/// fact that the container went away underneath it.
+#[tokio::test]
+async fn an_erase_records_provenance_for_what_it_released() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    nest(&world, shelf, cupboard).await;
+
+    world.submit(&world.one, erase(&[cupboard])).await;
+
+    let after = world.counter(shelf).await;
+    let moved = moved_parts(&world, shelf).await;
+    assert!(
+        moved
+            .iter()
+            .any(|(name, counter)| name == "specific.1" && *counter == after),
+        "the released parent recorded nothing at counter {after}: {moved:?}"
+    );
+}
+
+/// The membership half owes the same thing. Two parts move — the category and
+/// the position within it — and the counter advances, so both are recorded.
+#[tokio::test]
+async fn erasing_a_category_records_provenance_for_what_it_uncategorised() {
+    let world = World::new().await;
+    let category = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let filed = world
+        .create(
+            &world.one,
+            item(v1::ItemContent::default()),
+            v1::EntityContent {
+                title: Some("filed".into()),
+                category_id: Some(id_bytes(category)),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    world.submit(&world.one, erase(&[category])).await;
+
+    let after = world.counter(filed).await;
+    let moved = moved_parts(&world, filed).await;
+    for part in ["category_id", "category_position"] {
+        assert!(
+            moved
+                .iter()
+                .any(|(name, counter)| name == part && *counter == after),
+            "{part} moved with the counter and recorded nothing: {moved:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A write that changed nothing did not move the part
+// ---------------------------------------------------------------------------
+
+/// **The member who wrote nothing must not own the part.**
+///
+/// `entity_part_counter` carries who last moved a part. A same-value write is
+/// correctly not a conflict — but if it also claimed the part, a later conflict
+/// would name a member who authored nothing and erase the one who did, and
+/// `theirs_member_id` crosses the wire for a client to render.
+#[tokio::test]
+async fn a_write_that_changed_nothing_does_not_take_ownership_of_the_part() {
+    let world = World::new().await;
+    let id = shared_item(
+        &world,
+        v1::ItemContent {
+            unit: Some("tins".into()),
+            ..Default::default()
+        },
+    )
+    .await;
+    let base = world.counter(id).await;
+
+    // Two really moves it.
+    world
+        .submit(
+            &world.two,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    unit: Some("jars".into()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+    // One, stale, submits the same value. Not a conflict — and not a move.
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    unit: Some("jars".into()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert!(
+        world.conflicts(id).await.is_empty(),
+        "agreement was recorded as a disagreement"
+    );
+
+    let owner: Option<Uuid> = sqlx::query(
+        "SELECT member_id FROM entity_part_counter \
+         WHERE entity_id = $1 AND field_name = 'specific.2'",
+    )
+    .bind(id.as_uuid())
+    .fetch_one(&world.db.pool)
+    .await
+    .expect("part counter")
+    .try_get("member_id")
+    .expect("member");
+    assert_eq!(
+        owner,
+        Some(world.two.membership_id()),
+        "the no-op write took ownership of a part it did not change"
+    );
+}
+
+/// And the consequence the ownership bug actually produces: a later conflict
+/// naming the wrong person.
+#[tokio::test]
+async fn a_later_conflict_names_the_member_who_really_wrote_the_value() {
+    let world = World::new().await;
+    let id = shared_item(
+        &world,
+        v1::ItemContent {
+            unit: Some("tins".into()),
+            ..Default::default()
+        },
+    )
+    .await;
+    let base = world.counter(id).await;
+
+    for member in [&world.two, &world.one] {
+        world
+            .submit(
+                member,
+                edit_specific(
+                    id,
+                    base,
+                    item(v1::ItemContent {
+                        unit: Some("jars".into()),
+                        ..Default::default()
+                    }),
+                ),
+            )
+            .await;
+    }
+
+    // Now a third write, still from the old base, that genuinely disagrees.
+    world
+        .submit(
+            &world.two,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    unit: Some("bottles".into()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let conflicts = world.conflicts(id).await;
+    let unit = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.2"))
+        .expect("bottles disagrees with jars from a stale base");
+    assert_eq!(
+        unit.theirs_member,
+        Some(world.two.membership_id()),
+        "the displaced value is attributed to the member whose no-op touched it \
+         rather than the one who wrote it"
+    );
+}
+
+/// **The counter still advances on a no-op.** Clients learn that a write
+/// happened from the entity's counter; only the per-part record is withheld.
+#[tokio::test]
+async fn a_no_op_write_still_advances_the_entitys_counter() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                unit: Some("tins".into()),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let before = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                before,
+                item(v1::ItemContent {
+                    unit: Some("tins".into()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert_eq!(world.counter(id).await, before + 1);
+}
+
+/// **Inverted, as its own message said to be.**
+///
+/// This was a characterisation test. It pinned what an erased parent category
+/// left behind — the child's `parent_category_id` naming a tombstone for ever,
+/// unrepairable because re-parenting means naming the erased one and
+/// `available_for_write` refuses it, and silent because `would_cycle` reads the
+/// deleted row, finds none and returns false. A coherence problem is the quieter
+/// kind, which is why it survived a wave.
+///
+/// It failed the moment the categories lane wired the release, with the message
+/// it was written to carry. **The assertion is now `None`** and nothing else
+/// about the test changed, which is the whole point of writing the pin rather
+/// than a comment: the fix had to walk past it.
+#[tokio::test]
+async fn erasing_a_parent_category_releases_its_nested_children() {
+    let world = World::new().await;
+    let outer = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent {
+                title: Some("outer".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    let inner = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent {
+                parent_category_id: Some(id_bytes(outer)),
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("inner".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    world.submit(&world.one, erase(&[outer])).await;
+    assert_eq!(world.lifecycle(outer).await, "erased");
+
+    let parent: Option<Uuid> =
+        sqlx::query("SELECT parent_category_id AS p FROM category WHERE entity_id = $1")
+            .bind(inner.as_uuid())
+            .fetch_one(&world.db.pool)
+            .await
+            .expect("category row")
+            .try_get("p")
+            .expect("parent");
+    assert_eq!(
+        parent, None,
+        "the nested category still points at its erased parent"
+    );
 }

--- a/crates/altaird/tests/write_spine.rs
+++ b/crates/altaird/tests/write_spine.rs
@@ -1049,6 +1049,48 @@ async fn a_timestamp_that_cannot_be_read_is_refused_wherever_it_arrives() {
     assert_eq!(w.counter(id).await, 1);
 }
 
+/// **Zero is refused from the other end, and it is the reachable one.**
+///
+/// The upper bound below is refused because a garbled value reads as *current*
+/// and skips conflict detection. Zero fails the same test — the first counter an
+/// entity has is 1, from its own create — but it arrives by accident rather than
+/// by garbling: `base_counter` is a proto3 `uint64`, so a client that omits the
+/// field sends zero and cannot tell that apart from meaning it.
+///
+/// Accepting it manufactured conflicts. A create records the parts it applied
+/// without comparing them, because on a create there is nothing to compare
+/// against — so an entity created with its title explicitly cleared carries
+/// provenance for a title that never changed. An edit with base zero reads
+/// `0 < 1`, asks what moved since, finds that record, and retains a conflict
+/// over a part only the second write ever touched.
+///
+/// The boundary is the point: 1 is a counter this instance issues, and 0 is not.
+#[tokio::test]
+async fn a_base_counter_of_zero_is_refused_and_one_is_not() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "start").await;
+    assert_eq!(w.counter(id).await, 1, "a create issues the first counter");
+
+    let ack = w
+        .submit(
+            &w.one,
+            edit_entity(id, 0, note_content("omitted the field")),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+    assert_eq!(
+        w.title(id).await.as_deref(),
+        Some("start"),
+        "and nothing was written"
+    );
+
+    // The very next value is ordinary, so the refusal is a boundary rather than
+    // a rejection of early edits.
+    w.submit(&w.one, edit_entity(id, 1, note_content("stated it")))
+        .await;
+    assert_eq!(w.title(id).await.as_deref(), Some("stated it"));
+}
+
 #[tokio::test]
 async fn a_base_counter_this_instance_could_not_have_issued_is_refused() {
     // Clamping it was worse than it looks. A base larger than any counter the


### PR DESCRIPTION
Seventh of nine slices of Wave 2.2. Stacked on #26.

**This is the slice to read hardest.** The six before it are per-lane work that could each be built in isolation. This one is what came out of putting them together, and it is where every defect found late in the wave lived. Nothing here was in anyone's original brief.

## Container release on erasure

`write/entity.rs` says outright that *"the type-specific containers, the ladder and nested locations, are Wave 2.2's for the same reason their content is."* Wave 2.1 built the membership half — erasing a category clears `entity.category_id` on everything filed in it. The type-specific half was not built, so an erased campaign left its arcs and quests pointing at a tombstone, and an erased location left its children and its items.

**The hook answers three variants, not two, and that is the load-bearing design decision.** A container that held nothing, a type that has no container, and a container whose release is *not built* all release nothing — and the last is a leak rather than an answer. Wiring the call while an unbuilt lane answered as though empty would have left every arc on a tombstone with the suite green. That variant caught two real gaps during this slice, both in the code of the person who designed it.

Three properties hold across all three containers, and none is re-decided per container:

- **Erasure only, never removal.** Removal is recoverable and grouped; a child detached on removal would come back parentless with its position forgotten, destroying what the deletion group preserves.
- **Unscoped.** The container is gone for everybody, so leaving behind the children the eraser cannot see would strand a reference precisely where nobody can find it. Each container has a test proving a child the eraser cannot see is still released.
- **Parentless, not promoted.** A child does not inherit its erased parent's parent. Promotion would be the system moving something into a container the person never put it in, and appending it at the end of an order they did not choose.

**A location releases its items as well as its child locations.** Items are the larger set and nothing catches either, because both columns are typed foreign keys into `entity` and erasure leaves the entity row standing.

## The companion seam, widened once rather than twice

`validate_and_place` took one part and returned one companion. Two separate needs broke on that:

**A client-stated `asserted_at` could not be honoured.** The wire carries it precisely so a client states it, and Wave 2.1 already honours a client-stated `created_at` rather than substituting the instance clock — its comment gives the reason directly, that a client was otherwise "told its capture had been accepted with a time it never sent". Refusing it meant a count taken offline at 09:00 and replayed at 18:00 recorded 18:00, in the one field whose entire purpose is to say when the person last looked.

**A vacated parent recorded no provenance.** A quest moving from an arc to a campaign clears `arc_id` in the same statement, and only the addressed parent and the position were recorded — so a concurrent edit to the vacated arc **merged silently instead of retaining both values**, which is a hole in a standing constraint.

The seam now passes the whole set of addressed parts in and returns as many companions as the write moved. Measured rather than asserted: with the cross-part check removed, clearing an amount while stating a time produces a raw `23514` store fault that takes the transaction down, instead of a refusal anyone can act on.

**A companion is owed only when the column it names was actually holding something.** Emitting one unconditionally would not manufacture a false conflict — the comparison catches that — but it *would* write an `entity_part_counter` row claiming a part moved, which a later unrelated edit reads as an overlap.

## Three provenance defects, all silent

**A no-op write took ownership of the part.** `moved` was pushed unconditionally, one line after the loop computed the exact equality that should gate it and threw it away. So when two people resolve one thing the same way — the case the substrate explicitly protects — the second writer took `entity_part_counter.member_id`, and a later conflict named, on the wire, a person who authored nothing.

**A release moved two parts and recorded one.** An erased container clears its child's parent *and* its ladder position; only the parent was recorded, so a stale cross-parent move merged silently on the position. The membership half of the same erase path already did it correctly and says why.

**`uncategorise_all` recorded neither part** while advancing the counter. Either it is a write to that entity and owes provenance, or it is not and should not move its counter — it does, so it pays.

## A base counter of zero

`base_counter` is a proto3 `uint64`, so **a client that omits the field sends zero and cannot tell that apart from meaning it.** Conversion accepted it and `0 < 1` made conflict detection run against a freshly created entity. Since a create records the parts it applied without comparing them — there being nothing to compare against — an entity created with its title explicitly cleared carried provenance for a title that never changed, and the first edit retained a conflict over a part only the second write ever touched.

The check two lines above already stated the principle: *a base counter is a counter this instance could have issued*. The first one is 1.

## Also here

A shared `part_held_in` derives a released part from the type's own declaration rather than carrying the field number beside the statement — the same drift shape as two callers of a shared helper diverging, demonstrated by moving a declaration out from under a release and watching the release *refuse* rather than claim a stale field number.

`tests/part_provenance.rs` asserts **the set of parts a write records equals the set whose rendered value changed**, across content parts, type-specific parts and blocks, and over consequential writes. It found the vacated-parent hole on its first run, from behaviour, naming the part — and **nothing about that test changed when the fix landed**, which is the claim of an invariant written before its subject.

## Verification

- `cargo test --workspace`: 31 targets, 439 tests, 0 failures.
- `prek run --all-files`: 13 hooks, all passed.
- Every load-bearing claim in this slice was checked by deliberate violation — breaking the implementation and confirming the intended test, and only that test, went red.
