### PR TITLE
Wave 2.2 slice 8: say which tables v0 defines and never writes

### DIFF
--- a/crates/altaird/src/store/entity.rs
+++ b/crates/altaird/src/store/entity.rs
@@ -255,6 +255,81 @@ pub async fn uncategorise_all(
         .collect()
 }
 
+/// Finish detaching entities a vanished type-specific container let go of.
+///
+/// # Why this is here and not in the type's own module
+///
+/// The release itself is the type's: an arc's `campaign_id`, a location's
+/// `parent_location_id`, an item's `location_id`. Each is a column of that
+/// type's own side table and belongs in that type's module, which is the whole
+/// point of the type-content seam.
+///
+/// What cannot live there is this half. A change entry per orphan needs the
+/// audience, and `tests/one_predicate.rs` refuses any source outside
+/// `store/audience.rs` that names the audience column and issues SQL — rightly,
+/// because a paraphrased predicate is a second implementation whatever it is
+/// spelled like. [`uncategorise_all`] gets to write `RETURNING … audience`
+/// precisely because it lives here. So the split is: the type module clears its
+/// own column and hands back identities, and this reads what the change sequence
+/// needs.
+///
+/// One helper rather than one per container, because the ladder and nested
+/// locations owe exactly the same thing and two implementations of *what a
+/// detach does to the entity row* is two chances to forget the counter.
+///
+/// # Deliberately unscoped
+///
+/// The same reason [`uncategorise_all`] gives, and it is not a smaller reason
+/// here: **the container is gone for everybody.** Leaving the entities a writing
+/// member cannot see still pointing at it would keep a dangling reference alive
+/// precisely where nobody can find it. Nothing leaves this function that a
+/// caller can show anyone — the identities become change entries, and those are
+/// assembled per member by the read path, which applies the predicate then.
+///
+/// Do not add a predicate here. A later reader who "fixes" this will produce
+/// orphans that only the invisible members keep.
+///
+/// The counter advances on each, because losing a container is an accepted write
+/// to the entity that lost it, and a client holding the old counter has to learn
+/// it happened.
+pub async fn detached_from_container(
+    tx: &mut WriteTx,
+    released: &[EntityId],
+    at: DateTime<Utc>,
+) -> sqlx::Result<Vec<Uncategorised>> {
+    if released.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ids: Vec<uuid::Uuid> = released.iter().map(|e| e.as_uuid()).collect();
+    let sql = format!(
+        "UPDATE entity SET counter = counter + 1, updated_at = $2 \
+         WHERE id = ANY($1) \
+         RETURNING id, {AUDIENCE_COLUMN} AS audience, author_member_id, counter"
+    );
+    let rows = sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(&ids)
+        .bind(at)
+        .fetch_all(tx.conn())
+        .await?;
+
+    rows.iter()
+        .map(|r| {
+            Ok(Uncategorised {
+                id: r.try_get("id")?,
+                audience: r
+                    .try_get::<Vec<uuid::Uuid>, _>("audience")?
+                    .into_iter()
+                    .map(MemberRef::from_uuid)
+                    .collect(),
+                author: r
+                    .try_get::<Option<uuid::Uuid>, _>("author_member_id")?
+                    .map(MemberRef::from_uuid),
+                counter: r.try_get("counter")?,
+            })
+        })
+        .collect()
+}
+
 /// The entities a single removal act put into holding, as this member can see
 /// them.
 ///

--- a/crates/altaird/src/write/entity.rs
+++ b/crates/altaird/src/write/entity.rs
@@ -39,7 +39,7 @@ use super::changes::{self, EntityChange};
 use super::content::{Date, Malformed, PartWrite, Written};
 use super::outcome::{ConflictParts, Outcome};
 use super::parts::Part;
-use super::specific;
+use super::specific::{self, SpecificPart};
 use super::{body, provenance};
 
 /// One intent's worth of context: the transaction, who is writing, and when.
@@ -169,17 +169,22 @@ async fn current(ctx: &mut Ctx<'_>, row: &EntityRow, part: &PartWrite) -> Applie
 
 /// Apply one part to the store. Assumes it has already been validated.
 ///
-/// `placement` is the position the instance assigned as a consequence, which is
-/// only ever set alongside a category. **The two move in one statement**,
-/// because the store's own check says a category and a position are either both
-/// there or both absent: writing them in sequence puts the row through a state
-/// the schema refuses, whichever order the sequence is in.
+/// `placements` are the parts the instance moved as a consequence. The shared
+/// model produces at most one — the position assigned alongside a category, and
+/// **the two move in one statement**, because the store's own check says a
+/// category and a position are either both there or both absent: writing them in
+/// sequence puts the row through a state the schema refuses, whichever order the
+/// sequence is in.
+///
+/// A type's content may produce more than one, so this takes a slice. **Each
+/// arm finds what it needs by kind rather than by position**, because the order
+/// a lane returns companions in is that lane's business.
 async fn apply_part(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &PartWrite,
-    placement: Option<&PartWrite>,
+    placements: &[PartWrite],
 ) -> Applied<()> {
     match part {
         PartWrite::Title(v) => {
@@ -213,10 +218,11 @@ async fn apply_part(
             }
         }
         PartWrite::Category(v) => {
-            let position = match placement {
-                Some(PartWrite::CategoryPosition(p)) => *p,
+            let position = placements.iter().find_map(|p| match p {
+                PartWrite::CategoryPosition(v) => Some(*v),
                 _ => None,
-            };
+            });
+            let position = position.flatten();
             sqlx::query("UPDATE entity SET category_id = $2, category_position = $3 WHERE id = $1")
                 .bind(entity.as_uuid())
                 .bind(v.map(EntityId::as_uuid))
@@ -268,11 +274,14 @@ async fn apply_part(
             // amount — and is handed through so the module can write both in
             // one statement, for the same reason a category and its position
             // move together here.
-            let placement = placement.and_then(|p| match p {
-                PartWrite::Specific(s) => Some(s),
-                _ => None,
-            });
-            specific::apply(ctx, entity, kind, s, placement).await?;
+            let companions: Vec<SpecificPart> = placements
+                .iter()
+                .filter_map(|p| match p {
+                    PartWrite::Specific(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .collect();
+            specific::apply(ctx, entity, kind, s, &companions).await?;
         }
     }
     Ok(())
@@ -298,27 +307,37 @@ async fn refresh_search_text(ctx: &mut Ctx<'_>, entity: EntityId, kind: EntityTy
     Ok(())
 }
 
-/// Checks a part owes before it is applied, and the placement the instance
+/// Checks a part owes before it is applied, and the placements the instance
 /// makes rather than the client.
 ///
-/// Returns any extra part the instance moved as a consequence — a position,
-/// when a category changed.
+/// Returns every extra part the instance moved as a consequence — a position,
+/// when a category changed, and whatever a type's content moved beside the part
+/// the write named.
+///
+/// `addressed` is every type-specific part this same message writes, handed
+/// down because a type sometimes cannot decide one part without seeing another.
+/// See [`specific::validate_and_place`] for the two cases that need it.
 async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     entering: Option<EntityId>,
     part: &PartWrite,
-) -> Applied<Option<PartWrite>> {
+    addressed: &[SpecificPart],
+) -> Applied<Vec<PartWrite>> {
     match part {
-        PartWrite::Specific(s) => Ok(specific::validate_and_place(ctx, entity, kind, s)
-            .await?
-            .map(PartWrite::Specific)),
+        PartWrite::Specific(s) => Ok(
+            specific::validate_and_place(ctx, entity, kind, s, addressed)
+                .await?
+                .into_iter()
+                .map(PartWrite::Specific)
+                .collect(),
+        ),
         PartWrite::Audience(ids) | PartWrite::Assignments(ids) => {
             if !memberships_exist(ctx.tx, ids).await? {
                 return Err(Refusal::NotAvailable.into());
             }
-            Ok(None)
+            Ok(Vec::new())
         }
         PartWrite::CategoryPosition(_) => Err(Refusal::Malformed(
             "position is assigned by the instance, which appends on entry to a container; \
@@ -342,15 +361,30 @@ async fn validate_and_place(
             let entering_this = entering != Some(*category);
             if entering_this {
                 let next = crate::store::entity::next_category_position(ctx.tx, *category).await?;
-                return Ok(Some(PartWrite::CategoryPosition(Some(next))));
+                return Ok(vec![PartWrite::CategoryPosition(Some(next))]);
             }
-            Ok(None)
+            Ok(Vec::new())
         }
         // Leaving a container forgets the position. Nothing is carried and
         // nothing needs repair.
-        PartWrite::Category(None) => Ok(Some(PartWrite::CategoryPosition(None))),
-        _ => Ok(None),
+        PartWrite::Category(None) => Ok(vec![PartWrite::CategoryPosition(None)]),
+        _ => Ok(Vec::new()),
     }
+}
+
+/// Every type-specific part one message writes.
+///
+/// Built once per write rather than per part: it is the same set for every part
+/// in the loop, and a type asking about a sibling field is asking about this.
+fn addressed_specifics(written: &Written) -> Vec<SpecificPart> {
+    written
+        .parts
+        .iter()
+        .filter_map(|p| match p {
+            PartWrite::Specific(s) => Some(s.clone()),
+            _ => None,
+        })
+        .collect()
 }
 
 /// The side-table row a type carries beyond the shared model, with its
@@ -474,12 +508,13 @@ pub async fn create(
 
     make_type_row(ctx, id, kind).await?;
 
+    let addressed = addressed_specifics(&written);
     let mut moved = Vec::new();
     for part in &written.parts {
-        let placement = validate_and_place(ctx, id, kind, None, part).await?;
-        apply_part(ctx, id, kind, part, placement.as_ref()).await?;
+        let placements = validate_and_place(ctx, id, kind, None, part, &addressed).await?;
+        apply_part(ctx, id, kind, part, &placements).await?;
         moved.push(part.part());
-        if let Some(placement) = &placement {
+        for placement in &placements {
             moved.push(placement.part());
         }
     }
@@ -505,7 +540,7 @@ pub async fn create(
                 return Err(Refusal::NotAvailable.into());
             }
             let part = PartWrite::Audience(default);
-            apply_part(ctx, id, kind, &part, None).await?;
+            apply_part(ctx, id, kind, &part, &[]).await?;
             moved.push(part.part());
         }
     }
@@ -588,17 +623,21 @@ pub async fn edit(
     let mut moved = Vec::new();
     let counter = row.counter + 1;
 
+    let addressed = addressed_specifics(&written);
     for part in &written.parts {
-        let placement = validate_and_place(ctx, id, kind, row.category_id, part).await?;
+        let placements =
+            validate_and_place(ctx, id, kind, row.category_id, part, &addressed).await?;
         let stored = current(ctx, &row, part).await?;
         touching.push((part.part(), part.text(), stored.text()));
-        if let Some(placement) = &placement {
+        // Each companion is compared like any other part, and against what the
+        // store holds *now* — which is why this runs before the write below.
+        for placement in &placements {
             let stored = current(ctx, &row, placement).await?;
             touching.push((placement.part(), placement.text(), stored.text()));
         }
-        apply_part(ctx, id, kind, part, placement.as_ref()).await?;
+        apply_part(ctx, id, kind, part, &placements).await?;
         moved.push(part.part());
-        if let Some(placement) = &placement {
+        for placement in &placements {
             moved.push(placement.part());
         }
     }
@@ -801,7 +840,7 @@ pub async fn restore(
         if let Some(category) = row.category_id {
             let next = crate::store::entity::next_category_position(ctx.tx, category).await?;
             let part = PartWrite::CategoryPosition(Some(next));
-            apply_part(ctx, row.id, row.entity_type, &part, None).await?;
+            apply_part(ctx, row.id, row.entity_type, &part, &[]).await?;
             provenance::record(ctx.tx, row.id, &[part.part()], row.counter + 1, ctx.member).await?;
         }
 
@@ -914,8 +953,40 @@ pub async fn erase(ctx: &mut Ctx<'_>, ids: &[EntityId]) -> Applied<(Vec<EntityId
         // fortiori to an erased one, and leaving the reference would point
         // every member of the category at a tombstone.
         //
-        // The type-specific containers, the ladder and nested locations, are
-        // Wave 2.2's for the same reason their content is.
+        // The type-specific containers — the ladder, and nested locations —
+        // release through the type-content seam, because the column that points
+        // at the container is a column of the type's own side table. The seam
+        // hands back identities; the counter and the audience a change entry
+        // needs come from the store layer, which is the only place entitled to
+        // read that column. See `specific::detach_contained`.
+        //
+        // **A type that has not built its release must not look like an empty
+        // one.** `Detachment::NotBuilt` is a distinct answer for exactly that
+        // reason, and it is stepped over here rather than treated as nothing to
+        // do — Guidance's arcs and quests still point at their tombstone, and
+        // that is visible rather than silent.
+        let contained = match specific::detach_contained(ctx, *id, row.entity_type).await? {
+            specific::Detachment::Released(ids) => ids,
+            specific::Detachment::NoContainer | specific::Detachment::NotBuilt => Vec::new(),
+        };
+        for orphan in
+            crate::store::entity::detached_from_container(ctx.tx, &contained, ctx.at).await?
+        {
+            changes::entity_written(
+                ctx.tx,
+                ctx.at,
+                &EntityChange {
+                    entity: orphan.id,
+                    audience_before: Some(orphan.audience.clone()),
+                    audience_after: Some(orphan.audience),
+                    author_before: orphan.author,
+                    author_after: orphan.author,
+                    changed_blocks: Vec::new(),
+                },
+            )
+            .await?;
+        }
+
         if row.entity_type == EntityType::Category {
             for orphan in crate::store::entity::uncategorise_all(ctx.tx, *id, ctx.at).await? {
                 changes::entity_written(

--- a/crates/altaird/src/write/entity.rs
+++ b/crates/altaird/src/write/entity.rs
@@ -38,7 +38,7 @@ use crate::store::{WriteScope, WriteTx};
 use super::changes::{self, EntityChange};
 use super::content::{Date, Malformed, PartWrite, Written};
 use super::outcome::{ConflictParts, Outcome};
-use super::parts::Part;
+use super::parts::{ContentPart, Part};
 use super::specific::{self, SpecificPart};
 use super::{body, provenance};
 
@@ -629,17 +629,37 @@ pub async fn edit(
             validate_and_place(ctx, id, kind, row.category_id, part, &addressed).await?;
         let stored = current(ctx, &row, part).await?;
         touching.push((part.part(), part.text(), stored.text()));
+        // **A write that changed nothing did not move the part.** The same
+        // comparison that decides a conflict decides this, and it has to: a
+        // part's provenance row carries *who* last moved it, so recording a
+        // no-op would hand ownership to a member who wrote nothing and erase the
+        // one who did. A later conflict would then name the wrong person, and
+        // `conflict.theirs_member_id` is stored and crosses the wire — the
+        // substrate requires that whose edit each value was is known and may be
+        // shown, and after a same-value write it would be known and wrong.
+        //
+        // The entity's own counter still advances below, which is what tells a
+        // client there was a write at all. Only the per-part record is withheld,
+        // and a part a write does not address already goes unrecorded — so this
+        // is the existing shape rather than a new rule.
+        //
+        // `specific::guidance` already does this in the upward climb, reading the
+        // current state and returning before recording when nothing moves. The
+        // general edit path now agrees with it.
+        let mut record = |part: &PartWrite, stored: &PartWrite| {
+            if part.text() != stored.text() {
+                moved.push(part.part());
+            }
+        };
+        record(part, &stored);
         // Each companion is compared like any other part, and against what the
         // store holds *now* — which is why this runs before the write below.
         for placement in &placements {
             let stored = current(ctx, &row, placement).await?;
             touching.push((placement.part(), placement.text(), stored.text()));
+            record(placement, &stored);
         }
         apply_part(ctx, id, kind, part, &placements).await?;
-        moved.push(part.part());
-        for placement in &placements {
-            moved.push(placement.part());
-        }
     }
 
     // A body reads what is stored and writes what changed in one step, because
@@ -966,12 +986,31 @@ pub async fn erase(ctx: &mut Ctx<'_>, ids: &[EntityId]) -> Applied<(Vec<EntityId
         // do — Guidance's arcs and quests still point at their tombstone, and
         // that is visible rather than silent.
         let contained = match specific::detach_contained(ctx, *id, row.entity_type).await? {
-            specific::Detachment::Released(ids) => ids,
+            specific::Detachment::Released(released) => released,
             specific::Detachment::NoContainer | specific::Detachment::NotBuilt => Vec::new(),
         };
-        for orphan in
-            crate::store::entity::detached_from_container(ctx.tx, &contained, ctx.at).await?
-        {
+        let ids: Vec<EntityId> = contained.iter().map(|r| r.entity).collect();
+        for orphan in crate::store::entity::detached_from_container(ctx.tx, &ids, ctx.at).await? {
+            // **A release is a write, so it owes provenance.** The counter
+            // advanced, and a part that moves a counter without recording which
+            // part moved is invisible to conflict detection: a later stale edit
+            // to the same field would merge silently, losing the fact that the
+            // container went away underneath it. `restore` already records the
+            // position it moves as a consequence of something else; this is the
+            // same shape and now gets the same treatment.
+            //
+            // Attributed to the member who erased the container, because that is
+            // who caused it.
+            for r in contained.iter().filter(|r| r.entity == orphan.id) {
+                provenance::record(
+                    ctx.tx,
+                    orphan.id,
+                    std::slice::from_ref(&r.part),
+                    orphan.counter,
+                    ctx.member,
+                )
+                .await?;
+            }
             changes::entity_written(
                 ctx.tx,
                 ctx.at,
@@ -989,6 +1028,28 @@ pub async fn erase(ctx: &mut Ctx<'_>, ids: &[EntityId]) -> Applied<(Vec<EntityId
 
         if row.entity_type == EntityType::Category {
             for orphan in crate::store::entity::uncategorise_all(ctx.tx, *id, ctx.at).await? {
+                // The same reasoning, for the membership half. Two parts move —
+                // the category and the position within it — and both are
+                // recorded, because the counter advanced and something has to be
+                // able to say what changed.
+                //
+                // **The alternative reading was considered and rejected**: that
+                // uncategorising is a consequence rather than an authored
+                // placement and so should not conflict. It cannot be had for
+                // free — the counter already advances here, and a write that
+                // moves a counter and records nothing is the silent case. Either
+                // it is a write to this entity or it is not; it is, so it pays.
+                provenance::record(
+                    ctx.tx,
+                    orphan.id,
+                    &[
+                        Part::Content(ContentPart::Category),
+                        Part::Content(ContentPart::CategoryPosition),
+                    ],
+                    orphan.counter,
+                    ctx.member,
+                )
+                .await?;
                 changes::entity_written(
                     ctx.tx,
                     ctx.at,

--- a/crates/altaird/src/write/entity.rs
+++ b/crates/altaird/src/write/entity.rs
@@ -973,18 +973,27 @@ pub async fn erase(ctx: &mut Ctx<'_>, ids: &[EntityId]) -> Applied<(Vec<EntityId
         // fortiori to an erased one, and leaving the reference would point
         // every member of the category at a tombstone.
         //
-        // The type-specific containers — the ladder, and nested locations —
-        // release through the type-content seam, because the column that points
-        // at the container is a column of the type's own side table. The seam
-        // hands back identities; the counter and the audience a change entry
-        // needs come from the store layer, which is the only place entitled to
-        // read that column. See `specific::detach_contained`.
+        // **That is category *membership*, and it is only half of what a
+        // category holds.** The other half is category *nesting* —
+        // `category.parent_category_id` — and `uncategorise_all` does not touch
+        // it. An earlier version of this comment named "the ladder and nested
+        // locations" and omitted the third case, which is where the blind spot
+        // started; it is spelled out here so the next reader does not inherit
+        // it.
+        //
+        // The type-specific containers — the ladder, nested locations, and
+        // nested categories — release through the type-content seam, because
+        // the column that points at the container is a column of the type's own
+        // side table. The seam hands back identities and which part of each
+        // moved; the counter and the audience a change entry needs come from the
+        // store layer, which is the only place entitled to read that column. See
+        // `specific::detach_contained`.
         //
         // **A type that has not built its release must not look like an empty
         // one.** `Detachment::NotBuilt` is a distinct answer for exactly that
         // reason, and it is stepped over here rather than treated as nothing to
-        // do — Guidance's arcs and quests still point at their tombstone, and
-        // that is visible rather than silent.
+        // do. Two types still answer that way and both are visible rather than
+        // silent: Guidance's arcs and quests, and a nested category.
         let contained = match specific::detach_contained(ctx, *id, row.entity_type).await? {
             specific::Detachment::Released(released) => released,
             specific::Detachment::NoContainer | specific::Detachment::NotBuilt => Vec::new(),

--- a/crates/altaird/src/write/mod.rs
+++ b/crates/altaird/src/write/mod.rs
@@ -286,6 +286,30 @@ async fn act(ctx: &mut Ctx<'_>, intent: &v1::Intent) -> Result<Outcome, Failed> 
                 // detection entirely — the one mechanism this item exists to
                 // build — rather than being refused as the unreadable message
                 // it is.
+                //
+                // **Zero is refused for the same reason, from the other end.**
+                // The first counter an entity has is 1, issued by its own
+                // create, so zero is not a counter this instance could have
+                // issued either — and it is the value the wire produces when a
+                // client omits the field, because `base_counter` is a proto3
+                // `uint64` whose default is indistinguishable from unset.
+                //
+                // Accepting it was not harmless. A create records the parts it
+                // applied without comparing them, because on a create there is
+                // no prior value to compare against; so an entity created with
+                // its title explicitly cleared carries provenance for a title
+                // that never changed. An edit arriving with base zero reads
+                // `0 < 1`, asks what moved since, finds that record, and retains
+                // a conflict over a part only the second write ever touched.
+                // The client that hits this is one that forgot a field, not one
+                // doing anything exotic.
+                if e.base_counter == 0 {
+                    return Err(Refusal::Malformed(
+                        "a base counter is a counter this instance could have issued,                          and the first one is 1"
+                            .into(),
+                    )
+                    .into());
+                }
                 let base = i64::try_from(e.base_counter).map_err(|_| {
                     Refusal::Malformed(
                         "a base counter is a counter this instance could have issued".into(),

--- a/crates/altaird/src/write/specific/category.rs
+++ b/crates/altaird/src/write/specific/category.rs
@@ -63,7 +63,11 @@ use crate::store::ids::EntityId;
 
 use super::super::content::{Malformed, Written, identifier};
 use super::super::entity::{Applied, Ctx, Refusal, memberships_exist};
-use super::{Field, Held, Reader, SpecificPart, SpecificValue, nesting, read_column, write_column};
+use super::super::parts::Part;
+use super::{
+    Detachment, Field, Held, Reader, Released, SpecificPart, SpecificValue, nesting, read_column,
+    write_column,
+};
 
 /// A category's field 1, the category it nests inside.
 pub const CATEGORY_PARENT: u32 = 1;
@@ -225,4 +229,64 @@ pub async fn apply(
 pub async fn search_text(ctx: &mut Ctx<'_>, entity: EntityId) -> Applied<Option<String>> {
     let _ = (ctx, entity);
     Ok(None)
+}
+
+/// Let go of the categories nested inside this one, because it is gone.
+///
+/// # A category is a container in two senses and only one of them is here
+///
+/// **Membership** is an entity filed *in* a category, held on the `entity` row
+/// as `category_id`, and released by `uncategorise_all` — the shared model's,
+/// built in Wave 2.1, and called in the same erase path a few lines further on.
+/// **Nesting** is a category sitting *under* another, held in this type's own
+/// side table as `parent_category_id`, and released by nobody until now. The
+/// erase path's comment names "the ladder and nested locations" and silently
+/// omits this third case, which is how it stayed missing.
+///
+/// The two sets are different and the two releases do not double-count. A
+/// category nested under the erased one is reached here, through
+/// `parent_category_id`. An entity filed in it is reached there, through
+/// `category_id`. A category that is *both* — nested under it and filed in it —
+/// is released once by each, of two different columns, and ends up with neither
+/// a parent nor a filing, which is exactly right. Nothing is written twice
+/// because nothing writes the same column twice.
+///
+/// # Parentless, not promoted
+///
+/// A child does not inherit its erased parent's parent. Guidance settled this
+/// for the ladder and the reasoning carries without change: promotion would be
+/// the system moving something into a container the person never put it in.
+/// Being parentless is a complete state — the substrate's rule that *an entity
+/// whose category is deleted becomes uncategorised, which is a valid state
+/// requiring no repair* is the same rule one level up.
+///
+/// # Erasure only, never removal
+///
+/// Removal is recoverable and grouped, and restoring the group is meant to put
+/// back what was there. A child detached on removal would come back parentless,
+/// so the release would quietly destroy what the deletion group exists to
+/// preserve. This is reached from the erase path alone.
+///
+/// # Unscoped
+///
+/// [`nesting::detach_children`] applies no audience predicate, and that is
+/// deliberate rather than overlooked — see its documentation for the reasoning,
+/// which is `uncategorise_all`'s and is no smaller here.
+pub async fn detach_contained(ctx: &mut Ctx<'_>, entity: EntityId) -> Applied<Detachment> {
+    let table = super::side_table(EntityType::Category)
+        .ok_or_else(|| Refusal::Malformed("a category has no table".into()))?;
+    let released = nesting::detach_children(ctx.tx, table, PARENT_COLUMN, entity).await?;
+    Ok(Detachment::Released(
+        released
+            .into_iter()
+            // The part that moved is this type's field 1. A release advances the
+            // released entity's counter, and a write that advances a counter
+            // owes provenance; which part moved is the type's knowledge, and a
+            // child category lost its parent rather than its shelf.
+            .map(|entity| Released {
+                entity,
+                part: Part::Specific(CATEGORY_PARENT),
+            })
+            .collect(),
+    ))
 }

--- a/crates/altaird/src/write/specific/category.rs
+++ b/crates/altaird/src/write/specific/category.rs
@@ -22,31 +22,71 @@
 //!
 //! Add a bespoke query here and the guard fails on the next run. That is the
 //! guard working. Read its module documentation before deciding it is in the
-//! way.
+//! way. The same rule is why the two checks below reach the store through
+//! [`available_for_write`], [`memberships_exist`] and
+//! [`nesting::would_cycle`] rather than through a statement of their own.
 //!
-//! # What is not decided here
+//! # What a creation default is, and the three things it is not
 //!
-//! **Cycle prevention in nested categories.** Migration one refuses
-//! self-reference and records a longer loop as its gap (h).
-//! [`super::nesting::would_cycle`] is the check, and it is written once because
+//! `altair-substrate-spec.md` states it in one sentence and the schema repeats
+//! it: **it acts once, at the creation of an entity placed in this category.
+//! Not a standing rule, and never inherited.** Each clause is a separate claim,
+//! and none of them is enforced here — they are all consequences of where the
+//! value is *read*, which is [`super::super::entity`]'s create and nowhere
+//! else:
+//!
+//! - **Once, at creation.** Only the create path asks a category for its
+//!   default, so an edit moving an existing entity into this category cannot
+//!   apply one.
+//! - **Not a standing rule.** The value is copied onto the entity at creation
+//!   and never consulted again, so editing it here reaches nothing already
+//!   placed.
+//! - **Never inherited.** The read is of one row and walks no ancestry, so a
+//!   child category with no default of its own has none.
+//!
+//! Writing it is therefore an ordinary column write, and the care goes into not
+//! accidentally making it anything more than that. A category **never sets an
+//! audience** as a standing rule, which is exactly why the default is this
+//! narrow.
+//!
+//! # Cycle prevention in nested categories
+//!
+//! Migration one refuses self-reference and records a longer loop as its gap
+//! (h). [`nesting::would_cycle`] is the check, and it is written once because
 //! nested locations need exactly the same one.
 
 use altair_proto::v1;
 
-use crate::store::entity::EntityType;
+use crate::store::WriteScope;
+use crate::store::entity::{EntityType, available_for_write};
 use crate::store::ids::EntityId;
 
-use super::super::content::{Malformed, Written};
-use super::super::entity::{Applied, Ctx, Refusal};
-use super::{Field, Held, SpecificPart, not_yet_built, unbuilt};
+use super::super::content::{Malformed, Written, identifier};
+use super::super::entity::{Applied, Ctx, Refusal, memberships_exist};
+use super::{Field, Held, Reader, SpecificPart, SpecificValue, nesting, read_column, write_column};
+
+/// A category's field 1, the category it nests inside.
+pub const CATEGORY_PARENT: u32 = 1;
+
+/// A category's field 2, the audience a newly created entity placed here takes
+/// when the write states none of its own.
+pub const CATEGORY_CREATION_DEFAULT: u32 = 2;
+
+/// The store's spelling of the parent column, named once.
+///
+/// [`nesting::would_cycle`] is generic over the column so that one walk serves
+/// nested categories and nested locations, and it takes a `&'static str` so
+/// that nothing a caller sent can ever reach it. This is that string, and it is
+/// the same one [`CATEGORY_FIELDS`] declares.
+const PARENT_COLUMN: &str = "parent_category_id";
 
 pub const CATEGORY_FIELDS: &[Field] = &[
     Field {
-        number: 1,
-        held: Held::Column("parent_category_id"),
+        number: CATEGORY_PARENT,
+        held: Held::Column(PARENT_COLUMN),
     },
     Field {
-        number: 2,
+        number: CATEGORY_CREATION_DEFAULT,
         held: Held::Column("creation_default_audience"),
     },
 ];
@@ -56,24 +96,104 @@ pub const CATEGORY_FIELDS: &[Field] = &[
 /// **LANE: Knowledge + categories.** Wave 2.1 already *reads* the creation
 /// default when it places a newly created entity, so filling this in is what
 /// makes that path reachable by anything other than a hand-written row.
+///
+/// Emptying the member list is how the default is cleared, which is the
+/// repeated field's rule and not a special case: a category with no default and
+/// one whose default was emptied are the same category, and the column is
+/// `NOT NULL DEFAULT '{}'` so there is no third state for them to differ in.
 pub fn category(c: &v1::CategoryContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::Category,
-        &c.cleared,
-        &[
-            (1, c.parent_category_id.is_some()),
-            (2, !c.creation_default_audience_member_ids.is_empty()),
-        ],
-    )
+    let read = Reader::new(EntityType::Category, &c.cleared)?;
+    let mut parts = Vec::new();
+    read.singular(
+        &mut parts,
+        CATEGORY_PARENT,
+        c.parent_category_id.as_deref(),
+        |v| Ok(SpecificValue::Id(v.map(identifier).transpose()?)),
+    )?;
+    read.repeated(
+        &mut parts,
+        CATEGORY_CREATION_DEFAULT,
+        &c.creation_default_audience_member_ids,
+        |v| {
+            let mut ids = Vec::with_capacity(v.len());
+            for member in v {
+                ids.push(identifier(member)?);
+            }
+            Ok(SpecificValue::Members(ids))
+        },
+    )?;
+    Ok(Written::from_specific(parts))
 }
 
+/// What a category's parts owe before they are applied.
+///
+/// **No companion part.** Entering a category places an entity at the end of
+/// it, and that is the shared model's `category_id` and `category_position`
+/// moving together. Nesting a category inside another is not that: migration
+/// one's gap (g) records that nested categories carry no position, because
+/// nothing yet states that their contents are hand ordered. So this returns
+/// `None` always, and the day something states otherwise is the day this grows
+/// a companion, exactly as an arc's ladder position is one.
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     part: &SpecificPart,
 ) -> Applied<Option<SpecificPart>> {
-    let _ = (ctx, entity, part);
-    Err(Refusal::Malformed(not_yet_built(EntityType::Category).0).into())
+    match (part.field, &part.value) {
+        // Leaving the nesting owes nothing. There is no position to forget, and
+        // a category at the top is an ordinary category.
+        (CATEGORY_PARENT, SpecificValue::Id(None)) => Ok(None),
+        (CATEGORY_PARENT, SpecificValue::Id(Some(parent))) => {
+            let parent = EntityId::from_uuid(*parent);
+            // The parent has to be one this member can see, and it has to be a
+            // category. **Both refusals are the same nothing**, which is the
+            // same answer the shared model gives for the category an entity is
+            // placed in: a category the member cannot see and one that does not
+            // exist are indistinguishable from outside, or the refusal is an
+            // oracle for what else the household holds.
+            let found = available_for_write(ctx.tx, ctx.member, parent, WriteScope::Active)
+                .await?
+                .ok_or(Refusal::NotAvailable)?;
+            if found.entity_type != EntityType::Category {
+                return Err(Refusal::NotAvailable.into());
+            }
+            // And the nesting has to terminate. The schema refuses the one-step
+            // case and can see no further; this is its gap (h), closed where
+            // the write is decided because a constraint cannot walk a chain.
+            //
+            // **Malformed rather than not-available**, and that is not a leak:
+            // the member has already been told the parent is there — the check
+            // above passed — so saying the nesting would close a loop discloses
+            // nothing further, and telling them the category is merely
+            // unavailable would send them looking for a permission problem that
+            // is not there.
+            let table = super::side_table(EntityType::Category)
+                .ok_or_else(|| Refusal::Malformed("a category has no table".into()))?;
+            if nesting::would_cycle(ctx.tx, table, PARENT_COLUMN, entity, parent).await? {
+                return Err(Refusal::Malformed(
+                    "nesting this category there would close a loop, and a category cannot \
+                     contain itself at any distance"
+                        .into(),
+                )
+                .into());
+            }
+            Ok(None)
+        }
+        // **Every member named must answer to a real membership.** A foreign
+        // key cannot reach inside an array, which is why the schema lists this
+        // among the checks it cannot make. The refusal is the same nothing
+        // again: a membership in another household and one that was never
+        // created are both simply not there.
+        (CATEGORY_CREATION_DEFAULT, SpecificValue::Members(ids)) => {
+            if !memberships_exist(ctx.tx, ids).await? {
+                return Err(Refusal::NotAvailable.into());
+            }
+            Ok(None)
+        }
+        _ => Err(
+            Refusal::Malformed(format!("field {} is not a part of a category", part.field)).into(),
+        ),
+    }
 }
 
 pub async fn current(
@@ -81,8 +201,7 @@ pub async fn current(
     entity: EntityId,
     part: &SpecificPart,
 ) -> Applied<SpecificPart> {
-    let _ = (ctx, entity, part);
-    Err(Refusal::Malformed(not_yet_built(EntityType::Category).0).into())
+    read_column(ctx, entity, EntityType::Category, part).await
 }
 
 pub async fn apply(
@@ -91,14 +210,18 @@ pub async fn apply(
     part: &SpecificPart,
     placement: Option<&SpecificPart>,
 ) -> Applied<()> {
-    let _ = (ctx, entity, part, placement);
-    Err(Refusal::Malformed(not_yet_built(EntityType::Category).0).into())
+    // A category nests without a position, so nothing moves alongside either of
+    // its parts. See [`validate_and_place`].
+    debug_assert!(placement.is_none());
+    write_column(ctx, entity, EntityType::Category, part).await
 }
 
 /// A category contributes nothing to searchable text.
 ///
 /// Its own title is the shared model's and is already searchable; what it holds
-/// is other entities, and each of those carries its own words.
+/// is other entities, and each of those carries its own words. A category is an
+/// entity rather than a label — describable, relatable, and returned by
+/// retrieval in its own right — and the title is what makes that true.
 pub async fn search_text(ctx: &mut Ctx<'_>, entity: EntityId) -> Applied<Option<String>> {
     let _ = (ctx, entity);
     Ok(None)

--- a/crates/altaird/src/write/specific/guidance.rs
+++ b/crates/altaird/src/write/specific/guidance.rs
@@ -101,8 +101,8 @@ use super::super::entity::{Applied, Ctx, Refusal, type_name};
 use super::super::parts::Part;
 use super::super::provenance;
 use super::{
-    Detachment,
-    Field, GuidanceState, Held, Reader, SpecificPart, SpecificValue, read_column, write_column,
+    Detachment, Field, GuidanceState, Held, Reader, SpecificPart, SpecificValue, read_column,
+    write_column,
 };
 
 /// The state field. **The same number in all three messages**, which is what

--- a/crates/altaird/src/write/specific/guidance.rs
+++ b/crates/altaird/src/write/specific/guidance.rs
@@ -102,7 +102,7 @@ use super::super::parts::Part;
 use super::super::provenance;
 use super::{
     Detachment, Field, GuidanceState, Held, Reader, Released, SpecificPart, SpecificValue,
-    read_column, write_column,
+    part_held_in, read_column, write_column,
 };
 
 /// The state field. **The same number in all three messages**, which is what
@@ -931,27 +931,6 @@ pub async fn detach_contained(
         }
     }
     Ok(Detachment::Released(released))
-}
-
-/// The part of a type's message that a column holds.
-///
-/// One lookup over the type's own [`Field`] declarations, so a column and the
-/// field number that names it cannot disagree. `None` is impossible for the
-/// three columns [`detach_contained`] asks about — each is declared — and is a
-/// refusal rather than a panic because everything else in this file answers
-/// that way.
-fn part_held_in(kind: EntityType, column: &str) -> Applied<Part> {
-    super::fields(kind)
-        .iter()
-        .find(|f| matches!(f.held, Held::Column(c) if c == column))
-        .map(|f| Part::Specific(f.number))
-        .ok_or_else(|| {
-            Refusal::Malformed(format!(
-                "no field of a {} is held in {column}",
-                type_name(kind)
-            ))
-            .into()
-        })
 }
 
 /// Guidance contributes nothing to searchable text.

--- a/crates/altaird/src/write/specific/guidance.rs
+++ b/crates/altaird/src/write/specific/guidance.rs
@@ -101,6 +101,7 @@ use super::super::entity::{Applied, Ctx, Refusal, type_name};
 use super::super::parts::Part;
 use super::super::provenance;
 use super::{
+    Detachment,
     Field, GuidanceState, Held, Reader, SpecificPart, SpecificValue, read_column, write_column,
 };
 
@@ -122,38 +123,51 @@ const QUEST_CAMPAIGN: u32 = 3;
 const QUEST_ROUTINE: u32 = 4;
 const QUEST_POSITION: u32 = 5;
 
+/// The columns this file names in a statement as well as in a declaration.
+///
+/// **Named once because two things must not drift.** [`detach_contained`] and
+/// [`apply`] write these columns by name, and the `FIELDS` tables below declare
+/// the same columns as where a wire field is held; `tests/type_content.rs`
+/// checks the declarations against the store but cannot see a statement that
+/// spells one differently. Following the convention Tracking arrived at for
+/// exactly this reason.
+const STATE_COLUMN: &str = "state";
+const CAMPAIGN_COLUMN: &str = "campaign_id";
+const ARC_COLUMN: &str = "arc_id";
+const LADDER_POSITION_COLUMN: &str = "ladder_position";
+
 pub const CAMPAIGN_FIELDS: &[Field] = &[Field {
     number: CAMPAIGN_STATE,
-    held: Held::Column("state"),
+    held: Held::Column(STATE_COLUMN),
 }];
 
 pub const ARC_FIELDS: &[Field] = &[
     Field {
         number: STATE,
-        held: Held::Column("state"),
+        held: Held::Column(STATE_COLUMN),
     },
     Field {
         number: ARC_CAMPAIGN,
-        held: Held::Column("campaign_id"),
+        held: Held::Column(CAMPAIGN_COLUMN),
     },
     Field {
         number: ARC_POSITION,
-        held: Held::Column("ladder_position"),
+        held: Held::Column(LADDER_POSITION_COLUMN),
     },
 ];
 
 pub const QUEST_FIELDS: &[Field] = &[
     Field {
         number: STATE,
-        held: Held::Column("state"),
+        held: Held::Column(STATE_COLUMN),
     },
     Field {
         number: QUEST_ARC,
-        held: Held::Column("arc_id"),
+        held: Held::Column(ARC_COLUMN),
     },
     Field {
         number: QUEST_CAMPAIGN,
-        held: Held::Column("campaign_id"),
+        held: Held::Column(CAMPAIGN_COLUMN),
     },
     Field {
         number: QUEST_ROUTINE,
@@ -161,9 +175,19 @@ pub const QUEST_FIELDS: &[Field] = &[
     },
     Field {
         number: QUEST_POSITION,
-        held: Held::Column("ladder_position"),
+        held: Held::Column(LADDER_POSITION_COLUMN),
     },
 ];
+
+/// The side table a type keeps its content in.
+///
+/// Taken from [`super::side_table`] rather than written out, so the statements
+/// here cannot disagree with the one place that decides which table a type has.
+fn table_of(kind: EntityType) -> Applied<&'static str> {
+    super::side_table(kind).ok_or_else(|| {
+        Refusal::Malformed(format!("a {} has no table of its own", type_name(kind))).into()
+    })
+}
 
 // ---------------------------------------------------------------------------
 // Reading the three messages
@@ -361,7 +385,8 @@ fn explicit_position_refusal() -> Refusal {
     )
 }
 
-/// The ladder position a parent part carries with it.
+/// The companions a parent part carries with it: the ladder position always,
+/// and the parent it vacated where it vacated one.
 ///
 /// **The parent and the position are one movement.** Both of the schema's
 /// checks tie them together — an arc's
@@ -369,36 +394,60 @@ fn explicit_position_refusal() -> Refusal {
 /// `CHECK ((num_nonnulls(arc_id, campaign_id) = 0) = (ladder_position IS NULL))`
 /// — so writing them in sequence puts the row through a state the schema
 /// refuses, whichever order the sequence is in. This is the same shape
-/// `write::entity` solves for a category and its position, and the companion
-/// travels the same channel.
+/// `write::entity` solves for a category and its position.
+///
+/// **The vacated parent is a companion too, and it is provenance rather than
+/// placement.** A quest has two parent columns and may hold only one, so
+/// setting an arc clears the campaign — in the same statement, by the `CASE`
+/// in [`apply`], because the row may never hold two. That vacated column is a
+/// part like any other: a part that does not record the counter it moved at is
+/// invisible to conflict detection, so a concurrent edit to it would merge
+/// silently instead of retaining both values. Returning it here is what puts it
+/// in provenance. It is already written by the statement that clears it, so it
+/// never needs to reach [`apply`].
+///
+/// **A companion is owed only when the part genuinely moved.** Handing back a
+/// vacated parent that was already null would not manufacture a conflict —
+/// `provenance::detect` compares rendered text, and arriving equals stored —
+/// but it *would* write an `entity_part_counter` row claiming that part moved,
+/// and a later unrelated edit would read that as an overlap.
+///
+/// **The position comes first, and [`write_parent`] checks that rather than
+/// trusting it.** The dispatch hands a narrow lane only the first companion, so
+/// the one `apply` needs has to lead; the check turns an ordering assumption
+/// into a refusal somebody sees.
 async fn parent_placement(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
     container_kind: EntityType,
-) -> Applied<Option<SpecificPart>> {
+) -> Applied<Vec<SpecificPart>> {
     let SpecificValue::Id(target) = part.value else {
         return Err(Refusal::Malformed("a ladder parent is an identifier".into()).into());
     };
     let ladder = ladder_of(ctx, entity, kind).await?;
-    let position = |p: Option<i32>| {
-        Some(SpecificPart {
-            field: position_field(kind),
-            value: SpecificValue::Count(p),
-        })
+    let position = |p: Option<i32>| SpecificPart {
+        field: position_field(kind),
+        value: SpecificValue::Count(p),
+    };
+
+    // The other parent column, which setting this one clears in the same
+    // statement, paired with what it holds now. Only a quest has one; an arc's
+    // single parent has nothing to displace.
+    let sibling = match (kind, container_kind) {
+        (EntityType::Quest, EntityType::Arc) => Some((QUEST_CAMPAIGN, ladder.campaign)),
+        (EntityType::Quest, EntityType::Campaign) => Some((QUEST_ARC, ladder.arc)),
+        _ => None,
     };
 
     let Some(target) = target else {
         // Leaving a container forgets the position — unless the *other* parent
         // column still holds one. Clearing an arc a quest never had must not
-        // strip the position its campaign gave it.
-        let other = match (kind, container_kind) {
-            (EntityType::Quest, EntityType::Arc) => ladder.campaign,
-            (EntityType::Quest, EntityType::Campaign) => ladder.arc,
-            _ => None,
-        };
-        return Ok(position(other.and(ladder.position)));
+        // strip the position its campaign gave it. Nothing is vacated here:
+        // clearing leaves the sibling exactly as it was.
+        let held = sibling.and_then(|(_, holds)| holds);
+        return Ok(vec![position(held.and(ladder.position))]);
     };
 
     // The container has to be one this member can see, and it has to be the
@@ -422,11 +471,21 @@ async fn parent_placement(
     };
     if already == Some(target.as_uuid()) {
         // Not an entry. The position stands, and is handed back anyway so the
-        // parent and the position still move in one statement.
-        return Ok(position(ladder.position));
+        // parent and the position still move in one statement. Nothing is
+        // vacated: the two parents are exclusive, so the sibling is already
+        // null.
+        return Ok(vec![position(ladder.position)]);
     }
+
     let next = next_ladder_position(ctx, target, container_kind).await?;
-    Ok(position(Some(next)))
+    let mut companions = vec![position(Some(next))];
+    if let Some((field, Some(_))) = sibling {
+        companions.push(SpecificPart {
+            field,
+            value: SpecificValue::Id(None),
+        });
+    }
+    Ok(companions)
 }
 
 // ---------------------------------------------------------------------------
@@ -558,12 +617,12 @@ pub async fn validate_and_place(
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
-) -> Applied<Option<SpecificPart>> {
+) -> Applied<Vec<SpecificPart>> {
     match (kind, part.field) {
         // A state owes nothing before it is written. No transition is refused;
         // see the head of this module for why the diagram's undrawn arrow is
         // not a prohibition.
-        (EntityType::Campaign | EntityType::Arc | EntityType::Quest, STATE) => Ok(None),
+        (EntityType::Campaign | EntityType::Arc | EntityType::Quest, STATE) => Ok(Vec::new()),
         (EntityType::Arc, ARC_CAMPAIGN) => {
             parent_placement(ctx, entity, kind, part, EntityType::Campaign).await
         }
@@ -575,7 +634,7 @@ pub async fn validate_and_place(
         }
         // Stored and never interpreted, because the routine it would name has
         // no table to be checked against. See the head of this module.
-        (EntityType::Quest, QUEST_ROUTINE) => Ok(None),
+        (EntityType::Quest, QUEST_ROUTINE) => Ok(Vec::new()),
         (EntityType::Arc, ARC_POSITION) | (EntityType::Quest, QUEST_POSITION) => {
             Err(explicit_position_refusal().into())
         }
@@ -626,28 +685,21 @@ pub async fn apply(
             }
             Ok(())
         }
+        // An arc has one parent and nothing to displace.
         (EntityType::Arc, ARC_CAMPAIGN) => {
-            write_parent(
-                ctx,
-                entity,
-                "UPDATE arc SET campaign_id = $2, ladder_position = $3 WHERE entity_id = $1",
-                part,
-                placement,
-            )
-            .await
+            write_parent(ctx, entity, kind, CAMPAIGN_COLUMN, None, part, placement).await
         }
+        // Setting one ladder parent clears the other, in the same statement and
+        // for the same reason the position moves in it: the row may never hold
+        // two. Clearing this one leaves the other alone, because clearing an arc
+        // a quest never had is not a request to detach it from its campaign.
         (EntityType::Quest, QUEST_ARC) => {
-            // Setting one ladder parent clears the other, in the same statement
-            // and for the same reason the position moves in it: the row may
-            // never hold two. Clearing this one leaves the other alone, because
-            // clearing an arc a quest never had is not a request to detach it
-            // from its campaign.
             write_parent(
                 ctx,
                 entity,
-                "UPDATE quest SET arc_id = $2, \
-                 campaign_id = CASE WHEN $2::uuid IS NULL THEN campaign_id ELSE NULL END, \
-                 ladder_position = $3 WHERE entity_id = $1",
+                kind,
+                ARC_COLUMN,
+                Some(CAMPAIGN_COLUMN),
                 part,
                 placement,
             )
@@ -657,9 +709,9 @@ pub async fn apply(
             write_parent(
                 ctx,
                 entity,
-                "UPDATE quest SET campaign_id = $2, \
-                 arc_id = CASE WHEN $2::uuid IS NULL THEN arc_id ELSE NULL END, \
-                 ladder_position = $3 WHERE entity_id = $1",
+                kind,
+                CAMPAIGN_COLUMN,
+                Some(ARC_COLUMN),
                 part,
                 placement,
             )
@@ -680,20 +732,41 @@ pub async fn apply(
 
 /// Write a ladder parent and the position that belongs with it, in one
 /// statement.
+///
+/// `sibling` is the other parent column where the type has one, cleared in this
+/// same statement because the row may never hold two. It is left alone when the
+/// addressed parent is being cleared: clearing a parent a quest never had is not
+/// a request to detach it from the one it does have.
 async fn write_parent(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
-    sql: &'static str,
+    kind: EntityType,
+    column: &'static str,
+    sibling: Option<&'static str>,
     part: &SpecificPart,
     placement: Option<&SpecificPart>,
 ) -> Applied<()> {
     let SpecificValue::Id(parent) = part.value else {
         return Err(Refusal::Malformed("a ladder parent is an identifier".into()).into());
     };
-    // The companion is produced by `parent_placement` for every parent part, so
-    // an absent one means this file has grown a second path into the column.
-    let position = match placement.map(|p| &p.value) {
-        Some(SpecificValue::Count(p)) => *p,
+    // **The companion is identified by field number, not by having arrived.**
+    // `parent_placement` can return two — the position and a vacated parent —
+    // and the dispatch hands a narrow lane only the first, so this checks that
+    // what arrived is the position rather than assuming it. An absent or
+    // mismatched companion means the ordering there changed, or that this file
+    // has grown a second path into the column; either is a refusal somebody
+    // sees rather than a position silently written from the wrong part.
+    let expected = position_field(kind);
+    let position = match placement {
+        Some(p) if p.field == expected => match p.value {
+            SpecificValue::Count(v) => v,
+            _ => {
+                return Err(Refusal::Malformed(
+                    "a ladder position is a whole number of places".into(),
+                )
+                .into());
+            }
+        },
         _ => {
             return Err(Refusal::Malformed(
                 "a ladder parent moves with the position that belongs to it".into(),
@@ -701,6 +774,15 @@ async fn write_parent(
             .into());
         }
     };
+    let table = table_of(kind)?;
+    let clear_sibling = match sibling {
+        Some(other) => format!("{other} = CASE WHEN $2::uuid IS NULL THEN {other} ELSE NULL END, "),
+        None => String::new(),
+    };
+    let sql = format!(
+        "UPDATE {table} SET {column} = $2, {clear_sibling}{LADDER_POSITION_COLUMN} = $3 \
+         WHERE entity_id = $1"
+    );
     sqlx::query(sqlx::AssertSqlSafe(sql))
         .bind(entity.as_uuid())
         .bind(parent)
@@ -721,6 +803,96 @@ fn unknown_field(kind: EntityType, part: &SpecificPart) -> Refusal {
         part.field,
         type_name(kind)
     ))
+}
+
+// ---------------------------------------------------------------------------
+// What an erased ladder container lets go of
+// ---------------------------------------------------------------------------
+
+/// Release everything that hung beneath an erased campaign or arc.
+///
+/// # Erasure only, never removal
+///
+/// **Removal is recoverable and grouped**, and 2.1 retains the grouping so that
+/// restoring one member of an act brings back the rest. A removed campaign is
+/// coming back; a child detached on removal would come back parentless with its
+/// position forgotten, which quietly destroys the thing the deletion group
+/// exists to preserve. Erasure is the case with no prompt, no group and no
+/// return — the container is gone for everybody and permanently — which is what
+/// makes detaching correct there and only there. 2.1 placed `uncategorise_all`
+/// the same way, on the erase path and not on remove.
+///
+/// The PRD's *"the children survive as standalone quests and arcs"* is about the
+/// **declines** branch of a deletion prompt, where the person has chosen that
+/// they stand alone. It is not a licence to detach whenever a parent leaves.
+///
+/// # A detached child is parentless, not promoted
+///
+/// A quest whose arc is erased does **not** inherit that arc's campaign, even
+/// though the campaign usually still exists. Promotion would be the system
+/// moving something into a container the person never put it in, and appending
+/// it at the end of an order they did not choose — which is the one thing the
+/// substrate's Arrangement rules refuse to do anywhere else. The PRD agrees:
+/// *"nothing required them to have one in the first place, and they remain
+/// reachable rather than stranded inside something that is gone."*
+///
+/// # Deliberately unscoped
+///
+/// The reason [`crate::store::entity::uncategorise_all`] gives, and it is no
+/// smaller here: **the container is gone for everybody.** Leaving behind the
+/// children the erasing member cannot see would keep a dangling reference alive
+/// precisely where nobody can find it. Nothing leaves this function that a
+/// caller can show anyone — the identities become change entries, and those are
+/// assembled per member by the read path, which applies the predicate then.
+/// Do not add a predicate here.
+///
+/// # Why the position moves with the parent
+///
+/// Same reason as everywhere else in this file: an arc's
+/// `CHECK ((campaign_id IS NULL) = (ladder_position IS NULL))` and a quest's
+/// `CHECK ((num_nonnulls(arc_id, campaign_id) = 0) = (ladder_position IS NULL))`
+/// tie the two together, so a release that cleared only the parent would trip
+/// the check on the way. A quest beneath an arc holds no campaign and a quest
+/// beneath a campaign holds no arc, so nulling the addressed parent always takes
+/// the row to no parent at all, and the position must go with it.
+///
+/// The counter and the change entry are
+/// [`crate::store::entity::detached_from_container`]'s, because a change entry
+/// needs the audience and this file may not name that column.
+pub async fn detach_contained(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+) -> Applied<Detachment> {
+    // Which child tables carry a column naming this kind of container. A
+    // campaign is one container over mixed kinds, so it releases across both.
+    let children: &[(EntityType, &str)] = match kind {
+        EntityType::Campaign => &[
+            (EntityType::Arc, CAMPAIGN_COLUMN),
+            (EntityType::Quest, CAMPAIGN_COLUMN),
+        ],
+        EntityType::Arc => &[(EntityType::Quest, ARC_COLUMN)],
+        // A quest is a leaf of the ladder: nothing names one as a parent, and
+        // nothing ever will.
+        _ => return Ok(Detachment::NoContainer),
+    };
+
+    let mut released = Vec::new();
+    for (child, column) in children {
+        let table = table_of(*child)?;
+        let sql = format!(
+            "UPDATE {table} SET {column} = NULL, {LADDER_POSITION_COLUMN} = NULL \
+             WHERE {column} = $1 RETURNING entity_id"
+        );
+        let rows = sqlx::query(sqlx::AssertSqlSafe(sql))
+            .bind(entity.as_uuid())
+            .fetch_all(ctx.tx.conn())
+            .await?;
+        for r in &rows {
+            released.push(EntityId::from_uuid(r.try_get("entity_id")?));
+        }
+    }
+    Ok(Detachment::Released(released))
 }
 
 /// Guidance contributes nothing to searchable text.

--- a/crates/altaird/src/write/specific/guidance.rs
+++ b/crates/altaird/src/write/specific/guidance.rs
@@ -241,7 +241,12 @@ pub fn quest(c: &v1::QuestContent) -> Result<Written, Malformed> {
     read.singular(&mut parts, QUEST_ARC, arc_id, id_value)?;
     read.singular(&mut parts, QUEST_CAMPAIGN, campaign_id, id_value)?;
     read.singular(&mut parts, QUEST_ROUTINE, c.routine_id.as_ref(), id_value)?;
-    read.singular(&mut parts, QUEST_POSITION, c.ladder_position, position_value)?;
+    read.singular(
+        &mut parts,
+        QUEST_POSITION,
+        c.ladder_position,
+        position_value,
+    )?;
     read.singular(&mut parts, STATE, c.state, state_value)?;
     Ok(Written::from_specific(parts))
 }
@@ -516,7 +521,14 @@ async fn start_container(ctx: &mut Ctx<'_>, row: &EntityRow) -> Applied<()> {
         .bind(ctx.at)
         .execute(ctx.tx.conn())
         .await?;
-    provenance::record(ctx.tx, row.id, &[Part::Specific(STATE)], counter, ctx.member).await?;
+    provenance::record(
+        ctx.tx,
+        row.id,
+        &[Part::Specific(STATE)],
+        counter,
+        ctx.member,
+    )
+    .await?;
 
     // Audience did not move, so both sides of the pair are what it already was.
     // The entry still has to exist: to every member who can see this container,

--- a/crates/altaird/src/write/specific/guidance.rs
+++ b/crates/altaird/src/write/specific/guidance.rs
@@ -101,8 +101,8 @@ use super::super::entity::{Applied, Ctx, Refusal, type_name};
 use super::super::parts::Part;
 use super::super::provenance;
 use super::{
-    Detachment, Field, GuidanceState, Held, Reader, SpecificPart, SpecificValue, read_column,
-    write_column,
+    Detachment, Field, GuidanceState, Held, Reader, Released, SpecificPart, SpecificValue,
+    read_column, write_column,
 };
 
 /// The state field. **The same number in all three messages**, which is what
@@ -880,6 +880,14 @@ pub async fn detach_contained(
     let mut released = Vec::new();
     for (child, column) in children {
         let table = table_of(*child)?;
+        // **Which part moved is read out of the declaration, not written here.**
+        // A release advances the child's counter, so it owes provenance, and
+        // provenance needs the part. The `FIELDS` lists above already say which
+        // field each column holds and `tests/type_content.rs` checks them
+        // against the store; naming the number again beside the statement would
+        // put it in two places, and the copy that drifts is the one nothing
+        // checks. The same reasoning that gave `would_cycle` one implementation.
+        let part = part_held_in(*child, column)?;
         let sql = format!(
             "UPDATE {table} SET {column} = NULL, {LADDER_POSITION_COLUMN} = NULL \
              WHERE {column} = $1 RETURNING entity_id"
@@ -889,10 +897,34 @@ pub async fn detach_contained(
             .fetch_all(ctx.tx.conn())
             .await?;
         for r in &rows {
-            released.push(EntityId::from_uuid(r.try_get("entity_id")?));
+            released.push(Released {
+                entity: EntityId::from_uuid(r.try_get("entity_id")?),
+                part: part.clone(),
+            });
         }
     }
     Ok(Detachment::Released(released))
+}
+
+/// The part of a type's message that a column holds.
+///
+/// One lookup over the type's own [`Field`] declarations, so a column and the
+/// field number that names it cannot disagree. `None` is impossible for the
+/// three columns [`detach_contained`] asks about — each is declared — and is a
+/// refusal rather than a panic because everything else in this file answers
+/// that way.
+fn part_held_in(kind: EntityType, column: &str) -> Applied<Part> {
+    super::fields(kind)
+        .iter()
+        .find(|f| matches!(f.held, Held::Column(c) if c == column))
+        .map(|f| Part::Specific(f.number))
+        .ok_or_else(|| {
+            Refusal::Malformed(format!(
+                "no field of a {} is held in {column}",
+                type_name(kind)
+            ))
+            .into()
+        })
 }
 
 /// Guidance contributes nothing to searchable text.

--- a/crates/altaird/src/write/specific/guidance.rs
+++ b/crates/altaird/src/write/specific/guidance.rs
@@ -1,40 +1,126 @@
 //! Guidance's type content: campaign, arc, quest.
 //!
-//! **LANE: Guidance owns this file.** Campaign's `state` is filled in as the
-//! spine's proof that a type-specific part reaches the store, conflicts, and
-//! comes back; arc and quest are declared and refused.
+//! **LANE: Guidance owns this file.** Three types, one state enum, and one
+//! container — the ladder — that the shared model does not cover.
+//!
+//! # The states, and why nothing here refuses a transition
+//!
+//! The shipped set is waiting, working, worked, and the PRD is explicit that a
+//! person may rename them but may not add, remove, reorder, or define their
+//! own. That is settled and the store's enum is the whole of it.
+//!
+//! **No transition is refused, and that is a decision rather than an omission.**
+//! The PRD's state diagram draws five movements between the three states and
+//! leaves worked → waiting undrawn. Read as a prohibition it would make one
+//! write a rejection, and three things say it is not:
+//!
+//! - **No prose forbids it.** The diagram's neighbouring prose constrains the
+//!   *set* of states and the one upward movement below; it says nothing about
+//!   which movements a person may make. A rule this file invented from an
+//!   undrawn arrow would be a rule nothing normative states.
+//! - **The substrate does not reject well-formed writes.** A device that was
+//!   away replays what the person did, and the only ways a write does not land
+//!   are that the content cannot be read or that the entity is not available.
+//!   "The person moved this the wrong way round" is neither.
+//! - **The spine already relies on it.** Clearing the state field sets it back
+//!   to waiting, because the column is `NOT NULL DEFAULT 'waiting'`; a worked
+//!   campaign whose state is cleared therefore performs exactly the undrawn
+//!   movement, and `tests/type_content.rs` has asserted since 2.2's spine that
+//!   it arrives at waiting.
+//!
+//! `tests/type_content_guidance.rs` walks every movement the diagram draws and
+//! names the undrawn one, so the reading is visible rather than inferred from
+//! an absence of code.
+//!
+//! # The one upward movement
+//!
+//! Starting a quest moves the containers above it from waiting to working, and
+//! it happens silently. [`propagate_start_upward`] is the whole of it, and each
+//! clause of the PRD's narrowing has its own test.
+//!
+//! # The ladder is a container, and Arrangement is where its rules come from
+//!
+//! **Two documents disagree about where the ladder's ordering rules live, and
+//! this file does not resolve it.** The substrate spec's *Arrangement* section
+//! says the ladder defines its own order "in the Guidance PRD"; the Guidance
+//! PRD says a campaign's mixed-kind order "needs nothing of its own" and then
+//! defines no rules. Something has to be implemented, so this file implements
+//! **Arrangement's**: entering a container appends at the end, leaving forgets
+//! the position, no container is unordered, and the order is total and stable.
+//! That is the reading that leaves nothing undefined, and it is what the PRD's
+//! "nothing of its own" most plausibly means — the ladder needs no ordering
+//! rules *because the substrate's already cover it*.
+//!
+//! **A campaign is one container over mixed kinds.** Arcs and quests beneath
+//! one campaign are ordered together, in one sequence spanning two tables,
+//! which is why the order cannot be a unique constraint and why
+//! [`next_ladder_position`] takes a maximum across both.
 //!
 //! # What is deliberately not here
 //!
-//! **The Guidance state machine.** Which transitions are legal, the silent
-//! upward `Waiting → Working` propagation when something beneath starts, and
-//! what a state means for the ladder are all the Guidance PRD's and the
-//! Guidance lane's. Nothing below checks a transition, and that is not an
-//! omission: the spine is proving that a value crosses the boundary intact, and
-//! a rule bolted on here would be a rule written by whoever was proving the
-//! plumbing.
+//! - **Explicit reordering.** Appending is what a container entry does; a
+//!   client stating a `ladder_position` is refused as malformed, in the
+//!   register of the three refusals Wave 2.1 makes that expire when a named
+//!   lane lands. See [`explicit_position_refusal`].
+//! - **Recurrence.** `quest.routine_id` is a column with no `routine` table
+//!   behind it, because the scope defers routines. The field is read and stored
+//!   and **nothing interprets it**; whatever builds recurrence owes the
+//!   reference check that no foreign key can make today. The PRD's clause that
+//!   *a recurrence is not a container for this* is therefore moot rather than
+//!   implemented: nothing here walks a routine, so nothing can propagate
+//!   through one.
+//! - **The prompts on a parent reaching the terminal state, and on deleting
+//!   one.** The PRD asks about the children and the person answers. That is a
+//!   client behaviour and there is no client until Wave 4, so this file neither
+//!   prompts nor cascades — a silent cascade would be the exact thing the PRD
+//!   rules out, and building half of it now would foreclose the question.
+//! - **Two open questions the PRD holds, which nothing here closes:** the exact
+//!   inflections of the state names, and the absence of any mechanism for
+//!   ordering one quest against another outside a container.
 //!
-//! What is settled, and is the plumbing's own answer rather than the domain's:
-//! **clearing a state sets it to waiting**, because the column is
+//! # What is settled by the plumbing rather than by the domain
+//!
+//! **Clearing a state sets it to waiting**, because the column is
 //! `NOT NULL DEFAULT 'waiting'` and there is no state a campaign is not in. Two
 //! members arriving at waiting — one by setting it, one by clearing it —
 //! therefore compare equal rather than conflict, which is the substrate's rule
 //! that writes producing the same value are not divergent.
 
+use sqlx::Row;
+use uuid::Uuid;
+
 use altair_proto::v1;
 
-use crate::store::entity::EntityType;
+use crate::store::WriteScope;
+use crate::store::entity::{EntityRow, EntityType, available_for_write};
 use crate::store::ids::EntityId;
 
-use super::super::content::{Malformed, Written};
-use super::super::entity::{Applied, Ctx, Refusal};
+use super::super::changes::{self, EntityChange};
+use super::super::content::{Malformed, Written, identifier, malformed};
+use super::super::entity::{Applied, Ctx, Refusal, type_name};
+use super::super::parts::Part;
+use super::super::provenance;
 use super::{
-    Field, GuidanceState, Held, Reader, SpecificPart, SpecificValue, not_yet_built, read_column,
-    unbuilt, write_column,
+    Field, GuidanceState, Held, Reader, SpecificPart, SpecificValue, read_column, write_column,
 };
 
+/// The state field. **The same number in all three messages**, which is what
+/// lets one propagation record a container's movement without asking which kind
+/// of container it reached.
+pub const STATE: u32 = 1;
+
 /// Campaign's field 1, its state. The only part a campaign carries.
-pub const CAMPAIGN_STATE: u32 = 1;
+pub const CAMPAIGN_STATE: u32 = STATE;
+
+/// An arc's campaign, and its position beneath it.
+const ARC_CAMPAIGN: u32 = 2;
+const ARC_POSITION: u32 = 3;
+
+/// A quest's two possible ladder parents, its routine, and its position.
+const QUEST_ARC: u32 = 2;
+const QUEST_CAMPAIGN: u32 = 3;
+const QUEST_ROUTINE: u32 = 4;
+const QUEST_POSITION: u32 = 5;
 
 pub const CAMPAIGN_FIELDS: &[Field] = &[Field {
     number: CAMPAIGN_STATE,
@@ -43,101 +129,417 @@ pub const CAMPAIGN_FIELDS: &[Field] = &[Field {
 
 pub const ARC_FIELDS: &[Field] = &[
     Field {
-        number: 1,
+        number: STATE,
         held: Held::Column("state"),
     },
     Field {
-        number: 2,
+        number: ARC_CAMPAIGN,
         held: Held::Column("campaign_id"),
     },
     Field {
-        number: 3,
+        number: ARC_POSITION,
         held: Held::Column("ladder_position"),
     },
 ];
 
 pub const QUEST_FIELDS: &[Field] = &[
     Field {
-        number: 1,
+        number: STATE,
         held: Held::Column("state"),
     },
     Field {
-        number: 2,
+        number: QUEST_ARC,
         held: Held::Column("arc_id"),
     },
     Field {
-        number: 3,
+        number: QUEST_CAMPAIGN,
         held: Held::Column("campaign_id"),
     },
     Field {
-        number: 4,
+        number: QUEST_ROUTINE,
         held: Held::Column("routine_id"),
     },
     Field {
-        number: 5,
+        number: QUEST_POSITION,
         held: Held::Column("ladder_position"),
     },
 ];
+
+// ---------------------------------------------------------------------------
+// Reading the three messages
+// ---------------------------------------------------------------------------
+
+/// The state a wire field names, resolving a clear to the column's default.
+fn state_value(v: Option<i32>) -> Result<SpecificValue, Malformed> {
+    Ok(SpecificValue::State(match v {
+        Some(number) => GuidanceState::from_wire(number)?,
+        None => GuidanceState::DEFAULT,
+    }))
+}
+
+/// An identifier a wire field names, or nothing where it was cleared.
+fn id_value(v: Option<&Vec<u8>>) -> Result<SpecificValue, Malformed> {
+    Ok(SpecificValue::Id(
+        v.map(|bytes| identifier(bytes)).transpose()?,
+    ))
+}
+
+/// A position a client stated, which is refused later and read here so that the
+/// refusal is about reordering rather than about the number's width.
+fn position_value(v: Option<u32>) -> Result<SpecificValue, Malformed> {
+    Ok(SpecificValue::Count(
+        v.map(|p| i32::try_from(p).map_err(|_| malformed("a position that large is not one")))
+            .transpose()?,
+    ))
+}
 
 /// A campaign's content, off the wire.
 pub fn campaign(c: &v1::CampaignContent) -> Result<Written, Malformed> {
     let read = Reader::new(EntityType::Campaign, &c.cleared)?;
     let mut parts = Vec::new();
-    read.singular(&mut parts, CAMPAIGN_STATE, c.state, |v| {
-        Ok(SpecificValue::State(match v {
-            Some(number) => GuidanceState::from_wire(number)?,
-            None => GuidanceState::DEFAULT,
-        }))
-    })?;
+    read.singular(&mut parts, CAMPAIGN_STATE, c.state, state_value)?;
     Ok(Written::from_specific(parts))
 }
 
 /// An arc's content, off the wire.
 ///
-/// **LANE: Guidance.** The campaign it hangs beneath and its position on the
-/// ladder are here, and the ladder is a container the shared model does not
-/// cover: entering one appends, exactly as entering a category does, which is
-/// why `campaign_id` and `ladder_position` must move in one statement — the
-/// table's `CHECK ((campaign_id IS NULL) = (ladder_position IS NULL))` refuses
-/// the state in between. [`validate_and_place`] is where that companion is
-/// produced.
+/// **The parent is read before the state, and the order is load-bearing.** A
+/// write applies parts in the order this list gives them, and the upward
+/// propagation a state can trigger asks the store which container the entity is
+/// beneath. Reading the state first would mean a quest created already started
+/// beneath a campaign moved nothing, because at the moment its state landed it
+/// would have had no parent yet. The same order is used here so that all three
+/// messages read the same way.
 pub fn arc(c: &v1::ArcContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::Arc,
-        &c.cleared,
-        &[
-            (1, c.state.is_some()),
-            (2, c.campaign_id.is_some()),
-            (3, c.ladder_position.is_some()),
-        ],
-    )
+    let read = Reader::new(EntityType::Arc, &c.cleared)?;
+    let mut parts = Vec::new();
+    read.singular(&mut parts, ARC_CAMPAIGN, c.campaign_id.as_ref(), id_value)?;
+    read.singular(&mut parts, ARC_POSITION, c.ladder_position, position_value)?;
+    read.singular(&mut parts, STATE, c.state, state_value)?;
+    Ok(Written::from_specific(parts))
 }
 
 /// A quest's content, off the wire.
 ///
-/// **LANE: Guidance.** At most one ladder parent in total, an arc or a
-/// campaign, never both — the wire says so with a `oneof` and the table says so
-/// with `CHECK (num_nonnulls(arc_id, campaign_id) <= 1)`. Moving between them
-/// clears the other, and both move with `ladder_position`.
+/// **At most one ladder parent in total**, an arc or a campaign, never both:
+/// the wire says so with a `oneof` and the table says so with
+/// `CHECK (num_nonnulls(arc_id, campaign_id) <= 1)`. The `oneof` means one
+/// message can only ever *set* one of the two, so they are separate parts here
+/// and setting either clears the other where it is applied.
 pub fn quest(c: &v1::QuestContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::Quest,
-        &c.cleared,
-        &[
-            (1, c.state.is_some()),
-            (
-                2,
-                matches!(c.parent, Some(v1::quest_content::Parent::ArcId(_))),
-            ),
-            (
-                3,
-                matches!(c.parent, Some(v1::quest_content::Parent::CampaignId(_))),
-            ),
-            (4, c.routine_id.is_some()),
-            (5, c.ladder_position.is_some()),
-        ],
+    use v1::quest_content::Parent;
+    let read = Reader::new(EntityType::Quest, &c.cleared)?;
+    let mut parts = Vec::new();
+    let arc_id = match &c.parent {
+        Some(Parent::ArcId(id)) => Some(id),
+        _ => None,
+    };
+    let campaign_id = match &c.parent {
+        Some(Parent::CampaignId(id)) => Some(id),
+        _ => None,
+    };
+    read.singular(&mut parts, QUEST_ARC, arc_id, id_value)?;
+    read.singular(&mut parts, QUEST_CAMPAIGN, campaign_id, id_value)?;
+    read.singular(&mut parts, QUEST_ROUTINE, c.routine_id.as_ref(), id_value)?;
+    read.singular(&mut parts, QUEST_POSITION, c.ladder_position, position_value)?;
+    read.singular(&mut parts, STATE, c.state, state_value)?;
+    Ok(Written::from_specific(parts))
+}
+
+// ---------------------------------------------------------------------------
+// The ladder
+// ---------------------------------------------------------------------------
+
+/// Where an entity sits on the ladder, as its own side table holds it.
+#[derive(Debug, Clone, Copy, Default)]
+struct Ladder {
+    arc: Option<Uuid>,
+    campaign: Option<Uuid>,
+    position: Option<i32>,
+}
+
+impl Ladder {
+    /// The parent to climb from, arc first because a quest beneath an arc is
+    /// beneath that arc's campaign only through the arc.
+    fn parent(self) -> Option<EntityId> {
+        self.arc.or(self.campaign).map(EntityId::from_uuid)
+    }
+}
+
+/// Read one entity's ladder placement.
+///
+/// A campaign has none — it is a container and never a child — so it answers
+/// with the empty placement rather than being refused.
+async fn ladder_of(ctx: &mut Ctx<'_>, entity: EntityId, kind: EntityType) -> Applied<Ladder> {
+    let sql = match kind {
+        EntityType::Arc => {
+            "SELECT NULL::uuid AS arc_id, campaign_id, ladder_position FROM arc WHERE entity_id = $1"
+        }
+        EntityType::Quest => {
+            "SELECT arc_id, campaign_id, ladder_position FROM quest WHERE entity_id = $1"
+        }
+        _ => return Ok(Ladder::default()),
+    };
+    let row = sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(entity.as_uuid())
+        .fetch_optional(ctx.tx.conn())
+        .await?;
+    let Some(row) = row else {
+        return Ok(Ladder::default());
+    };
+    Ok(Ladder {
+        arc: row.try_get("arc_id")?,
+        campaign: row.try_get("campaign_id")?,
+        position: row.try_get("ladder_position")?,
+    })
+}
+
+/// The next position beneath a container, which is one past the last.
+///
+/// **A campaign's order spans two tables.** Arcs and quests beneath one
+/// campaign are one sequence, so the maximum is taken across both and the order
+/// cannot be a unique constraint. An arc holds only quests.
+///
+/// **Deliberately unscoped by audience**, for exactly the reason
+/// `store::entity::next_category_position` records: this produces an integer
+/// and no content, and a maximum taken over only the entities the writing
+/// member can see would hand out a position already held by one they cannot, so
+/// two entities would share a position and the order would stop being total.
+/// That is a correctness failure produced by applying an access rule to
+/// something that is not an access question.
+async fn next_ladder_position(
+    ctx: &mut Ctx<'_>,
+    container: EntityId,
+    kind: EntityType,
+) -> Applied<i32> {
+    let sql = match kind {
+        EntityType::Campaign => {
+            "SELECT coalesce(max(p), -1) + 1 AS next FROM ( \
+               SELECT ladder_position AS p FROM arc WHERE campaign_id = $1 \
+               UNION ALL \
+               SELECT ladder_position AS p FROM quest WHERE campaign_id = $1 \
+             ) AS beneath"
+        }
+        EntityType::Arc => {
+            "SELECT coalesce(max(ladder_position), -1) + 1 AS next FROM quest WHERE arc_id = $1"
+        }
+        // Nothing else is a ladder container, and the typed foreign keys refuse
+        // one. Reached only if this file grows a caller it should not have.
+        _ => return Err(Refusal::NotAvailable.into()),
+    };
+    let row = sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(container.as_uuid())
+        .fetch_one(ctx.tx.conn())
+        .await?;
+    Ok(row.try_get("next")?)
+}
+
+/// The position field of the type whose parent is being written.
+fn position_field(kind: EntityType) -> u32 {
+    match kind {
+        EntityType::Arc => ARC_POSITION,
+        _ => QUEST_POSITION,
+    }
+}
+
+/// **An expiring refusal, in the register of the three Wave 2.1 makes.**
+///
+/// Wave 2.1 refuses an explicit `category_position` in the same words and for
+/// the same reason: appending is the only placement an entry performs, and
+/// reordering is a deliberate act on a surface with the container in front of
+/// the person. Neither exists until something reorders.
+fn explicit_position_refusal() -> Refusal {
+    Refusal::Malformed(
+        "a position on the ladder is assigned by the instance, which appends on entry to a \
+         container; explicit reordering is not served yet"
+            .into(),
     )
 }
+
+/// The ladder position a parent part carries with it.
+///
+/// **The parent and the position are one movement.** Both of the schema's
+/// checks tie them together — an arc's
+/// `CHECK ((campaign_id IS NULL) = (ladder_position IS NULL))` and a quest's
+/// `CHECK ((num_nonnulls(arc_id, campaign_id) = 0) = (ladder_position IS NULL))`
+/// — so writing them in sequence puts the row through a state the schema
+/// refuses, whichever order the sequence is in. This is the same shape
+/// `write::entity` solves for a category and its position, and the companion
+/// travels the same channel.
+async fn parent_placement(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+    part: &SpecificPart,
+    container_kind: EntityType,
+) -> Applied<Option<SpecificPart>> {
+    let SpecificValue::Id(target) = part.value else {
+        return Err(Refusal::Malformed("a ladder parent is an identifier".into()).into());
+    };
+    let ladder = ladder_of(ctx, entity, kind).await?;
+    let position = |p: Option<i32>| {
+        Some(SpecificPart {
+            field: position_field(kind),
+            value: SpecificValue::Count(p),
+        })
+    };
+
+    let Some(target) = target else {
+        // Leaving a container forgets the position — unless the *other* parent
+        // column still holds one. Clearing an arc a quest never had must not
+        // strip the position its campaign gave it.
+        let other = match (kind, container_kind) {
+            (EntityType::Quest, EntityType::Arc) => ladder.campaign,
+            (EntityType::Quest, EntityType::Campaign) => ladder.arc,
+            _ => None,
+        };
+        return Ok(position(other.and(ladder.position)));
+    };
+
+    // The container has to be one this member can see, and it has to be the
+    // right kind of container. Both refusals are the same nothing, which is
+    // what makes refusal on audience indistinguishable from refusal on
+    // nonexistence.
+    let target = EntityId::from_uuid(target);
+    let found = available_for_write(ctx.tx, ctx.member, target, WriteScope::Active)
+        .await?
+        .ok_or(Refusal::NotAvailable)?;
+    if found.entity_type != container_kind {
+        return Err(Refusal::NotAvailable.into());
+    }
+    // A cycle is not reachable here and needs no check: a campaign has no
+    // parent, an arc's only parent is a campaign, and a quest is never a
+    // container. The typed foreign keys refuse anything else.
+
+    let already = match container_kind {
+        EntityType::Arc => ladder.arc,
+        _ => ladder.campaign,
+    };
+    if already == Some(target.as_uuid()) {
+        // Not an entry. The position stands, and is handed back anyway so the
+        // parent and the position still move in one statement.
+        return Ok(position(ladder.position));
+    }
+    let next = next_ladder_position(ctx, target, container_kind).await?;
+    Ok(position(Some(next)))
+}
+
+// ---------------------------------------------------------------------------
+// The one upward movement
+// ---------------------------------------------------------------------------
+
+/// Starting a quest moves the containers above it from waiting to working.
+///
+/// Every clause of the PRD's narrowing is a line of this function, and
+/// `tests/type_content_guidance.rs` has a test per clause:
+///
+/// - **Waiting to working only, and never in reverse.** [`start_container`]
+///   writes nothing unless it finds waiting.
+/// - **Upward only.** Nothing here reads a container's children.
+/// - **It never touches a parent already in the terminal state**, because a
+///   stray child would silently reopen something the person deliberately
+///   closed.
+/// - **It climbs the whole chain, skipping any container already working**, and
+///   a quest attached directly to a campaign moves that campaign because
+///   attachment need not be adjacent. The clauses are stated per parent, so a
+///   worked arc is left alone *and the climb continues past it*: nothing says a
+///   campaign's movement depends on the state of the arc below it.
+/// - **A recurrence is not a container for this.** Nothing here walks
+///   `routine_id`, so nothing can.
+///
+/// **Only a quest's own state triggers this.** The PRD names the trigger
+/// exactly once — *starting a quest moves the containers above it* — and every
+/// clause of the narrowing is written about a quest. An arc set to working by
+/// hand therefore moves nothing, and a working quest *moved into* a waiting
+/// container moves nothing either: neither is somebody starting work. Both are
+/// the drift the PRD accepts as this rule's cost, and closing them would be
+/// this file deciding something the PRD did not.
+///
+/// **The climb stops at a container this member cannot see.** The chain is
+/// followed through each container's own row, and moving a state on an entity
+/// the writer is not entitled to see would attribute a write — in provenance
+/// and in the change sequence — to a member who cannot see what they moved.
+///
+/// **A container this moves gets a counter and a change entry of its own.** The
+/// state is a part like any other: a part that does not record the counter it
+/// moved at is invisible to conflict detection, and a movement nothing records
+/// is one no client ever learns about.
+async fn propagate_start_upward(ctx: &mut Ctx<'_>, quest: EntityId) -> Applied<()> {
+    let mut next = ladder_of(ctx, quest, EntityType::Quest).await?.parent();
+    while let Some(id) = next {
+        let Some(row) = available_for_write(ctx.tx, ctx.member, id, WriteScope::Active).await?
+        else {
+            break;
+        };
+        next = match row.entity_type {
+            EntityType::Arc => {
+                start_container(ctx, &row).await?;
+                ladder_of(ctx, id, EntityType::Arc).await?.parent()
+            }
+            EntityType::Campaign => {
+                start_container(ctx, &row).await?;
+                None
+            }
+            // A ladder parent of any other type is not representable: both
+            // foreign keys carry the container's type.
+            _ => None,
+        };
+    }
+    Ok(())
+}
+
+/// Move one container from waiting to working, or leave it exactly as it is.
+async fn start_container(ctx: &mut Ctx<'_>, row: &EntityRow) -> Applied<()> {
+    let asking = SpecificPart {
+        field: STATE,
+        value: SpecificValue::State(GuidanceState::DEFAULT),
+    };
+    let current = read_column(ctx, row.id, row.entity_type, &asking).await?;
+    if current.value != SpecificValue::State(GuidanceState::Waiting) {
+        // Already working, so there is nothing to do; or already worked, which
+        // this movement never touches.
+        return Ok(());
+    }
+
+    let working = SpecificPart {
+        field: STATE,
+        value: SpecificValue::State(GuidanceState::Working),
+    };
+    write_column(ctx, row.id, row.entity_type, &working).await?;
+
+    // The counter advances because this is an accepted write to that entity,
+    // and a client holding the old one has to learn its state moved.
+    let counter = row.counter + 1;
+    sqlx::query("UPDATE entity SET counter = $2, updated_at = $3 WHERE id = $1")
+        .bind(row.id.as_uuid())
+        .bind(counter)
+        .bind(ctx.at)
+        .execute(ctx.tx.conn())
+        .await?;
+    provenance::record(ctx.tx, row.id, &[Part::Specific(STATE)], counter, ctx.member).await?;
+
+    // Audience did not move, so both sides of the pair are what it already was.
+    // The entry still has to exist: to every member who can see this container,
+    // its state changed.
+    changes::entity_written(
+        ctx.tx,
+        ctx.at,
+        &EntityChange {
+            entity: row.id,
+            audience_before: Some(row.audience.clone()),
+            audience_after: Some(row.audience.clone()),
+            author_before: row.author,
+            author_after: row.author,
+            changed_blocks: Vec::new(),
+        },
+    )
+    .await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The seams the dispatch calls
+// ---------------------------------------------------------------------------
 
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
@@ -145,13 +547,27 @@ pub async fn validate_and_place(
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<Option<SpecificPart>> {
-    let _ = (ctx, entity);
     match (kind, part.field) {
-        // A state owes nothing before it is written. Whether the transition is
-        // legal is the Guidance lane's question and is deliberately not asked
-        // here; see the note at the head of this module.
-        (EntityType::Campaign, CAMPAIGN_STATE) => Ok(None),
-        _ => Err(Refusal::Malformed(not_yet_built(kind).0).into()),
+        // A state owes nothing before it is written. No transition is refused;
+        // see the head of this module for why the diagram's undrawn arrow is
+        // not a prohibition.
+        (EntityType::Campaign | EntityType::Arc | EntityType::Quest, STATE) => Ok(None),
+        (EntityType::Arc, ARC_CAMPAIGN) => {
+            parent_placement(ctx, entity, kind, part, EntityType::Campaign).await
+        }
+        (EntityType::Quest, QUEST_ARC) => {
+            parent_placement(ctx, entity, kind, part, EntityType::Arc).await
+        }
+        (EntityType::Quest, QUEST_CAMPAIGN) => {
+            parent_placement(ctx, entity, kind, part, EntityType::Campaign).await
+        }
+        // Stored and never interpreted, because the routine it would name has
+        // no table to be checked against. See the head of this module.
+        (EntityType::Quest, QUEST_ROUTINE) => Ok(None),
+        (EntityType::Arc, ARC_POSITION) | (EntityType::Quest, QUEST_POSITION) => {
+            Err(explicit_position_refusal().into())
+        }
+        _ => Err(unknown_field(kind, part).into()),
     }
 }
 
@@ -161,9 +577,18 @@ pub async fn current(
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<SpecificPart> {
+    // Every Guidance field is one column of the type's own side table, so the
+    // generic reader serves all of them — including the position, which a
+    // client may not address but which travels as a companion and needs its
+    // stored value read for the same conflict comparison as anything else.
     match (kind, part.field) {
-        (EntityType::Campaign, CAMPAIGN_STATE) => read_column(ctx, entity, kind, part).await,
-        _ => Err(Refusal::Malformed(not_yet_built(kind).0).into()),
+        (EntityType::Campaign, CAMPAIGN_STATE)
+        | (EntityType::Arc, STATE | ARC_CAMPAIGN | ARC_POSITION)
+        | (
+            EntityType::Quest,
+            STATE | QUEST_ARC | QUEST_CAMPAIGN | QUEST_ROUTINE | QUEST_POSITION,
+        ) => read_column(ctx, entity, kind, part).await,
+        _ => Err(unknown_field(kind, part).into()),
     }
 }
 
@@ -175,14 +600,115 @@ pub async fn apply(
     placement: Option<&SpecificPart>,
 ) -> Applied<()> {
     match (kind, part.field) {
-        (EntityType::Campaign, CAMPAIGN_STATE) => {
-            // A campaign has no companion part, so there is nothing to write
-            // alongside. An arc's or a quest's ladder position will be one.
+        (EntityType::Campaign | EntityType::Arc, STATE) => {
+            // Neither is a child of anything that starts, so neither has a
+            // companion and neither propagates.
             debug_assert!(placement.is_none());
             write_column(ctx, entity, kind, part).await
         }
-        _ => Err(Refusal::Malformed(not_yet_built(kind).0).into()),
+        (EntityType::Quest, STATE) => {
+            debug_assert!(placement.is_none());
+            write_column(ctx, entity, kind, part).await?;
+            if part.value == SpecificValue::State(GuidanceState::Working) {
+                propagate_start_upward(ctx, entity).await?;
+            }
+            Ok(())
+        }
+        (EntityType::Arc, ARC_CAMPAIGN) => {
+            write_parent(
+                ctx,
+                entity,
+                "UPDATE arc SET campaign_id = $2, ladder_position = $3 WHERE entity_id = $1",
+                part,
+                placement,
+            )
+            .await
+        }
+        (EntityType::Quest, QUEST_ARC) => {
+            // Setting one ladder parent clears the other, in the same statement
+            // and for the same reason the position moves in it: the row may
+            // never hold two. Clearing this one leaves the other alone, because
+            // clearing an arc a quest never had is not a request to detach it
+            // from its campaign.
+            write_parent(
+                ctx,
+                entity,
+                "UPDATE quest SET arc_id = $2, \
+                 campaign_id = CASE WHEN $2::uuid IS NULL THEN campaign_id ELSE NULL END, \
+                 ladder_position = $3 WHERE entity_id = $1",
+                part,
+                placement,
+            )
+            .await
+        }
+        (EntityType::Quest, QUEST_CAMPAIGN) => {
+            write_parent(
+                ctx,
+                entity,
+                "UPDATE quest SET campaign_id = $2, \
+                 arc_id = CASE WHEN $2::uuid IS NULL THEN arc_id ELSE NULL END, \
+                 ladder_position = $3 WHERE entity_id = $1",
+                part,
+                placement,
+            )
+            .await
+        }
+        (EntityType::Quest, QUEST_ROUTINE) => write_column(ctx, entity, kind, part).await,
+        // Unreachable: `validate_and_place` refuses a client-stated position
+        // before anything is applied, and the instance's own position arrives
+        // as the companion above rather than as a part of its own. Refused
+        // rather than written, so a future caller finds the rule instead of a
+        // silent second path into the column.
+        (EntityType::Arc, ARC_POSITION) | (EntityType::Quest, QUEST_POSITION) => {
+            Err(explicit_position_refusal().into())
+        }
+        _ => Err(unknown_field(kind, part).into()),
     }
+}
+
+/// Write a ladder parent and the position that belongs with it, in one
+/// statement.
+async fn write_parent(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    sql: &'static str,
+    part: &SpecificPart,
+    placement: Option<&SpecificPart>,
+) -> Applied<()> {
+    let SpecificValue::Id(parent) = part.value else {
+        return Err(Refusal::Malformed("a ladder parent is an identifier".into()).into());
+    };
+    // The companion is produced by `parent_placement` for every parent part, so
+    // an absent one means this file has grown a second path into the column.
+    let position = match placement.map(|p| &p.value) {
+        Some(SpecificValue::Count(p)) => *p,
+        _ => {
+            return Err(Refusal::Malformed(
+                "a ladder parent moves with the position that belongs to it".into(),
+            )
+            .into());
+        }
+    };
+    sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(entity.as_uuid())
+        .bind(parent)
+        .bind(position)
+        .execute(ctx.tx.conn())
+        .await?;
+    Ok(())
+}
+
+/// A number that names no field of this type.
+///
+/// [`Reader`] refuses a *cleared* number that names nothing before a part is
+/// ever built, so reaching this means a part was constructed inside the
+/// instance with a number its type does not have.
+fn unknown_field(kind: EntityType, part: &SpecificPart) -> Refusal {
+    Refusal::Malformed(format!(
+        "field {} is not a part of a {}",
+        part.field,
+        type_name(kind)
+    ))
 }
 
 /// Guidance contributes nothing to searchable text.

--- a/crates/altaird/src/write/specific/guidance.rs
+++ b/crates/altaird/src/write/specific/guidance.rs
@@ -880,14 +880,29 @@ pub async fn detach_contained(
     let mut released = Vec::new();
     for (child, column) in children {
         let table = table_of(*child)?;
-        // **Which part moved is read out of the declaration, not written here.**
-        // A release advances the child's counter, so it owes provenance, and
-        // provenance needs the part. The `FIELDS` lists above already say which
-        // field each column holds and `tests/type_content.rs` checks them
-        // against the store; naming the number again beside the statement would
-        // put it in two places, and the copy that drifts is the one nothing
-        // checks. The same reasoning that gave `would_cycle` one implementation.
-        let part = part_held_in(*child, column)?;
+        // **Which parts moved are read out of the declaration, not written
+        // here.** A release advances the child's counter, so it owes
+        // provenance, and provenance needs the parts. The `FIELDS` lists above
+        // already say which field each column holds and `tests/type_content.rs`
+        // checks them against the store; naming the numbers again beside the
+        // statement would put them in two places, and the copy that drifts is
+        // the one nothing checks. The same reasoning that gave `would_cycle`
+        // one implementation.
+        //
+        // **Two columns are cleared, so two parts moved.** The position is not
+        // incidental to the parent going away — it is a part of its own, and a
+        // part that moves a counter without saying so is invisible to conflict
+        // detection. A member holding a base from before the erasure who then
+        // moves the child under a new parent writes the position as a
+        // companion; with only the parent recorded, the two writes overlap on
+        // the position and merge in silence. The membership half of the erase
+        // path records exactly this pair for the same reason — *the category
+        // and the position within it, and both are recorded, because the
+        // counter advanced and something has to be able to say what changed*.
+        let parts = [
+            part_held_in(*child, column)?,
+            part_held_in(*child, LADDER_POSITION_COLUMN)?,
+        ];
         let sql = format!(
             "UPDATE {table} SET {column} = NULL, {LADDER_POSITION_COLUMN} = NULL \
              WHERE {column} = $1 RETURNING entity_id"
@@ -897,10 +912,22 @@ pub async fn detach_contained(
             .fetch_all(ctx.tx.conn())
             .await?;
         for r in &rows {
-            released.push(Released {
-                entity: EntityId::from_uuid(r.try_get("entity_id")?),
-                part: part.clone(),
-            });
+            let child_id = EntityId::from_uuid(r.try_get("entity_id")?);
+            // **Both parts genuinely moved, and the schema is what guarantees
+            // it.** Elsewhere in this file a companion is owed only when the
+            // column it names was actually holding something, because recording
+            // a part that did not move is its own silent fault. No runtime check
+            // is needed here: an arc's `CHECK ((campaign_id IS NULL) =
+            // (ladder_position IS NULL))` and a quest's
+            // `CHECK ((num_nonnulls(arc_id, campaign_id) = 0) = (ladder_position
+            // IS NULL))` mean a row this statement matched had a parent, and so
+            // had a position.
+            for part in &parts {
+                released.push(Released {
+                    entity: child_id,
+                    part: part.clone(),
+                });
+            }
         }
     }
     Ok(Detachment::Released(released))

--- a/crates/altaird/src/write/specific/knowledge.rs
+++ b/crates/altaird/src/write/specific/knowledge.rs
@@ -40,6 +40,7 @@
 //! bytes.
 
 use altair_proto::v1;
+use sqlx::Row;
 
 use crate::store::entity::EntityType;
 use crate::store::ids::EntityId;
@@ -198,23 +199,77 @@ fn unreachable_part(kind: EntityType, part: &SpecificPart) -> Refusal {
     ))
 }
 
+/// The separator the blocks of a body are joined with.
+///
+/// Both indexes treat any run of non-alphanumeric text as a separator, so this
+/// changes nothing about what matches. It is a newline rather than a space
+/// because the column holds plain text that a person may read and an export may
+/// carry, and paragraphs that ran together would be worse to look at for no
+/// gain.
+const BETWEEN_BLOCKS: &str = "\n";
+
 /// What Knowledge contributes to searchable text.
 ///
-/// **LANE: Knowledge.** A note's words are the obvious candidate and they are
-/// deliberately not taken here: a body's blocks are written by
-/// [`super::super::body`], which this lane also fills, and taking half the
-/// answer now would settle the shape of the other half. Contributing nothing is
-/// a valid answer, and the literal arm still finds a note by its title.
+/// # A note's words, because otherwise nothing has them
 ///
-/// A media type is deliberately not contributed either. It is a machine label
-/// rather than the person's words, and putting `image/png` into the text a
-/// literal search matches would make every photograph answer a search for
-/// *image*.
+/// **This is the whole of a note's literal searchability.** Both literal
+/// indexes are on the `entity` row — `entity_search_vector_idx` over the
+/// generated `tsvector` and `entity_search_trgm_idx` over the plain text — and
+/// `block` carries no search index at all. So a body that does not reach
+/// `search_text` reaches no index by any route, and a note captured with three
+/// paragraphs about descaling a kettle would be findable only by its title.
+/// That would make the standing claim false for exactly the type whose whole
+/// content is words: *literal matching is a permanent arm, not a fallback,
+/// which is why a just-captured entity is findable by its words before
+/// derivation runs.*
+///
+/// Migration one's own comment on the column describes this case in as many
+/// words — maintained by the write path "from the title and whatever the type
+/// contributes, because those live in side tables and a generated column cannot
+/// reach them". A body is a side table and this is the seam for it.
+///
+/// # Why the text is copied rather than the blocks indexed
+///
+/// A second index on `block.text` would put the literal arm on two tables with
+/// two candidate sets to fuse, which is the read path's decision at 3.1 and not
+/// one this lane should force. It would also put a candidate set on a table
+/// that carries no audience: the predicate must sit **inside** the candidate
+/// query, and `entity` is where the audience column is. One index on one table
+/// keeps that true without a join.
+///
+/// The cost is that a long body is stored twice. It is real and it is the price
+/// of the two properties above; see the note on refresh cost in the lane's
+/// report.
+///
+/// # What is deliberately still not contributed
+///
+/// **A media type.** It is a machine label rather than the person's words, and
+/// putting `image/png` into the text a literal search matches would make every
+/// photograph answer a search for *image*. A file therefore contributes
+/// nothing, which is still a valid answer.
 pub async fn search_text(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
 ) -> Applied<Option<String>> {
-    let _ = (ctx, entity, kind);
-    Ok(None)
+    if kind != EntityType::Note {
+        return Ok(None);
+    }
+    // In the order the body reads. A set of paragraphs is not a body, and the
+    // column holds text a person may read.
+    let rows = sqlx::query("SELECT text FROM block WHERE entity_id = $1 ORDER BY position")
+        .bind(entity.as_uuid())
+        .fetch_all(ctx.tx.conn())
+        .await?;
+    if rows.is_empty() {
+        // No body is no contribution, not an empty one. `concat_ws` drops a
+        // null, so a note without a body keeps a `search_text` of exactly its
+        // title — which is what it was before this lane filled the seam in.
+        return Ok(None);
+    }
+    let mut words: Vec<String> = Vec::with_capacity(rows.len());
+    for r in &rows {
+        words.push(r.try_get("text")?);
+    }
+    Ok(Some(words.join(BETWEEN_BLOCKS)))
 }

--- a/crates/altaird/src/write/specific/knowledge.rs
+++ b/crates/altaird/src/write/specific/knowledge.rs
@@ -2,17 +2,42 @@
 //!
 //! **LANE: Knowledge owns this file.**
 //!
-//! A note is the one type whose whole content is a body, and a body is not a
-//! part: it divides into blocks and each block is a part of its own. So the
-//! wire reading below produces a [`BodyWrite`] rather than a
-//! [`SpecificPart`], and everything downstream of it lives in
-//! [`super::super::body`] — division, matching against the blocks already held,
-//! and writing only what changed. That split is deliberate: reading the wire
-//! needs no store and the matching needs nothing else.
+//! # A note has no fields of its own, and that is the answer rather than a gap
 //!
-//! A file's content waits on Wave 2.3 in full, because Wave 2.1 refuses a file
-//! create for a reason that has not expired: the schema requires a file to name
-//! a body and there is no way to have uploaded one.
+//! Migration one says it plainly: *"There is no note table. A note holds a body
+//! beyond the shared set, a body is its blocks in order, and there is no second
+//! representation of the same content for them to disagree with."* So a note's
+//! whole content is a body, and a body is not a part: it divides into blocks and
+//! each block is a part of its own. The wire reading below therefore produces a
+//! [`BodyWrite`] rather than a [`SpecificPart`], and everything downstream of it
+//! lives in [`super::super::body`] — division, matching against the blocks
+//! already held, and writing only what changed. That split is deliberate:
+//! reading the wire needs no store and the matching needs nothing else.
+//!
+//! Nothing here writes a block. [`validate_and_place`] and its two companions
+//! can be reached for a note only by a part that cannot be constructed, and they
+//! say so rather than pretending a note's content is unbuilt.
+//!
+//! # A file is mostly two other lanes'
+//!
+//! Of the three fields the wire gives a file, one is served here:
+//!
+//! - `body_id` is **Wave 2.3's**. The bytes come first — the standing constraint
+//!   is *bytes before the record on creation* — and there is no way to have
+//!   uploaded any, because `PutBody` is not served. So the field refuses with
+//!   that reason, and [`super::super::entity`]'s create refuses a file outright
+//!   for the same one.
+//! - `extracted_text` is **deferred by `altair-v0-scope.md`**, which governs the
+//!   implementation plan where the two disagree. A person's correction to
+//!   extracted text has nothing to correct while extraction does not exist.
+//! - `media_type` is served, and is the whole of a v0 file's own content. The
+//!   scope's v0 files are *entities with a title and relations*, and a media
+//!   type is what display follows.
+//!
+//! `file.byte_size` exists in the store and **the wire has no field for it**, on
+//! purpose: it is what the object store measured rather than what a client
+//! claimed. Nothing in this module can set it, and 2.3 writes it beside the
+//! bytes.
 
 use altair_proto::v1;
 
@@ -21,7 +46,9 @@ use crate::store::ids::EntityId;
 
 use super::super::content::{BodyWrite, Malformed, Written};
 use super::super::entity::{Applied, Ctx, Refusal};
-use super::{Addressed, Field, Held, Reader, SpecificPart, not_yet_built, unbuilt};
+use super::{
+    Addressed, Field, Held, Reader, SpecificPart, SpecificValue, read_column, write_column,
+};
 
 /// A note's field 1, its body.
 pub const NOTE_BODY: u32 = 1;
@@ -31,13 +58,26 @@ pub const NOTE_FIELDS: &[Field] = &[Field {
     held: Held::Body,
 }];
 
+/// A file's field 2, the media type as captured.
+pub const FILE_MEDIA_TYPE: u32 = 2;
+
 pub const FILE_FIELDS: &[Field] = &[
+    // **LANE: 2.3, file bodies.** `body_id` names bytes already uploaded
+    // through `PutBody`; until that call is served there is no identity to
+    // name, which is why the create path refuses a file outright. The column is
+    // `NOT NULL`, so clearing it is not a thing an edit can do either, and
+    // saying so here is better than letting the store raise a fault.
+    //
+    // 2.3 turns this back into `Held::Column("body_id")`; the column already
+    // exists and `tests/type_content.rs` will check it again the moment it does.
     Field {
         number: 1,
-        held: Held::Column("body_id"),
+        held: Held::NotServed(
+            "a file names a body that must be uploaded first, and PutBody is not served yet",
+        ),
     },
     Field {
-        number: 2,
+        number: FILE_MEDIA_TYPE,
         held: Held::Column("media_type"),
     },
     // A person's correction to extracted text, which has nothing to correct.
@@ -77,33 +117,39 @@ pub fn note(c: &v1::NoteContent) -> Result<Written, Malformed> {
 
 /// A file's content, off the wire.
 ///
-/// **LANE: 2.3, file bodies.** `body_id` names bytes already uploaded through
-/// `PutBody`; until that call is served there is no identity to name, which is
-/// why 2.1 refuses a file create outright. The column is `NOT NULL`, so
-/// clearing it is not a thing an edit can do and this module must say so rather
-/// than letting the store raise a fault.
+/// Only the media type is read. The other two refuse with their own reasons,
+/// through the declaration above rather than through a branch here, so a client
+/// is told what it is waiting on rather than that its message was wrong.
 pub fn file(c: &v1::FileContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::File,
-        &c.cleared,
-        &[
-            (1, c.body_id.is_some()),
-            (2, c.media_type.is_some()),
-            (3, c.extracted_text.is_some()),
-        ],
-    )
+    let read = Reader::new(EntityType::File, &c.cleared)?;
+    let mut parts = Vec::new();
+    // The two unserved fields are addressed so their refusals are reached.
+    // Asking for them and using nothing but the answer is the point: leaving
+    // them out would accept a write that named them and silently drop it.
+    read.addressed(1, c.body_id.is_some())?;
+    read.addressed(3, c.extracted_text.is_some())?;
+    read.singular(&mut parts, FILE_MEDIA_TYPE, c.media_type.clone(), |v| {
+        Ok(SpecificValue::Text(v))
+    })?;
+    Ok(Written::from_specific(parts))
 }
 
+/// What a Knowledge part owes before it is applied.
+///
+/// A media type owes nothing. It is the person's word for what the bytes are,
+/// interpreted by nothing here — the same treatment a unit gets in Tracking —
+/// and the entity stores no display preference beside it.
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<Option<SpecificPart>> {
-    let _ = (ctx, entity, part);
-    // A note addresses no part at all — its content is its body — so anything
-    // reaching here is a file's, and a file's content is 2.3's.
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    let _ = (ctx, entity);
+    match (kind, part.field) {
+        (EntityType::File, FILE_MEDIA_TYPE) => Ok(None),
+        _ => Err(unreachable_part(kind, part).into()),
+    }
 }
 
 pub async fn current(
@@ -112,8 +158,10 @@ pub async fn current(
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<SpecificPart> {
-    let _ = (ctx, entity, part);
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    match (kind, part.field) {
+        (EntityType::File, FILE_MEDIA_TYPE) => read_column(ctx, entity, kind, part).await,
+        _ => Err(unreachable_part(kind, part).into()),
+    }
 }
 
 pub async fn apply(
@@ -123,8 +171,31 @@ pub async fn apply(
     part: &SpecificPart,
     placement: Option<&SpecificPart>,
 ) -> Applied<()> {
-    let _ = (ctx, entity, part, placement);
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    match (kind, part.field) {
+        (EntityType::File, FILE_MEDIA_TYPE) => {
+            // Neither Knowledge type nests or is ordered, so nothing moves
+            // alongside.
+            debug_assert!(placement.is_none());
+            write_column(ctx, entity, kind, part).await
+        }
+        _ => Err(unreachable_part(kind, part).into()),
+    }
+}
+
+/// A part no Knowledge message can produce.
+///
+/// **Not the *not built yet* refusal**, which would be a lie in both directions.
+/// A note's one field is its body and a body never becomes a [`SpecificPart`];
+/// a file's other two fields refuse while the message is being read and never
+/// reach here. So anything arriving is a part that was constructed rather than
+/// transcribed, and saying the content is merely unbuilt would send whoever
+/// reads the log to the wrong module.
+fn unreachable_part(kind: EntityType, part: &SpecificPart) -> Refusal {
+    Refusal::Malformed(format!(
+        "field {} is not a part a {} carries",
+        part.field,
+        super::super::entity::type_name(kind)
+    ))
 }
 
 /// What Knowledge contributes to searchable text.
@@ -134,6 +205,11 @@ pub async fn apply(
 /// [`super::super::body`], which this lane also fills, and taking half the
 /// answer now would settle the shape of the other half. Contributing nothing is
 /// a valid answer, and the literal arm still finds a note by its title.
+///
+/// A media type is deliberately not contributed either. It is a machine label
+/// rather than the person's words, and putting `image/png` into the text a
+/// literal search matches would make every photograph answer a search for
+/// *image*.
 pub async fn search_text(
     ctx: &mut Ctx<'_>,
     entity: EntityId,

--- a/crates/altaird/src/write/specific/mod.rs
+++ b/crates/altaird/src/write/specific/mod.rs
@@ -792,6 +792,33 @@ pub enum Detachment {
     NotBuilt,
 }
 
+/// The part a type holds in a named column.
+///
+/// **One statement of the pairing, derived rather than restated.** A release
+/// clears a column and has to name the part that moved, and the field number is
+/// already declared beside that column in the type's own `*_FIELDS`. Carrying
+/// the number alongside the column at the call site states the same pairing
+/// twice, and the second copy is the one that goes stale — the shape both
+/// callers of [`nesting::would_cycle`] drifted into before it was noticed.
+///
+/// Refuses rather than guesses. A column no field declares is a caller naming
+/// something that is not a part, which is a programming error rather than a
+/// message anyone sent, and answering with the wrong part number would put a
+/// counter against a field that never moved.
+pub fn part_held_in(kind: EntityType, column: &str) -> Applied<Part> {
+    fields(kind)
+        .iter()
+        .find(|f| matches!(f.held, Held::Column(c) if c == column))
+        .map(|f| Part::Specific(f.number))
+        .ok_or_else(|| {
+            Refusal::Malformed(format!(
+                "no field of a {} is held in {column}",
+                crate::write::entity::type_name(kind)
+            ))
+            .into()
+        })
+}
+
 /// Let go of everything a type-specific container held, because it is gone.
 ///
 /// # Why this exists, and why it is not called yet

--- a/crates/altaird/src/write/specific/mod.rs
+++ b/crates/altaird/src/write/specific/mod.rs
@@ -862,9 +862,13 @@ pub async fn detach_contained(
     match kind {
         // **LANE: Guidance.** An arc hangs beneath a campaign and a quest
         // beneath either, so all three are containers and all three owe a
-        // release. Answering `NotBuilt` rather than an empty list is what stops
-        // that being invisible once this is wired.
-        EntityType::Campaign | EntityType::Arc | EntityType::Quest => Ok(Detachment::NotBuilt),
+        // release. Answering `NotBuilt` rather than an empty list is what kept
+        // that visible while it was unbuilt — an erased campaign left its arcs
+        // and quests on a tombstone, and the variant said so rather than
+        // reporting an empty release.
+        EntityType::Campaign | EntityType::Arc | EntityType::Quest => {
+            guidance::detach_contained(ctx, entity, kind).await
+        }
         EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
             tracking::detach_contained(ctx, entity, kind).await
         }

--- a/crates/altaird/src/write/specific/mod.rs
+++ b/crates/altaird/src/write/specific/mod.rs
@@ -841,18 +841,28 @@ pub async fn detach_contained(
         EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
             tracking::detach_contained(ctx, entity, kind).await
         }
-        // **LANE: Knowledge and categories.** A category is a container twice
-        // over and only one of them is handled. `uncategorise_all` releases its
-        // *membership* — the entities filed in it — and Wave 2.1 built that. It
-        // does nothing about its *nesting*: `category.parent_category_id` on a
-        // child category is released by nobody, so erasing a parent category
-        // leaves its children pointing at a tombstone, exactly as an erased
-        // location once left its own.
+        // **LANE: Knowledge and categories.** A category is a container in two
+        // distinct senses and only one of them is released.
+        //
+        // *Membership* — the entities filed in it — is the shared model's, and
+        // Wave 2.1 built it: `uncategorise_all` clears `entity.category_id` on
+        // everything inside. *Nesting* — `category.parent_category_id`, how one
+        // category sits under another — is a column of this side table, exactly
+        // like `location.parent_location_id`, and nothing releases it.
+        //
+        // What that leaves, concretely. Erase category A with category B nested
+        // inside it: A's `category` row goes, A's `entity` row survives as a
+        // tombstone so the composite foreign key stays satisfied, and **B's
+        // `parent_category_id` names A for ever**. No client can repair it
+        // either — re-parenting B means naming A, and `available_for_write` on
+        // an erased A refuses. It does not hang: [`nesting::would_cycle`] reads
+        // A's deleted row, finds none, and returns false. It is a coherence
+        // problem, which is the quieter kind.
         //
         // Answering `NotBuilt` rather than `NoContainer` is the whole reason the
-        // two are different answers. The comment in the erase path names "the
-        // ladder and nested locations" and silently omits this third case; this
-        // is where that omission stops being silent.
+        // two are different answers. This arm previously claimed nothing was
+        // owed here, and a comment asserting a gap does not exist is worse than
+        // the gap.
         EntityType::Category => Ok(Detachment::NotBuilt),
         // A note and a file hold nothing. The three the schema has no table for
         // hold nothing either, and cannot be created at all.

--- a/crates/altaird/src/write/specific/mod.rs
+++ b/crates/altaird/src/write/specific/mod.rs
@@ -860,10 +860,18 @@ pub async fn detach_contained(
         // problem, which is the quieter kind.
         //
         // Answering `NotBuilt` rather than `NoContainer` is the whole reason the
-        // two are different answers. This arm previously claimed nothing was
-        // owed here, and a comment asserting a gap does not exist is worse than
-        // the gap.
-        EntityType::Category => Ok(Detachment::NotBuilt),
+        // two are different answers. This arm once claimed nothing was owed
+        // here, and **a comment asserting a gap does not exist is worse than the
+        // gap** — it converts an open question into a settled one and talks the
+        // next reader out of checking. The erase path's own comment named "the
+        // ladder and nested locations" and silently omitted this third case.
+        //
+        // **Built now.** The two senses stay separate rather than merging: this
+        // releases the nesting, `uncategorise_all` goes on releasing the
+        // membership, and they write two different columns — so a category both
+        // nested under the erased one and filed in it is let go once by each,
+        // and neither overwrites what the other did.
+        EntityType::Category => category::detach_contained(ctx, entity).await,
         // A note and a file hold nothing. The three the schema has no table for
         // hold nothing either, and cannot be created at all.
         EntityType::Note

--- a/crates/altaird/src/write/specific/mod.rs
+++ b/crates/altaird/src/write/specific/mod.rs
@@ -693,6 +693,113 @@ pub async fn search_text(
 }
 
 // ---------------------------------------------------------------------------
+// What a type-specific container lets go of when it is erased
+// ---------------------------------------------------------------------------
+
+/// What an erased container let go of.
+///
+/// **Three answers, not two, because an empty list is ambiguous.** A container
+/// that held nothing and a type that has no container both release nothing, and
+/// a container whose lane has not built the release yet also releases nothing —
+/// and that last one is a leak rather than an answer. Whoever wires this must be
+/// able to tell them apart, or a campaign's arcs go on pointing at a tombstone
+/// and the suite stays green.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Detachment {
+    /// This type holds nothing that points back at it. There is no container
+    /// here and there never will be.
+    NoContainer,
+    /// The entities that pointed at this container and now point at nothing.
+    /// Empty means the container was empty, which is an answer.
+    Released(Vec<EntityId>),
+    /// **This type has a container and the release is not built yet.**
+    /// Distinct from `Released(vec![])` on purpose: wiring the call while a type
+    /// still answers this way would silently leave that container's contents
+    /// pointing at a tombstone.
+    NotBuilt,
+}
+
+/// Let go of everything a type-specific container held, because it is gone.
+///
+/// # Why this exists, and why it is not called yet
+///
+/// [`super::entity`]'s erase path says outright that *the type-specific
+/// containers, the ladder and nested locations, are Wave 2.2's for the same
+/// reason their content is*. Wave 2.1 built the shared-model half —
+/// `uncategorise_all`, for a category — and left these. Today an erased
+/// campaign leaves its arcs and quests pointing at a tombstone, and an erased
+/// location leaves both its child locations and the items shelved in it doing
+/// the same.
+///
+/// The substrate's rule for the category case is that *an entity whose category
+/// is deleted becomes uncategorised, which is a valid state requiring no
+/// repair*, and erasure is the stronger form of the same thing. Nothing about
+/// that reasoning is specific to categories.
+///
+/// **Declared here and deliberately unwired.** The call belongs in the erase
+/// path, which this lane does not own. Adding the seam without the call is the
+/// half that can be built in isolation; the other half is one line in a file
+/// another lane holds.
+///
+/// # What the caller still owes
+///
+/// The identities come back and nothing else. A change entry needs the
+/// audience, and `tests/one_predicate.rs` refuses any source outside
+/// `store/audience.rs` that names the audience column and issues SQL — rightly,
+/// because reasoning about audience belongs there. So the release happens here
+/// and the change sequence is assembled by the caller, from the store layer,
+/// exactly as the category case already does it.
+///
+/// The counter on each released entity is advanced here, because that is part
+/// of the release rather than part of the bookkeeping: it is an accepted write
+/// to those entities, and a client holding one has to learn the container went
+/// away.
+pub async fn detach_contained(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+) -> Applied<Detachment> {
+    match kind {
+        // **LANE: Guidance.** An arc hangs beneath a campaign and a quest
+        // beneath either, so all three are containers and all three owe a
+        // release. Answering `NotBuilt` rather than an empty list is what stops
+        // that being invisible once this is wired.
+        EntityType::Campaign | EntityType::Arc | EntityType::Quest => Ok(Detachment::NotBuilt),
+        EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
+            tracking::detach_contained(ctx, entity, kind).await
+        }
+        // **LANE: Knowledge and categories.** A category is a container, but its
+        // release is the shared model's and Wave 2.1 already built it — the
+        // erase path calls `uncategorise_all` directly. Nothing is owed here.
+        EntityType::Category => Ok(Detachment::NoContainer),
+        // A note and a file hold nothing. The three the schema has no table for
+        // hold nothing either, and cannot be created at all.
+        EntityType::Note
+        | EntityType::File
+        | EntityType::Routine
+        | EntityType::FocusSession
+        | EntityType::CheckIn => Ok(Detachment::NoContainer),
+    }
+}
+
+/// Advance the counter on each entity a vanished container let go of.
+///
+/// Shared by every lane's release so that *what a detach does to the entity row*
+/// has one implementation. A release that forgot this would leave a client
+/// holding a counter that never moved, and it would never learn the container
+/// was gone.
+pub async fn note_detached(ctx: &mut Ctx<'_>, released: &[EntityId]) -> Applied<()> {
+    for id in released {
+        sqlx::query("UPDATE entity SET counter = counter + 1, updated_at = $2 WHERE id = $1")
+            .bind(id.as_uuid())
+            .bind(ctx.at)
+            .execute(ctx.tx.conn())
+            .await?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Reading and writing a column, generically
 // ---------------------------------------------------------------------------
 

--- a/crates/altaird/src/write/specific/mod.rs
+++ b/crates/altaird/src/write/specific/mod.rs
@@ -61,6 +61,7 @@ use crate::store::ids::EntityId;
 
 use super::content::{Malformed, Written, malformed};
 use super::entity::{Applied, Ctx, Refusal};
+use super::parts::Part;
 
 // ---------------------------------------------------------------------------
 // What a type-specific field is
@@ -754,6 +755,13 @@ pub async fn search_text(
 // What a type-specific container lets go of when it is erased
 // ---------------------------------------------------------------------------
 
+/// One entity a vanished container let go of, and the part of it that moved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Released {
+    pub entity: EntityId,
+    pub part: Part,
+}
+
 /// What an erased container let go of.
 ///
 /// **Three answers, not two, because an empty list is ambiguous.** A container
@@ -767,9 +775,16 @@ pub enum Detachment {
     /// This type holds nothing that points back at it. There is no container
     /// here and there never will be.
     NoContainer,
-    /// The entities that pointed at this container and now point at nothing.
-    /// Empty means the container was empty, which is an answer.
-    Released(Vec<EntityId>),
+    /// The entities that pointed at this container and now point at nothing,
+    /// each with **the part of it that moved**. Empty means the container was
+    /// empty, which is an answer.
+    ///
+    /// The part is carried because a release is a write to the entity that lost
+    /// its container — its counter advances — and a write that advances a
+    /// counter owes provenance. Which part moved is the type's knowledge: a
+    /// child location lost its parent, an item lost its shelf, and those are
+    /// different fields of different messages.
+    Released(Vec<Released>),
     /// **This type has a container and the release is not built yet.**
     /// Distinct from `Released(vec![])` on purpose: wiring the call while a type
     /// still answers this way would silently leave that container's contents
@@ -826,10 +841,19 @@ pub async fn detach_contained(
         EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
             tracking::detach_contained(ctx, entity, kind).await
         }
-        // **LANE: Knowledge and categories.** A category is a container, but its
-        // release is the shared model's and Wave 2.1 already built it — the
-        // erase path calls `uncategorise_all` directly. Nothing is owed here.
-        EntityType::Category => Ok(Detachment::NoContainer),
+        // **LANE: Knowledge and categories.** A category is a container twice
+        // over and only one of them is handled. `uncategorise_all` releases its
+        // *membership* — the entities filed in it — and Wave 2.1 built that. It
+        // does nothing about its *nesting*: `category.parent_category_id` on a
+        // child category is released by nobody, so erasing a parent category
+        // leaves its children pointing at a tombstone, exactly as an erased
+        // location once left its own.
+        //
+        // Answering `NotBuilt` rather than `NoContainer` is the whole reason the
+        // two are different answers. The comment in the erase path names "the
+        // ladder and nested locations" and silently omits this third case; this
+        // is where that omission stops being silent.
+        EntityType::Category => Ok(Detachment::NotBuilt),
         // A note and a file hold nothing. The three the schema has no table for
         // hold nothing either, and cannot be created at all.
         EntityType::Note

--- a/crates/altaird/src/write/specific/mod.rs
+++ b/crates/altaird/src/write/specific/mod.rs
@@ -587,29 +587,80 @@ pub fn parts_written(specific: &v1::entity_content::Specific) -> Result<Written,
     }
 }
 
-/// What a type-specific part owes before it is applied, and the companion part
+/// What a type-specific part owes before it is applied, and the companion parts
 /// the instance moves as a consequence.
 ///
 /// The companion exists for the same reason the shared model's does: a
 /// container and a position within it are constrained together, so writing them
 /// in sequence puts the row through a state the schema refuses.
+///
+/// # Why the whole addressed set, and why many companions
+///
+/// Both halves were widened once, because two lanes needed one each and the
+/// pair of special cases would have been worse than the general seam.
+///
+/// **`addressed` — the whole set of parts this message writes.** A type
+/// sometimes cannot decide one part without seeing another. An item's amount
+/// and the moment it was asserted are constrained against each other, so they
+/// move in one statement; the instance stamps the moment only when the client
+/// did not state one, and *whether the client stated one* is a fact about a
+/// different part of the same message. Deciding it from one part alone means
+/// either refusing a field the wire exists to carry, or writing the two columns
+/// in sequence and tripping the table's check.
+///
+/// **A `Vec` — as many companions as the write actually moved.** A companion is
+/// not only a column written alongside; it is *any part this write moved that
+/// the addressed part does not name*. A quest moving from an arc to a campaign
+/// clears the arc in the same statement, and the vacated column is a part like
+/// any other: a part that does not record the counter it moved at is invisible
+/// to conflict detection, so a concurrent edit to the vacated parent would merge
+/// silently instead of retaining both values. Returning it here is what puts it
+/// in provenance.
+///
+/// **A companion is owed only when the part genuinely moved.** Handing back a
+/// vacated parent that was already null would not manufacture a conflict —
+/// [`super::provenance::detect`] compares rendered text, and arriving equals
+/// stored — but it *would* write an `entity_part_counter` row claiming that part
+/// moved, and a later unrelated edit would read that as an overlap. Silent, and
+/// exactly what the per-part counter exists to prevent.
+///
+/// # The adapters below are the migration point
+///
+/// Three lanes still take one part and return at most one companion, and their
+/// modules are not this lane's to edit. They are adapted here rather than
+/// reshaped in place, which is what makes this a widening: nothing about their
+/// behaviour changes, and a lane moves to the wide form by changing its own
+/// module and the one line here that calls it.
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
-) -> Applied<Option<SpecificPart>> {
+    addressed: &[SpecificPart],
+) -> Applied<Vec<SpecificPart>> {
     match kind {
+        // **LANE: Guidance.** Still narrow. The vacated ladder parent is the
+        // reason the `Vec` exists, and it is filled in by moving this arm to
+        // pass `addressed` through once that module returns more than one.
         EntityType::Campaign | EntityType::Arc | EntityType::Quest => {
-            guidance::validate_and_place(ctx, entity, kind, part).await
+            Ok(guidance::validate_and_place(ctx, entity, kind, part)
+                .await?
+                .into_iter()
+                .collect())
         }
         EntityType::Note | EntityType::File => {
-            knowledge::validate_and_place(ctx, entity, kind, part).await
+            Ok(knowledge::validate_and_place(ctx, entity, kind, part)
+                .await?
+                .into_iter()
+                .collect())
         }
         EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
-            tracking::validate_and_place(ctx, entity, kind, part).await
+            tracking::validate_and_place(ctx, entity, kind, part, addressed).await
         }
-        EntityType::Category => category::validate_and_place(ctx, entity, part).await,
+        EntityType::Category => Ok(category::validate_and_place(ctx, entity, part)
+            .await?
+            .into_iter()
+            .collect()),
         EntityType::Routine | EntityType::FocusSession | EntityType::CheckIn => {
             Err(Refusal::Malformed(not_yet_built(kind).0).into())
         }
@@ -641,26 +692,33 @@ pub async fn current(
 
 /// Apply one type-specific part.
 ///
-/// `placement` is whatever [`validate_and_place`] returned, passed through so a
+/// `placements` is whatever [`validate_and_place`] returned, passed through so a
 /// module can write a field and its companion in one statement.
+///
+/// **A module finds the companion it needs by field number, never by
+/// position.** The order a lane returns companions in is that lane's business,
+/// and a write that depended on it would break the first time one returned two.
+/// The three narrow lanes below return at most one, so passing the first is
+/// exactly today's behaviour for them and nothing changes.
 pub async fn apply(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
-    placement: Option<&SpecificPart>,
+    placements: &[SpecificPart],
 ) -> Applied<()> {
+    let first = placements.first();
     match kind {
         EntityType::Campaign | EntityType::Arc | EntityType::Quest => {
-            guidance::apply(ctx, entity, kind, part, placement).await
+            guidance::apply(ctx, entity, kind, part, first).await
         }
         EntityType::Note | EntityType::File => {
-            knowledge::apply(ctx, entity, kind, part, placement).await
+            knowledge::apply(ctx, entity, kind, part, first).await
         }
         EntityType::Item | EntityType::Location | EntityType::ShoppingList => {
-            tracking::apply(ctx, entity, kind, part, placement).await
+            tracking::apply(ctx, entity, kind, part, placements).await
         }
-        EntityType::Category => category::apply(ctx, entity, part, placement).await,
+        EntityType::Category => category::apply(ctx, entity, part, first).await,
         EntityType::Routine | EntityType::FocusSession | EntityType::CheckIn => {
             Err(Refusal::Malformed(not_yet_built(kind).0).into())
         }
@@ -780,23 +838,6 @@ pub async fn detach_contained(
         | EntityType::FocusSession
         | EntityType::CheckIn => Ok(Detachment::NoContainer),
     }
-}
-
-/// Advance the counter on each entity a vanished container let go of.
-///
-/// Shared by every lane's release so that *what a detach does to the entity row*
-/// has one implementation. A release that forgot this would leave a client
-/// holding a counter that never moved, and it would never learn the container
-/// was gone.
-pub async fn note_detached(ctx: &mut Ctx<'_>, released: &[EntityId]) -> Applied<()> {
-    for id in released {
-        sqlx::query("UPDATE entity SET counter = counter + 1, updated_at = $2 WHERE id = $1")
-            .bind(id.as_uuid())
-            .bind(ctx.at)
-            .execute(ctx.tx.conn())
-            .await?;
-    }
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/altaird/src/write/specific/nesting.rs
+++ b/crates/altaird/src/write/specific/nesting.rs
@@ -103,3 +103,64 @@ pub async fn would_cycle(
         }
     }
 }
+
+/// Everything that named `parent` as its container, released and handed back.
+///
+/// # Why this is here rather than in the calling module
+///
+/// The same reason [`would_cycle`] is: two containers nest, they are owned by
+/// two lanes, and a graph operation written twice is two chances to get it
+/// wrong. It is generic over the table and the parent column for the same
+/// reason too, and both are `&'static str` from a [`super::Field`] declaration,
+/// so neither is ever built from anything a caller sent.
+///
+/// There is a second reason particular to categories, and it is a guard rather
+/// than taste. `tests/one_predicate.rs` refuses any source outside
+/// `store/audience.rs` that both names the audience column and issues SQL, and
+/// **it matches by substring**. The wire's name for a category's creation
+/// default ends in the audience column's own name, and [`super::category`] must
+/// spell that field out because reading the wire is what the module is for — so
+/// any query written in that file is an offence, whatever it queries. The
+/// categories lane therefore cannot write this statement where it uses it.
+/// Watch the guard fail on a query added to `category.rs` before deciding this
+/// indirection is unnecessary.
+///
+/// The same bluntness is why this paragraph describes that field rather than
+/// naming it: spelling it here would make *this* file the offender instead.
+///
+/// # What this does not do
+///
+/// **Identities only.** The counter on each released entity and the audience a
+/// change entry needs are `store::entity::detached_from_container`'s, because a
+/// change entry needs the audience column and only the store layer may name it.
+///
+/// **Deliberately unscoped.** No audience predicate, for the reason
+/// `uncategorise_all` gives and which is no smaller here: the container is gone
+/// for everybody, so leaving behind the rows the erasing member cannot see
+/// would keep a dangling reference alive precisely where nobody can find it.
+/// Nothing leaves here that a caller can show anyone — these are identities the
+/// caller already has the container for.
+///
+/// # Errors
+///
+/// Only where the store could not be written.
+pub async fn detach_children(
+    tx: &mut WriteTx,
+    table: &'static str,
+    parent_column: &'static str,
+    parent: EntityId,
+) -> sqlx::Result<Vec<EntityId>> {
+    let sql = format!(
+        "UPDATE {table} SET {parent_column} = NULL \
+         WHERE {parent_column} = $1 RETURNING entity_id"
+    );
+    let rows = sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(parent.as_uuid())
+        .fetch_all(tx.conn())
+        .await?;
+    let mut released = Vec::with_capacity(rows.len());
+    for r in &rows {
+        released.push(EntityId::from_uuid(r.try_get("entity_id")?));
+    }
+    Ok(released)
+}

--- a/crates/altaird/src/write/specific/tracking.rs
+++ b/crates/altaird/src/write/specific/tracking.rs
@@ -73,8 +73,8 @@ use crate::store::ids::EntityId;
 use super::super::content::{Malformed, Written, identifier, instant, malformed};
 use super::super::entity::{Applied, Ctx, Failed, Refusal, type_name};
 use super::{
-    Decimal, Field, Held, Property, Reader, SpecificPart, SpecificValue, nesting, read_column,
-    read_properties, unbuilt, write_column, write_properties,
+    Decimal, Detachment, Field, Held, Property, Reader, SpecificPart, SpecificValue, nesting,
+    note_detached, read_column, read_properties, unbuilt, write_column, write_properties,
 };
 
 // ---------------------------------------------------------------------------
@@ -102,6 +102,11 @@ const UNIT: &str = "unit";
 /// same way, deliberately: two callers of one walk feeding it two different
 /// ways is how the walk ends up running against a column one of them renamed.
 const PARENT_LOCATION: &str = "parent_location_id";
+
+/// The store's spelling of the column an item's shelf is held in, named once
+/// for the same reason as the one above: [`detach_contained`] names it in a
+/// statement, and [`ITEM_FIELDS`] declares it, and the two must not drift.
+const ITEM_LOCATION_COLUMN: &str = "location_id";
 
 /// The side table a type keeps its content in.
 ///
@@ -138,7 +143,7 @@ pub const ITEM_FIELDS: &[Field] = &[
     },
     Field {
         number: ITEM_LOCATION,
-        held: Held::Column("location_id"),
+        held: Held::Column(ITEM_LOCATION_COLUMN),
     },
     Field {
         number: ITEM_TEMPLATE,
@@ -564,6 +569,73 @@ pub async fn apply(
         }
         _ => Err(unaddressable(kind, part.field)),
     }
+}
+
+// ---------------------------------------------------------------------------
+// What an erased location lets go of
+// ---------------------------------------------------------------------------
+
+/// Release everything a vanished location held.
+///
+/// **LANE: Tracking.** A location holds two different things and both point
+/// back at it by identity:
+///
+/// - **Child locations**, through `parent_location_id`. Nesting is optional, so
+///   a child that loses its parent becomes a top-level location, which is a
+///   complete state needing no repair — *an item whose location is a single
+///   unnested thing is complete, and so is an item with no location at all*.
+/// - **Items shelved in it**, through `location_id`. The same rule: *nothing
+///   insists the location be right*, and an item with no location is complete.
+///
+/// **Both, not just the first.** The nesting case is the one that gets
+/// remembered because the container is the same type as the thing contained;
+/// the items are easier to forget and are the larger set. Missing either leaves
+/// rows pointing at a tombstone.
+///
+/// **The schema will not catch this.** Both columns are typed foreign keys into
+/// `entity`, and erasure leaves the entity row standing as a tombstone — so
+/// nothing is violated, no constraint fires, and the dangling reference is
+/// silent. That is the same reason the cycle check had to be written here
+/// rather than declared.
+///
+/// An item and a shopping list contain nothing, which is an answer rather than
+/// an omission.
+pub async fn detach_contained(
+    ctx: &mut Ctx<'_>,
+    entity: EntityId,
+    kind: EntityType,
+) -> Applied<Detachment> {
+    if kind != EntityType::Location {
+        // An item is a leaf. A shopping list's entries are blocks of its own
+        // body rather than entities pointing at it, and are deferred besides.
+        return Ok(Detachment::NoContainer);
+    }
+
+    let mut released = Vec::new();
+    // The two columns that name a location, each in its own table.
+    for (table, column) in [
+        (table_of(EntityType::Location)?, PARENT_LOCATION),
+        (table_of(EntityType::Item)?, ITEM_LOCATION_COLUMN),
+    ] {
+        let sql =
+            format!("UPDATE {table} SET {column} = NULL WHERE {column} = $1 RETURNING entity_id");
+        let rows = sqlx::query(sqlx::AssertSqlSafe(sql))
+            .bind(entity.as_uuid())
+            .fetch_all(ctx.tx.conn())
+            .await?;
+        for r in &rows {
+            released.push(EntityId::from_uuid(r.try_get("entity_id")?));
+        }
+    }
+
+    // **Deliberately unscoped**, for the reason `uncategorise_all` gives: the
+    // container is gone for everybody, so leaving behind the rows the erasing
+    // member cannot see would keep a dangling reference alive precisely where
+    // nobody can find it. Nothing leaves here that a caller can show anyone —
+    // the identities become change entries, and those are assembled per member
+    // by the read path, which applies the predicate then.
+    note_detached(ctx, &released).await?;
+    Ok(Detachment::Released(released))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/altaird/src/write/specific/tracking.rs
+++ b/crates/altaird/src/write/specific/tracking.rs
@@ -10,8 +10,8 @@
 //!   table's `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))`
 //!   refuses the state in between, so writing them in sequence fails whichever
 //!   order the sequence is in. This is the same shape as a category and the
-//!   position within it, and [`super::validate_and_place`] is where the
-//!   companion part is produced.
+//!   position within it, and [`validate_and_place`] is where the companion part
+//!   is produced.
 //! - **A nested location can close a loop and the schema will not notice.**
 //!   Self-reference is refused by a constraint; a longer loop is migration
 //!   one's gap (h), and a recursive query would not terminate on one.
@@ -21,103 +21,254 @@
 //!   incidentally. `altair-v0-scope.md` says so and governs the implementation
 //!   plan where the two disagree, so the field carries an expiring refusal
 //!   naming the reason rather than being quietly absent.
+//!
+//! # Templates are in force, and that is a reading rather than an assumption
+//!
+//! Migration one records the ambiguity as its gap (i), at lines 935–938: the
+//! scope names Tracking's core as *items, nested locations and quantity*, which
+//! reads as an enumeration, while also saying anything not named as deferred is
+//! in force — and templates are not named as deferred. **The schema resolved
+//! this on the second reading and created the tables**, so this module follows
+//! the schema: `template_id` on both types is served, and property values are
+//! written. The reasoning is recorded here so the next reader finds it rather
+//! than re-arguing it.
+//!
+//! What a template contributes is names, never content
+//! (`proto/altair/v1/altair.proto:465`). So nothing here reads
+//! `template_property`: a value is stored under the name it was given, keyed by
+//! that name and not by a reference to the template's property, because
+//! detaching a template keeps every value with the names it had then
+//! (`0001_initial.sql:518-519`, `docs/altair-tracking-prd.md:100`). Detaching is
+//! therefore clearing one column and touching nothing else, which is what makes
+//! it *never destructive* without any code here saying so.
+//!
+//! **A property kind is not a constraint.** No lengths, no ranges, nothing
+//! required. Every value crosses as text and nothing here interprets it.
+//!
+//! # What is deliberately not here
+//!
+//! **Availability.** It is the asserted amount minus what live quantified
+//! relations commit, it is derived, and it is never stored
+//! (`0001_initial.sql:336-337`, `docs/altair-tracking-prd.md:172`). There is no
+//! column for it and this module computes none.
+//!
+//! **An item's name.** It is the shared model's `title` under this domain's
+//! word for it, and not a property of its own
+//! (`docs/altair-tracking-prd.md:78`). Duplicating it here would give two places
+//! to look and two things to keep in step.
+//!
+//! **Anything that would make a field required.** No field is required on
+//! either path: *an item with a name and nothing else is a complete item*. Every
+//! column below is nullable and has no default, and nothing here supplies one.
+
+use sqlx::Row;
+use uuid::Uuid;
 
 use altair_proto::v1;
 
-use crate::store::entity::EntityType;
+use crate::store::WriteScope;
+use crate::store::entity::{EntityType, available_for_write};
 use crate::store::ids::EntityId;
 
-use super::super::content::{Malformed, Written};
-use super::super::entity::{Applied, Ctx, Refusal};
-use super::{Field, Held, SpecificPart, not_yet_built, unbuilt};
+use super::super::content::{Malformed, Written, identifier, instant, malformed};
+use super::super::entity::{Applied, Ctx, Failed, Refusal, type_name};
+use super::{
+    Decimal, Field, Held, Property, Reader, SpecificPart, SpecificValue, nesting, read_column,
+    read_properties, unbuilt, write_column, write_properties,
+};
+
+// ---------------------------------------------------------------------------
+// The fields, and the columns spelled once
+// ---------------------------------------------------------------------------
+
+/// The columns a statement in this file names directly.
+///
+/// Every other column reaches the store through [`super::write_column`], which
+/// takes the name from the [`Field`] declaration and issues the SQL itself.
+/// These cannot: the amount and its timestamp move in one statement, and the
+/// unit is read back for searchable text. Naming them through a constant used
+/// by both the declaration and the statement is what stops the two drifting,
+/// because `tests/type_content.rs` only checks the declaration.
+const ASSERTED_AMOUNT: &str = "asserted_amount";
+const ASSERTED_AT: &str = "asserted_at";
+const UNIT: &str = "unit";
+
+/// The store's spelling of a location's parent column, named once.
+///
+/// [`nesting::would_cycle`] is generic over the column so that one walk serves
+/// nested locations and nested categories, and it takes a `&'static str` so that
+/// nothing a caller sent can ever reach it. This is that string, and it is the
+/// same one [`LOCATION_FIELDS`] declares. The categories lane names its own the
+/// same way, deliberately: two callers of one walk feeding it two different
+/// ways is how the walk ends up running against a column one of them renamed.
+const PARENT_LOCATION: &str = "parent_location_id";
+
+/// The side table a type keeps its content in.
+///
+/// Taken from [`super::side_table`] rather than written out, so the three
+/// statements in this file that name a table cannot disagree with the one place
+/// that decides which table a type has. The `None` arm is unreachable for the
+/// types that reach it — both have a table — and is an answer rather than a
+/// panic for the same reason everything else here refuses rather than asserts.
+fn table_of(kind: EntityType) -> Applied<&'static str> {
+    super::side_table(kind).ok_or_else(|| {
+        Refusal::Malformed(format!("a {} has no table of its own", type_name(kind))).into()
+    })
+}
+
+pub const ITEM_AMOUNT: u32 = 1;
+pub const ITEM_UNIT: u32 = 2;
+pub const ITEM_ASSERTED_AT: u32 = 3;
+pub const ITEM_LOCATION: u32 = 4;
+pub const ITEM_TEMPLATE: u32 = 5;
+pub const ITEM_PROPERTIES: u32 = 6;
 
 pub const ITEM_FIELDS: &[Field] = &[
     Field {
-        number: 1,
-        held: Held::Column("asserted_amount"),
+        number: ITEM_AMOUNT,
+        held: Held::Column(ASSERTED_AMOUNT),
     },
     Field {
-        number: 2,
-        held: Held::Column("unit"),
+        number: ITEM_UNIT,
+        held: Held::Column(UNIT),
     },
     Field {
-        number: 3,
-        held: Held::Column("asserted_at"),
+        number: ITEM_ASSERTED_AT,
+        held: Held::Column(ASSERTED_AT),
     },
     Field {
-        number: 4,
+        number: ITEM_LOCATION,
         held: Held::Column("location_id"),
     },
     Field {
-        number: 5,
+        number: ITEM_TEMPLATE,
         held: Held::Column("template_id"),
     },
     Field {
-        number: 6,
+        number: ITEM_PROPERTIES,
         held: Held::Rows("entity_property_value"),
     },
 ];
+
+pub const LOCATION_PARENT: u32 = 1;
+pub const LOCATION_TEMPLATE: u32 = 2;
+pub const LOCATION_PROPERTIES: u32 = 3;
 
 pub const LOCATION_FIELDS: &[Field] = &[
     Field {
-        number: 1,
-        held: Held::Column("parent_location_id"),
+        number: LOCATION_PARENT,
+        held: Held::Column(PARENT_LOCATION),
     },
     Field {
-        number: 2,
+        number: LOCATION_TEMPLATE,
         held: Held::Column("template_id"),
     },
     Field {
-        number: 3,
+        number: LOCATION_PROPERTIES,
         held: Held::Rows("entity_property_value"),
     },
 ];
 
+/// Why a shopping list's entries are refused, said once.
+const SHOPPING_LIST_DEFERRED: &str = "shopping lists are deferred in v0: their entry model leans on an anchor granularity \
+     the substrate does not yet define, and a first release should not be the thing that \
+     forces that question";
+
 pub const SHOPPING_LIST_FIELDS: &[Field] = &[Field {
     number: 1,
-    held: Held::NotServed(
-        "shopping lists are deferred in v0: their entry model leans on an anchor granularity \
-         the substrate does not yet define, and a first release should not be the thing that \
-         forces that question",
-    ),
+    held: Held::NotServed(SHOPPING_LIST_DEFERRED),
 }];
+
+/// Why an item's assertion time is not a field a client states.
+///
+/// **An expiring refusal, in the register of the three Wave 2.1 makes.** The
+/// field exists on the wire and will exist forever — field numbers are
+/// permanent — so this says what a client is waiting on rather than that its
+/// message was wrong.
+///
+/// The instance assigns it, for the same reason it assigns a category position:
+/// the column is constrained against another column, so the two move in one
+/// statement, and [`validate_and_place`] can see only one part at a time. A
+/// client free to state the time independently could put the row through the
+/// state `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))` refuses —
+/// by clearing the amount and stating a time in one message, or by stating a
+/// time on an item that has no amount — and the answer would be a constraint
+/// violation that takes the transaction down rather than a refusal anybody can
+/// act on.
+///
+/// **It expires when a device's own assertion time can cross.** A count taken
+/// offline at nine and replayed at six should read nine, not six. Today no
+/// client exists to have taken one, and the outbox that will carry it is Wave
+/// 4.1's; when it lands this becomes a companion carrying the stated instant
+/// rather than a refusal, and the pairing below is already where it goes.
+const ASSERTED_AT_IS_THE_INSTANCES: &str = "the time an amount was asserted is the amount's own and moves with it, so the instance \
+     sets it when the amount is written; stating it separately is not served yet";
+
+// ---------------------------------------------------------------------------
+// Reading the wire
+// ---------------------------------------------------------------------------
 
 /// An item's content, off the wire.
 ///
-/// **LANE: Tracking.** The amount is a [`super::Decimal`] and crosses as text
-/// on purpose — binary floating point is the wrong place to put a household's
+/// **LANE: Tracking.** The amount is a [`Decimal`] and crosses as text on
+/// purpose — binary floating point is the wrong place to put a household's
 /// stock, and the reading and the range check are already written in
-/// [`super::Decimal::from_wire`].
+/// [`Decimal::from_wire`], which refuses rather than clamps.
 pub fn item(c: &v1::ItemContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::Item,
-        &c.cleared,
-        &[
-            (1, c.asserted_amount.is_some()),
-            (2, c.unit.is_some()),
-            (3, c.asserted_at.is_some()),
-            (4, c.location_id.is_some()),
-            (5, c.template_id.is_some()),
-            (6, !c.property_values.is_empty()),
-        ],
-    )
+    let read = Reader::new(EntityType::Item, &c.cleared)?;
+    let mut parts = Vec::new();
+
+    read.singular(&mut parts, ITEM_AMOUNT, c.asserted_amount.as_ref(), |v| {
+        Ok(SpecificValue::Number(
+            v.map(Decimal::from_wire).transpose()?,
+        ))
+    })?;
+    read.singular(&mut parts, ITEM_UNIT, c.unit.as_deref(), |v| {
+        Ok(SpecificValue::Text(v.map(str::to_owned)))
+    })?;
+    read.singular(&mut parts, ITEM_ASSERTED_AT, c.asserted_at.as_ref(), |v| {
+        Ok(SpecificValue::Instant(v.map(instant).transpose()?))
+    })?;
+    read.singular(&mut parts, ITEM_LOCATION, c.location_id.as_deref(), |v| {
+        Ok(SpecificValue::Id(v.map(identifier).transpose()?))
+    })?;
+    read.singular(&mut parts, ITEM_TEMPLATE, c.template_id.as_deref(), |v| {
+        Ok(SpecificValue::Id(v.map(identifier).transpose()?))
+    })?;
+    read.repeated(&mut parts, ITEM_PROPERTIES, &c.property_values, |v| {
+        Ok(SpecificValue::Properties(properties(v)?))
+    })?;
+
+    Ok(Written::from_specific(parts))
 }
 
 /// A location's content, off the wire.
 ///
 /// **LANE: Tracking.** `parent_location_id` is the one that owes
-/// [`super::nesting::would_cycle`], from [`super::validate_and_place`], before
-/// the column is written.
+/// [`super::nesting::would_cycle`], from [`validate_and_place`], before the
+/// column is written. Nesting exists and is never required; nothing here bounds
+/// the depth, and a flat set of locations is complete rather than degraded.
 pub fn location(c: &v1::LocationContent) -> Result<Written, Malformed> {
-    unbuilt(
-        EntityType::Location,
-        &c.cleared,
-        &[
-            (1, c.parent_location_id.is_some()),
-            (2, c.template_id.is_some()),
-            (3, !c.property_values.is_empty()),
-        ],
-    )
+    let read = Reader::new(EntityType::Location, &c.cleared)?;
+    let mut parts = Vec::new();
+
+    read.singular(
+        &mut parts,
+        LOCATION_PARENT,
+        c.parent_location_id.as_deref(),
+        |v| Ok(SpecificValue::Id(v.map(identifier).transpose()?)),
+    )?;
+    read.singular(
+        &mut parts,
+        LOCATION_TEMPLATE,
+        c.template_id.as_deref(),
+        |v| Ok(SpecificValue::Id(v.map(identifier).transpose()?)),
+    )?;
+    read.repeated(&mut parts, LOCATION_PROPERTIES, &c.property_values, |v| {
+        Ok(SpecificValue::Properties(properties(v)?))
+    })?;
+
+    Ok(Written::from_specific(parts))
 }
 
 /// A shopping list's content, off the wire.
@@ -133,15 +284,181 @@ pub fn shopping_list(c: &v1::ShoppingListContent) -> Result<Written, Malformed> 
     )
 }
 
+/// The property values one message carries.
+///
+/// **A kind is not a constraint**, so nothing here consults what a template says
+/// a property holds, and no value is interpreted, measured, or refused for its
+/// content. The two refusals below are about the message rather than about the
+/// person's answer:
+///
+/// - **A name twice.** The store keys a value by name, so two values under one
+///   name are two instructions with no reading that honours both — the same
+///   class as a field both present and cleared. The store's own upsert would
+///   silently keep whichever came last.
+/// - **A name that is nothing.** The name is the key. A value filed under no
+///   name could never be found again, and the primary key would happily hold it.
+fn properties(values: &[v1::PropertyValue]) -> Result<Vec<Property>, Malformed> {
+    let mut out: Vec<Property> = Vec::with_capacity(values.len());
+    for v in values {
+        if v.name.is_empty() {
+            return Err(malformed(
+                "a property value is keyed by its name, and this one carries none",
+            ));
+        }
+        if out.iter().any(|p| p.name == v.name) {
+            return Err(malformed(format!(
+                "the property `{}` is given a value twice, and a value is keyed by its name",
+                v.name
+            )));
+        }
+        out.push(Property {
+            name: v.name.clone(),
+            value: v.value.clone(),
+        });
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// What a part owes before it is applied
+// ---------------------------------------------------------------------------
+
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<Option<SpecificPart>> {
-    let _ = (ctx, entity, part);
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    match (kind, part.field) {
+        // **The companion.** An amount and the time it was asserted are
+        // constrained against each other, so they move in one statement and the
+        // instance supplies the time. Asserting an amount stamps now; clearing
+        // one clears the stamp with it, because a time an amount was asserted at
+        // is not something an item with no amount has.
+        //
+        // Re-stating the same amount is a real act — *I looked again, still
+        // three* — and it moves the stamp while leaving the amount where it was.
+        // That is what makes freshness recordable at all, given that a count is
+        // only as good as the last time somebody looked.
+        (EntityType::Item, ITEM_AMOUNT) => {
+            let asserted = matches!(part.value, SpecificValue::Number(Some(_)));
+            Ok(Some(SpecificPart {
+                field: ITEM_ASSERTED_AT,
+                value: SpecificValue::Instant(asserted.then_some(ctx.at)),
+            }))
+        }
+
+        // **Not a general modified time.** Renaming an item or correcting its
+        // notes does not confirm what is on the shelf, so nothing but the amount
+        // moves this, and a client may not move it by hand.
+        (EntityType::Item, ITEM_ASSERTED_AT) => {
+            Err(Refusal::Malformed(ASSERTED_AT_IS_THE_INSTANCES.into()).into())
+        }
+
+        // A location has to be one this member can see, and it has to be a
+        // location — the column is a typed foreign key, so pointing at something
+        // else is a refusal rather than a cast.
+        (EntityType::Item, ITEM_LOCATION) => {
+            if let SpecificValue::Id(Some(id)) = part.value {
+                must_be(ctx, EntityId::from_uuid(id), EntityType::Location).await?;
+            }
+            Ok(None)
+        }
+
+        (EntityType::Location, LOCATION_PARENT) => {
+            if let SpecificValue::Id(Some(id)) = part.value {
+                let parent = EntityId::from_uuid(id);
+                // Availability answers first, and it answers before anything
+                // about ancestry is read. A parent this member cannot see and a
+                // parent that does not exist are the same nothing; the cycle
+                // refusal below says more than nothing, so it must not be
+                // reachable for a parent the member was never entitled to know
+                // about.
+                must_be(ctx, parent, EntityType::Location).await?;
+                let table = table_of(kind)?;
+                if nesting::would_cycle(ctx.tx, table, PARENT_LOCATION, entity, parent).await? {
+                    return Err(Refusal::Malformed(
+                        "a location cannot be nested inside itself, directly or through what \
+                         it already contains"
+                            .into(),
+                    )
+                    .into());
+                }
+            }
+            Ok(None)
+        }
+
+        // A template is not an entity and carries no audience: one shared set
+        // reaches items and locations, and following one is the person's own
+        // act. What it owes is existence, checked here so a missing one is a
+        // refusal rather than a foreign-key violation that takes the whole
+        // transaction down.
+        (EntityType::Item, ITEM_TEMPLATE) | (EntityType::Location, LOCATION_TEMPLATE) => {
+            if let SpecificValue::Id(Some(id)) = part.value {
+                template_exists(ctx, id).await?;
+            }
+            Ok(None)
+        }
+
+        // Words the person wrote. Nothing to check that reading them did not
+        // already check.
+        (EntityType::Item, ITEM_UNIT | ITEM_PROPERTIES)
+        | (EntityType::Location, LOCATION_PROPERTIES) => Ok(None),
+
+        (EntityType::ShoppingList, _) => {
+            Err(Refusal::Malformed(SHOPPING_LIST_DEFERRED.into()).into())
+        }
+        _ => Err(unaddressable(kind, part.field)),
+    }
 }
+
+/// An entity this member may act on, and of the type the column requires.
+///
+/// **The three refusals are one.** A location the member cannot see, a location
+/// that does not exist, and an identifier naming something that is not a
+/// location all answer the same nothing — otherwise the refusal would report the
+/// type of a thing the member was never entitled to know existed.
+async fn must_be(ctx: &mut Ctx<'_>, id: EntityId, kind: EntityType) -> Applied<()> {
+    let found = available_for_write(ctx.tx, ctx.member, id, WriteScope::Active)
+        .await?
+        .ok_or(Refusal::NotAvailable)?;
+    if found.entity_type != kind {
+        return Err(Refusal::NotAvailable.into());
+    }
+    Ok(())
+}
+
+/// A template the household has declared.
+///
+/// Not audience-scoped, because a template is not an entity and carries no
+/// audience: it is one shared set reaching items and locations, and remembering
+/// which set a template lives in is exactly the recall this product refuses to
+/// ask for.
+async fn template_exists(ctx: &mut Ctx<'_>, id: Uuid) -> Applied<()> {
+    let found = sqlx::query("SELECT id FROM template WHERE id = $1")
+        .bind(id)
+        .fetch_optional(ctx.tx.conn())
+        .await?;
+    found.ok_or(Refusal::NotAvailable)?;
+    Ok(())
+}
+
+/// A field number the type does not have.
+///
+/// Unreachable through the wire — [`Reader`] validates a number against the type
+/// before a part exists — so this is honesty about a part built some other way
+/// rather than a case that is expected.
+fn unaddressable(kind: EntityType, number: u32) -> Failed {
+    Refusal::Malformed(format!(
+        "field {number} is not a part of a {}",
+        type_name(kind)
+    ))
+    .into()
+}
+
+// ---------------------------------------------------------------------------
+// Reading back, and writing
+// ---------------------------------------------------------------------------
 
 pub async fn current(
     ctx: &mut Ctx<'_>,
@@ -149,8 +466,32 @@ pub async fn current(
     kind: EntityType,
     part: &SpecificPart,
 ) -> Applied<SpecificPart> {
-    let _ = (ctx, entity, part);
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    match (kind, part.field) {
+        // Rows rather than a column, so the generic column reader cannot serve
+        // them. The order is the one they compare in, which `read_properties`
+        // already puts them in.
+        (EntityType::Item, ITEM_PROPERTIES) | (EntityType::Location, LOCATION_PROPERTIES) => {
+            Ok(SpecificPart {
+                field: part.field,
+                value: SpecificValue::Properties(read_properties(ctx, entity).await?),
+            })
+        }
+        // Everything else is one column, read back through the same rendering
+        // the arriving value goes through. `ITEM_ASSERTED_AT` is here because
+        // the companion is compared like any other part even though no client
+        // may state it.
+        (
+            EntityType::Item,
+            ITEM_AMOUNT | ITEM_UNIT | ITEM_ASSERTED_AT | ITEM_LOCATION | ITEM_TEMPLATE,
+        )
+        | (EntityType::Location, LOCATION_PARENT | LOCATION_TEMPLATE) => {
+            read_column(ctx, entity, kind, part).await
+        }
+        (EntityType::ShoppingList, _) => {
+            Err(Refusal::Malformed(SHOPPING_LIST_DEFERRED.into()).into())
+        }
+        _ => Err(unaddressable(kind, part.field)),
+    }
 }
 
 pub async fn apply(
@@ -160,20 +501,123 @@ pub async fn apply(
     part: &SpecificPart,
     placement: Option<&SpecificPart>,
 ) -> Applied<()> {
-    let _ = (ctx, entity, part, placement);
-    Err(Refusal::Malformed(not_yet_built(kind).0).into())
+    match (kind, part.field) {
+        // **One statement, both columns.** The table refuses the state in
+        // between, so writing them in sequence fails whichever order the
+        // sequence is in.
+        (EntityType::Item, ITEM_AMOUNT) => {
+            let Some(SpecificPart {
+                field: ITEM_ASSERTED_AT,
+                value: SpecificValue::Instant(at),
+            }) = placement
+            else {
+                // Unreachable: `validate_and_place` always produces the
+                // companion for this part. Refused rather than written alone,
+                // because the alternative is a statement the table rejects with
+                // a message nobody can act on.
+                return Err(Refusal::Malformed(
+                    "an amount is written with the time it was asserted, and this write \
+                     carries no time"
+                        .into(),
+                )
+                .into());
+            };
+            let SpecificValue::Number(amount) = &part.value else {
+                return Err(unaddressable(kind, part.field));
+            };
+            // Bound as text and cast, so nothing rounds on the way through —
+            // the same route `write_column` takes for a number.
+            let table = table_of(kind)?;
+            let sql = format!(
+                "UPDATE {table} SET {ASSERTED_AMOUNT} = $2::numeric, {ASSERTED_AT} = $3 \
+                 WHERE entity_id = $1"
+            );
+            sqlx::query(sqlx::AssertSqlSafe(sql))
+                .bind(entity.as_uuid())
+                .bind(amount.as_ref().map(Decimal::text))
+                .bind(*at)
+                .execute(ctx.tx.conn())
+                .await?;
+            Ok(())
+        }
+
+        (EntityType::Item, ITEM_PROPERTIES) | (EntityType::Location, LOCATION_PROPERTIES) => {
+            let SpecificValue::Properties(values) = &part.value else {
+                return Err(unaddressable(kind, part.field));
+            };
+            debug_assert!(placement.is_none());
+            write_properties(ctx, entity, values).await
+        }
+
+        (EntityType::Item, ITEM_UNIT | ITEM_LOCATION | ITEM_TEMPLATE)
+        | (EntityType::Location, LOCATION_PARENT | LOCATION_TEMPLATE) => {
+            debug_assert!(placement.is_none());
+            write_column(ctx, entity, kind, part).await
+        }
+
+        // Refused before it could reach here; see `ASSERTED_AT_IS_THE_INSTANCES`.
+        (EntityType::Item, ITEM_ASSERTED_AT) => {
+            Err(Refusal::Malformed(ASSERTED_AT_IS_THE_INSTANCES.into()).into())
+        }
+        (EntityType::ShoppingList, _) => {
+            Err(Refusal::Malformed(SHOPPING_LIST_DEFERRED.into()).into())
+        }
+        _ => Err(unaddressable(kind, part.field)),
+    }
 }
+
+// ---------------------------------------------------------------------------
+// Searchable text
+// ---------------------------------------------------------------------------
 
 /// What Tracking contributes to searchable text.
 ///
-/// **LANE: Tracking.** The person's word for a unit is words rather than a
-/// value, so it is the plausible one. Contributing nothing is a valid answer
-/// and is what this returns until the lane decides otherwise.
+/// **LANE: Tracking.** The person's own words, and only those. A unit is what
+/// they call it — *tins*, *rolls*, *bottle* — and a property is a name they
+/// chose with a value they typed. Those are the words somebody reaches for when
+/// looking for the thing, and the literal arm is a permanent arm rather than a
+/// fallback, which is what makes a just-captured item findable by them before
+/// any derivation runs.
+///
+/// **Not here:** the amount, the assertion time, and the identifiers of a
+/// location or a template. A number and an instant are values rather than words,
+/// nothing ever reads an identifier (DR-007), and a location's own title is
+/// already searchable on the location.
+///
+/// Availability is not here either, and not because it is awkward: it is
+/// derived and never stored, and putting a derived figure into a person's search
+/// text would make the index disagree with itself the moment a relation moved.
 pub async fn search_text(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
 ) -> Applied<Option<String>> {
-    let _ = (ctx, entity, kind);
-    Ok(None)
+    let mut words: Vec<String> = Vec::new();
+
+    if kind == EntityType::Item {
+        let table = table_of(kind)?;
+        let sql = format!("SELECT {UNIT} AS u FROM {table} WHERE entity_id = $1");
+        let row = sqlx::query(sqlx::AssertSqlSafe(sql))
+            .bind(entity.as_uuid())
+            .fetch_optional(ctx.tx.conn())
+            .await?;
+        if let Some(row) = row
+            && let Some(unit) = row.try_get::<Option<String>, _>("u")?
+        {
+            words.push(unit);
+        }
+    }
+
+    // A shopping list holds no property values and has no side-table row to read
+    // them from. The query would answer empty, but asking it would say this
+    // module thought it might not.
+    if matches!(kind, EntityType::Item | EntityType::Location) {
+        for p in read_properties(ctx, entity).await? {
+            words.push(p.name);
+            words.push(p.value);
+        }
+    }
+
+    words.retain(|w| !w.trim().is_empty());
+    Ok((!words.is_empty()).then(|| words.join(" ")))
 }

--- a/crates/altaird/src/write/specific/tracking.rs
+++ b/crates/altaird/src/write/specific/tracking.rs
@@ -73,9 +73,10 @@ use crate::store::ids::EntityId;
 
 use super::super::content::{Malformed, Written, identifier, instant, malformed};
 use super::super::entity::{Applied, Ctx, Failed, Refusal, type_name};
+use super::super::parts::Part;
 use super::{
-    Decimal, Detachment, Field, Held, Property, Reader, SpecificPart, SpecificValue, nesting,
-    read_column, read_properties, unbuilt, write_column, write_properties,
+    Decimal, Detachment, Field, Held, Property, Reader, Released, SpecificPart, SpecificValue,
+    nesting, read_column, read_properties, unbuilt, write_column, write_properties,
 };
 
 // ---------------------------------------------------------------------------
@@ -667,10 +668,20 @@ pub async fn detach_contained(
     }
 
     let mut released = Vec::new();
-    // The two columns that name a location, each in its own table.
-    for (table, column) in [
-        (table_of(EntityType::Location)?, PARENT_LOCATION),
-        (table_of(EntityType::Item)?, ITEM_LOCATION_COLUMN),
+    // The two columns that name a location, each in its own table, each its own
+    // part of its own type's message — which is why the field number travels
+    // with the identity.
+    for (table, column, field) in [
+        (
+            table_of(EntityType::Location)?,
+            PARENT_LOCATION,
+            LOCATION_PARENT,
+        ),
+        (
+            table_of(EntityType::Item)?,
+            ITEM_LOCATION_COLUMN,
+            ITEM_LOCATION,
+        ),
     ] {
         let sql =
             format!("UPDATE {table} SET {column} = NULL WHERE {column} = $1 RETURNING entity_id");
@@ -679,7 +690,10 @@ pub async fn detach_contained(
             .fetch_all(ctx.tx.conn())
             .await?;
         for r in &rows {
-            released.push(EntityId::from_uuid(r.try_get("entity_id")?));
+            released.push(Released {
+                entity: EntityId::from_uuid(r.try_get("entity_id")?),
+                part: Part::Specific(field),
+            });
         }
     }
 

--- a/crates/altaird/src/write/specific/tracking.rs
+++ b/crates/altaird/src/write/specific/tracking.rs
@@ -73,7 +73,6 @@ use crate::store::ids::EntityId;
 
 use super::super::content::{Malformed, Written, identifier, instant, malformed};
 use super::super::entity::{Applied, Ctx, Failed, Refusal, type_name};
-use super::super::parts::Part;
 use super::{
     Decimal, Detachment, Field, Held, Property, Reader, Released, SpecificPart, SpecificValue,
     nesting, read_column, read_properties, unbuilt, write_column, write_properties,
@@ -668,21 +667,16 @@ pub async fn detach_contained(
     }
 
     let mut released = Vec::new();
-    // The two columns that name a location, each in its own table, each its own
-    // part of its own type's message — which is why the field number travels
-    // with the identity.
-    for (table, column, field) in [
-        (
-            table_of(EntityType::Location)?,
-            PARENT_LOCATION,
-            LOCATION_PARENT,
-        ),
-        (
-            table_of(EntityType::Item)?,
-            ITEM_LOCATION_COLUMN,
-            ITEM_LOCATION,
-        ),
+    // The two columns that name a location, each in its own table and each its
+    // own part of its own type's message. **The table and the part are both
+    // derived from the type**, so nothing here restates a pairing the field
+    // declarations already make — the second copy is the one that goes stale.
+    for (held_by, column) in [
+        (EntityType::Location, PARENT_LOCATION),
+        (EntityType::Item, ITEM_LOCATION_COLUMN),
     ] {
+        let table = table_of(held_by)?;
+        let field = super::part_held_in(held_by, column)?;
         let sql =
             format!("UPDATE {table} SET {column} = NULL WHERE {column} = $1 RETURNING entity_id");
         let rows = sqlx::query(sqlx::AssertSqlSafe(sql))
@@ -692,7 +686,7 @@ pub async fn detach_contained(
         for r in &rows {
             released.push(Released {
                 entity: EntityId::from_uuid(r.try_get("entity_id")?),
-                part: Part::Specific(field),
+                part: field.clone(),
             });
         }
     }

--- a/crates/altaird/src/write/specific/tracking.rs
+++ b/crates/altaird/src/write/specific/tracking.rs
@@ -61,6 +61,7 @@
 //! either path: *an item with a name and nothing else is a complete item*. Every
 //! column below is nullable and has no default, and nothing here supplies one.
 
+use chrono::{DateTime, Utc};
 use sqlx::Row;
 use uuid::Uuid;
 
@@ -74,7 +75,7 @@ use super::super::content::{Malformed, Written, identifier, instant, malformed};
 use super::super::entity::{Applied, Ctx, Failed, Refusal, type_name};
 use super::{
     Decimal, Detachment, Field, Held, Property, Reader, SpecificPart, SpecificValue, nesting,
-    note_detached, read_column, read_properties, unbuilt, write_column, write_properties,
+    read_column, read_properties, unbuilt, write_column, write_properties,
 };
 
 // ---------------------------------------------------------------------------
@@ -184,30 +185,24 @@ pub const SHOPPING_LIST_FIELDS: &[Field] = &[Field {
     held: Held::NotServed(SHOPPING_LIST_DEFERRED),
 }];
 
-/// Why an item's assertion time is not a field a client states.
+/// Why an item's assertion time may be stated but never stated alone.
 ///
-/// **An expiring refusal, in the register of the three Wave 2.1 makes.** The
-/// field exists on the wire and will exist forever — field numbers are
-/// permanent — so this says what a client is waiting on rather than that its
-/// message was wrong.
+/// **The wire carries it and the instance honours it.** `ItemContent`'s field 3
+/// is *when the amount was last asserted*, and it exists so a client can say so:
+/// acceptance is local and durable on the device and the outbox replays later,
+/// so a count taken at nine and replayed at six is the ordinary case, not the
+/// exotic one. Wave 2.1 settled the same question one level up — a create's
+/// `created_at` is the client's, and substituting the instance's clock told a
+/// client its capture had landed with a time it never sent.
 ///
-/// The instance assigns it, for the same reason it assigns a category position:
-/// the column is constrained against another column, so the two move in one
-/// statement, and [`validate_and_place`] can see only one part at a time. A
-/// client free to state the time independently could put the row through the
-/// state `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))` refuses —
-/// by clearing the amount and stating a time in one message, or by stating a
-/// time on an item that has no amount — and the answer would be a constraint
-/// violation that takes the transaction down rather than a refusal anybody can
-/// act on.
-///
-/// **It expires when a device's own assertion time can cross.** A count taken
-/// offline at nine and replayed at six should read nine, not six. Today no
-/// client exists to have taken one, and the outbox that will carry it is Wave
-/// 4.1's; when it lands this becomes a companion carrying the stated instant
-/// rather than a refusal, and the pairing below is already where it goes.
-const ASSERTED_AT_IS_THE_INSTANCES: &str = "the time an amount was asserted is the amount's own and moves with it, so the instance \
-     sets it when the amount is written; stating it separately is not served yet";
+/// What is still refused is a time with no amount to belong to. The column is
+/// constrained by `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))`,
+/// so an assertion time on an item holding no amount, or stated in the same
+/// message that clears one, names a row the store cannot hold. Refused as
+/// malformed here rather than left to the constraint, which would take the whole
+/// transaction down with a message nobody can act on.
+const ASSERTED_AT_WITHOUT_AN_AMOUNT: &str = "the time an amount was asserted belongs to an amount, and this item would have none: \
+     state the amount in the same write, or leave the time alone";
 
 // ---------------------------------------------------------------------------
 // Reading the wire
@@ -328,18 +323,44 @@ fn properties(values: &[v1::PropertyValue]) -> Result<Vec<Property>, Malformed> 
 // What a part owes before it is applied
 // ---------------------------------------------------------------------------
 
+/// The instant a message states for field 3, if it states one.
+///
+/// **This is why the seam carries the whole addressed set.** The amount's
+/// companion has to be the client's own time where there is one and the
+/// instance's clock otherwise, and *whether the client stated one* is a fact
+/// about a different part of the same message.
+fn stated_assertion_time(addressed: &[SpecificPart]) -> Option<DateTime<Utc>> {
+    addressed.iter().find_map(|p| match (p.field, &p.value) {
+        (ITEM_ASSERTED_AT, SpecificValue::Instant(at)) => *at,
+        _ => None,
+    })
+}
+
+/// Whether a message says anything at all about the amount.
+fn addresses_amount(addressed: &[SpecificPart]) -> bool {
+    addressed.iter().any(|p| p.field == ITEM_AMOUNT)
+}
+
 pub async fn validate_and_place(
     ctx: &mut Ctx<'_>,
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
-) -> Applied<Option<SpecificPart>> {
+    addressed: &[SpecificPart],
+) -> Applied<Vec<SpecificPart>> {
     match (kind, part.field) {
         // **The companion.** An amount and the time it was asserted are
-        // constrained against each other, so they move in one statement and the
-        // instance supplies the time. Asserting an amount stamps now; clearing
-        // one clears the stamp with it, because a time an amount was asserted at
-        // is not something an item with no amount has.
+        // constrained against each other, so they move in one statement.
+        //
+        // The time is the client's where the client stated one, and the
+        // instance's clock otherwise. Both are the same act — *this is what is
+        // on the shelf, and this is when I looked* — and a device that counted
+        // at nine and reached the instance at six must record nine.
+        //
+        // Clearing the amount clears the stamp with it, because a time an
+        // amount was asserted at is not something an item with no amount has.
+        // A message that clears the amount and states a time is refused below
+        // rather than silently resolved either way.
         //
         // Re-stating the same amount is a real act — *I looked again, still
         // three* — and it moves the stamp while leaving the amount where it was.
@@ -347,17 +368,48 @@ pub async fn validate_and_place(
         // only as good as the last time somebody looked.
         (EntityType::Item, ITEM_AMOUNT) => {
             let asserted = matches!(part.value, SpecificValue::Number(Some(_)));
-            Ok(Some(SpecificPart {
+            let stated = stated_assertion_time(addressed);
+            if !asserted && stated.is_some() {
+                return Err(Refusal::Malformed(ASSERTED_AT_WITHOUT_AN_AMOUNT.into()).into());
+            }
+            Ok(vec![SpecificPart {
                 field: ITEM_ASSERTED_AT,
-                value: SpecificValue::Instant(asserted.then_some(ctx.at)),
-            }))
+                value: SpecificValue::Instant(asserted.then(|| stated.unwrap_or(ctx.at))),
+            }])
         }
 
-        // **Not a general modified time.** Renaming an item or correcting its
-        // notes does not confirm what is on the shelf, so nothing but the amount
-        // moves this, and a client may not move it by hand.
+        // **Stated, but never stated alone.** Where the amount is in the same
+        // message, this part's value has already travelled as that part's
+        // companion and landed in one statement with it; applying it again is
+        // the same value written twice and changes nothing.
+        //
+        // Where the amount is *not* in the message, the item must already hold
+        // one — otherwise the row would have a time and no amount, which the
+        // table refuses. Checked here so the answer is a refusal a client can
+        // act on rather than a constraint violation that takes the transaction
+        // down.
         (EntityType::Item, ITEM_ASSERTED_AT) => {
-            Err(Refusal::Malformed(ASSERTED_AT_IS_THE_INSTANCES.into()).into())
+            if !addresses_amount(addressed) {
+                let stored = read_column(
+                    ctx,
+                    entity,
+                    kind,
+                    &SpecificPart {
+                        field: ITEM_AMOUNT,
+                        value: SpecificValue::Number(None),
+                    },
+                )
+                .await?;
+                let holds_amount = matches!(stored.value, SpecificValue::Number(Some(_)));
+                let clearing = matches!(part.value, SpecificValue::Instant(None));
+                if !holds_amount && !clearing {
+                    return Err(Refusal::Malformed(ASSERTED_AT_WITHOUT_AN_AMOUNT.into()).into());
+                }
+                if holds_amount && clearing {
+                    return Err(Refusal::Malformed(ASSERTED_AT_WITHOUT_AN_AMOUNT.into()).into());
+                }
+            }
+            Ok(Vec::new())
         }
 
         // A location has to be one this member can see, and it has to be a
@@ -367,7 +419,7 @@ pub async fn validate_and_place(
             if let SpecificValue::Id(Some(id)) = part.value {
                 must_be(ctx, EntityId::from_uuid(id), EntityType::Location).await?;
             }
-            Ok(None)
+            Ok(Vec::new())
         }
 
         (EntityType::Location, LOCATION_PARENT) => {
@@ -390,7 +442,7 @@ pub async fn validate_and_place(
                     .into());
                 }
             }
-            Ok(None)
+            Ok(Vec::new())
         }
 
         // A template is not an entity and carries no audience: one shared set
@@ -402,13 +454,13 @@ pub async fn validate_and_place(
             if let SpecificValue::Id(Some(id)) = part.value {
                 template_exists(ctx, id).await?;
             }
-            Ok(None)
+            Ok(Vec::new())
         }
 
         // Words the person wrote. Nothing to check that reading them did not
         // already check.
         (EntityType::Item, ITEM_UNIT | ITEM_PROPERTIES)
-        | (EntityType::Location, LOCATION_PROPERTIES) => Ok(None),
+        | (EntityType::Location, LOCATION_PROPERTIES) => Ok(Vec::new()),
 
         (EntityType::ShoppingList, _) => {
             Err(Refusal::Malformed(SHOPPING_LIST_DEFERRED.into()).into())
@@ -504,18 +556,20 @@ pub async fn apply(
     entity: EntityId,
     kind: EntityType,
     part: &SpecificPart,
-    placement: Option<&SpecificPart>,
+    placements: &[SpecificPart],
 ) -> Applied<()> {
     match (kind, part.field) {
         // **One statement, both columns.** The table refuses the state in
         // between, so writing them in sequence fails whichever order the
         // sequence is in.
         (EntityType::Item, ITEM_AMOUNT) => {
-            let Some(SpecificPart {
-                field: ITEM_ASSERTED_AT,
-                value: SpecificValue::Instant(at),
-            }) = placement
-            else {
+            // **By field number, never by position.** A lane returning two
+            // companions must not depend on the order it returned them in.
+            let at = placements.iter().find_map(|p| match (p.field, &p.value) {
+                (ITEM_ASSERTED_AT, SpecificValue::Instant(at)) => Some(*at),
+                _ => None,
+            });
+            let Some(at) = at else {
                 // Unreachable: `validate_and_place` always produces the
                 // companion for this part. Refused rather than written alone,
                 // because the alternative is a statement the table rejects with
@@ -540,7 +594,7 @@ pub async fn apply(
             sqlx::query(sqlx::AssertSqlSafe(sql))
                 .bind(entity.as_uuid())
                 .bind(amount.as_ref().map(Decimal::text))
-                .bind(*at)
+                .bind(at)
                 .execute(ctx.tx.conn())
                 .await?;
             Ok(())
@@ -550,20 +604,21 @@ pub async fn apply(
             let SpecificValue::Properties(values) = &part.value else {
                 return Err(unaddressable(kind, part.field));
             };
-            debug_assert!(placement.is_none());
+            debug_assert!(placements.is_empty());
             write_properties(ctx, entity, values).await
         }
 
         (EntityType::Item, ITEM_UNIT | ITEM_LOCATION | ITEM_TEMPLATE)
         | (EntityType::Location, LOCATION_PARENT | LOCATION_TEMPLATE) => {
-            debug_assert!(placement.is_none());
+            debug_assert!(placements.is_empty());
             write_column(ctx, entity, kind, part).await
         }
 
-        // Refused before it could reach here; see `ASSERTED_AT_IS_THE_INSTANCES`.
-        (EntityType::Item, ITEM_ASSERTED_AT) => {
-            Err(Refusal::Malformed(ASSERTED_AT_IS_THE_INSTANCES.into()).into())
-        }
+        // Validated above, and written here as its own column. Where the amount
+        // was in the same message this is the second write of a value that
+        // already landed with it, which is idempotent by construction: the
+        // companion carried this same instant.
+        (EntityType::Item, ITEM_ASSERTED_AT) => write_column(ctx, entity, kind, part).await,
         (EntityType::ShoppingList, _) => {
             Err(Refusal::Malformed(SHOPPING_LIST_DEFERRED.into()).into())
         }
@@ -628,13 +683,15 @@ pub async fn detach_contained(
         }
     }
 
-    // **Deliberately unscoped**, for the reason `uncategorise_all` gives: the
-    // container is gone for everybody, so leaving behind the rows the erasing
-    // member cannot see would keep a dangling reference alive precisely where
-    // nobody can find it. Nothing leaves here that a caller can show anyone —
-    // the identities become change entries, and those are assembled per member
-    // by the read path, which applies the predicate then.
-    note_detached(ctx, &released).await?;
+    // **Deliberately unscoped**, for the reason `uncategorise_all` gives and
+    // which is no smaller here: the container is gone for everybody, so leaving
+    // behind the rows the erasing member cannot see would keep a dangling
+    // reference alive precisely where nobody can find it. Do not add a
+    // predicate. Nothing leaves here that a caller can show anyone.
+    //
+    // The counter and the change entry are `store::entity::detached_from_container`'s,
+    // because a change entry needs the audience and this file may not name that
+    // column. See that function for the split.
     Ok(Detachment::Released(released))
 }
 

--- a/crates/altaird/tests/part_provenance.rs
+++ b/crates/altaird/tests/part_provenance.rs
@@ -1,0 +1,1113 @@
+//! One invariant over `entity_part_counter`, applied to every kind of part.
+//!
+//! # Why this suite exists
+//!
+//! Wave 2.2 produced four bugs in this one table, and every one of them was
+//! silent:
+//!
+//! - a part **recorded that did not move** — a write submitting a value that was
+//!   already there took ownership of the part, so a later conflict named a
+//!   member who had authored nothing;
+//! - a part that **moved and was not recorded** — `uncategorise_all` cleared a
+//!   category and its position and advanced the counter, and the table said
+//!   nothing happened;
+//! - the same again on the type-specific release, where an erased container let
+//!   go of what it held;
+//! - and **the member**, which is the third face of the first: `member_id` is
+//!   overwritten by whoever wrote last, and it crosses the wire in
+//!   `conflict.theirs_member_id` for a client to render.
+//!
+//! Each was found by reading code. None was caught by a test, because every
+//! check on this table was incidental to some other assertion — a test about
+//! conflicts that happened to look at a counter. **This suite makes the table
+//! the subject.**
+//!
+//! # The invariant
+//!
+//! > **The set of parts a write records is exactly the set whose stored value
+//! > changed, and each is attributed to the member who changed it.**
+//!
+//! Both halves matter and they fail in opposite directions. A part recorded
+//! without moving makes an unrelated later edit look like an overlap; a part
+//! that moves without being recorded makes a real overlap invisible, and *both
+//! values retained on a same-part conflict* is a standing constraint.
+//!
+//! # How the expected set is derived, and why not the obvious way
+//!
+//! **Never from the write path.** The tempting implementation asks
+//! `write::entity::current` what a part holds, which is the same code the write
+//! path uses to decide what it recorded — an assertion against itself, green
+//! whatever either does. This wave already produced one test that passed with
+//! the mechanism it was testing deliberately broken, and the lesson generalises.
+//!
+//! So the expected set comes from **the store's own columns, read as text**,
+//! through the field-to-column mapping each type declares in
+//! [`altaird::write::specific`]. Snapshot every part before a write, snapshot
+//! after, and the parts whose text differs are the parts that moved. Nothing in
+//! that path consults provenance, and nothing renders a value the way the write
+//! path renders it — [`snapshot`] reads `entity`, `block` and the side tables
+//! directly.
+//!
+//! The rendering here need not match the write path's. It only has to be
+//! *stable*, because the only question asked of it is whether two readings of
+//! the same column differ.
+//!
+//! # Two guards on the suite itself
+//!
+//! - **Every exercise must write something.** A write path that refused
+//!   everything would satisfy "no part was wrongly recorded" perfectly, and an
+//!   exercise whose intent drifts into refusal would go on passing while testing
+//!   nothing. [`Exercise::run`] refuses an empty change set unless the exercise
+//!   says it expects one.
+//! - **The mapping is walked, not listed.** Type-specific parts come from
+//!   `specific::fields`, so a type gaining a field is covered here without
+//!   anyone remembering to add it. Listing them would drift exactly as the two
+//!   callers of `would_cycle` drifted.
+
+mod common;
+
+use std::collections::{HashMap, HashSet};
+
+use altair_proto::v1;
+use altaird::store::audience::AUDIENCE_COLUMN;
+use altaird::store::entity::EntityType;
+use altaird::store::ids::EntityId;
+use altaird::write::parts::{ALL_CONTENT_PARTS, ContentPart, Part, PartKey};
+use altaird::write::specific::{self, Held};
+use common::*;
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Reading what the store actually holds
+// ---------------------------------------------------------------------------
+
+/// The separators a composite value is rendered with here.
+///
+/// The same two the write path uses, but that is a convenience rather than a
+/// requirement: nothing compares a value produced here against one produced
+/// there. What matters is that two readings of an unchanged column produce the
+/// same string.
+const WITHIN: &str = "\u{1f}";
+const BETWEEN: &str = "\u{1e}";
+
+async fn scalar(pool: &PgPool, sql: String, id: Uuid) -> Option<String> {
+    sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+        .expect("query")
+        .and_then(|r| r.try_get::<Option<String>, _>("v").expect("v"))
+}
+
+/// The raw column behind each shared-model part.
+///
+/// A test may name the audience column and query `entity` directly, and
+/// `tests/one_predicate.rs` exempts test sources deliberately — a suite that
+/// could only read the store through the audience-scoped surface would be
+/// checking the predicate against itself.
+fn content_sql(part: ContentPart) -> String {
+    match part {
+        ContentPart::Title => "SELECT title AS v FROM entity WHERE id = $1".into(),
+        ContentPart::Category => "SELECT category_id::text AS v FROM entity WHERE id = $1".into(),
+        ContentPart::CategoryPosition => {
+            "SELECT category_position::text AS v FROM entity WHERE id = $1".into()
+        }
+        ContentPart::Bulk => "SELECT bulk::text AS v FROM entity WHERE id = $1".into(),
+        ContentPart::Audience => format!(
+            "SELECT nullif(array_to_string(ARRAY(\
+               SELECT unnest({AUDIENCE_COLUMN}) ORDER BY 1), ','), '') AS v \
+             FROM entity WHERE id = $1"
+        ),
+        ContentPart::Dates => format!(
+            "SELECT string_agg(label || '{WITHIN}' || occurs_at::text || '{WITHIN}' || \
+               bring_forward::text, '{BETWEEN}' ORDER BY ordinal) AS v \
+             FROM entity_date WHERE entity_id = $1"
+        ),
+        ContentPart::Assignments => "SELECT string_agg(member_id::text, ',' ORDER BY \
+             member_id::text) AS v FROM entity_assignment WHERE entity_id = $1"
+            .into(),
+    }
+}
+
+/// Every part of one entity, and the text the store holds for it.
+///
+/// `None` means the part holds nothing — including the case where the entity or
+/// its side-table row does not exist, which is what makes a snapshot taken
+/// before a create meaningful.
+///
+/// **Type-specific parts are walked from the declaration**, so a type gaining a
+/// field is covered without anyone adding a line here.
+async fn snapshot(pool: &PgPool, id: EntityId, kind: EntityType) -> HashMap<Part, Option<String>> {
+    let uuid = id.as_uuid();
+    let mut out = HashMap::new();
+
+    for part in ALL_CONTENT_PARTS {
+        out.insert(
+            Part::Content(*part),
+            scalar(pool, content_sql(*part), uuid).await,
+        );
+    }
+
+    let table = specific::side_table(kind);
+    for field in specific::fields(kind) {
+        let value = match (field.held, table) {
+            (Held::Column(column), Some(table)) => {
+                scalar(
+                    pool,
+                    format!("SELECT {column}::text AS v FROM {table} WHERE entity_id = $1"),
+                    uuid,
+                )
+                .await
+            }
+            (Held::Rows(rows), _) => {
+                scalar(
+                    pool,
+                    format!(
+                        "SELECT string_agg(name || '{WITHIN}' || coalesce(value, ''), \
+                         '{BETWEEN}' ORDER BY name) AS v FROM {rows} WHERE entity_id = $1"
+                    ),
+                    uuid,
+                )
+                .await
+            }
+            // A body is not one part. Its blocks are, and they are collected
+            // below by identity rather than by field number.
+            (Held::Body, _) | (Held::NotServed(_), _) | (Held::Column(_), None) => continue,
+        };
+        out.insert(Part::Specific(field.number), value);
+    }
+
+    let blocks = sqlx::query("SELECT id, text FROM block WHERE entity_id = $1")
+        .bind(uuid)
+        .fetch_all(pool)
+        .await
+        .expect("blocks");
+    for b in &blocks {
+        out.insert(
+            Part::Block(b.try_get("id").expect("id")),
+            Some(b.try_get::<String, _>("text").expect("text")),
+        );
+    }
+
+    out
+}
+
+/// The parts whose stored text differs between two snapshots.
+///
+/// A part present in one snapshot and absent from the other is a block that was
+/// created or removed, and that is a change.
+fn changed(
+    before: &HashMap<Part, Option<String>>,
+    after: &HashMap<Part, Option<String>>,
+) -> HashSet<Part> {
+    let mut parts: HashSet<Part> = HashSet::new();
+    for key in before.keys().chain(after.keys()) {
+        let was = before.get(key).cloned().flatten();
+        let is = after.get(key).cloned().flatten();
+        if was != is {
+            parts.insert(key.clone());
+        }
+    }
+    parts
+}
+
+/// Parts in a stable order, for a message a person can read.
+///
+/// `Part` is hashed rather than ordered, so a set has no order of its own and an
+/// assertion message would otherwise vary between runs.
+fn listed(parts: &HashSet<Part>) -> Vec<String> {
+    let mut out: Vec<String> = parts.iter().map(|p| format!("{p:?}")).collect();
+    out.sort();
+    out
+}
+
+/// What `entity_part_counter` says moved at exactly this counter.
+async fn recorded_at(pool: &PgPool, id: EntityId, counter: i64) -> HashSet<Part> {
+    let rows = sqlx::query(
+        "SELECT field_name, block_id FROM entity_part_counter \
+         WHERE entity_id = $1 AND counter = $2",
+    )
+    .bind(id.as_uuid())
+    .bind(counter)
+    .fetch_all(pool)
+    .await
+    .expect("part counters");
+
+    rows.iter()
+        .map(|r| {
+            let field: Option<String> = r.try_get("field_name").expect("field_name");
+            let block: Option<Uuid> = r.try_get("block_id").expect("block_id");
+            let key = match (field, block) {
+                (Some(name), None) => PartKey::Field(name),
+                (None, Some(id)) => PartKey::Block(id),
+                other => panic!("a part row set both or neither: {other:?}"),
+            };
+            Part::from_key(&key).expect("a part name this build knows")
+        })
+        .collect()
+}
+
+/// Who `entity_part_counter` says last moved a part.
+async fn owner_of(pool: &PgPool, id: EntityId, part: &Part) -> Option<Uuid> {
+    let (field, block) = match part.key() {
+        PartKey::Field(name) => (Some(name), None),
+        PartKey::Block(id) => (None, Some(id)),
+    };
+    sqlx::query(
+        "SELECT member_id FROM entity_part_counter \
+         WHERE entity_id = $1 AND field_name IS NOT DISTINCT FROM $2 \
+           AND block_id IS NOT DISTINCT FROM $3",
+    )
+    .bind(id.as_uuid())
+    .bind(field)
+    .bind(block)
+    .fetch_optional(pool)
+    .await
+    .expect("query")
+    .and_then(|r| r.try_get("member_id").expect("member_id"))
+}
+
+async fn counter_of(pool: &PgPool, id: EntityId) -> i64 {
+    sqlx::query("SELECT counter FROM entity WHERE id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(pool)
+        .await
+        .expect("entity")
+        .try_get("counter")
+        .expect("counter")
+}
+
+// ---------------------------------------------------------------------------
+// The invariant, applied
+// ---------------------------------------------------------------------------
+
+/// One write, checked against the invariant.
+///
+/// The entity watched need not be the entity written: the upward state climb
+/// and both container releases move parts on *other* entities, and those are
+/// exactly the writes where "a part moved and nothing recorded it" lived.
+struct Watch {
+    entity: EntityId,
+    kind: EntityType,
+    before: HashMap<Part, Option<String>>,
+    counter_before: i64,
+}
+
+impl Watch {
+    async fn open(world: &World, entity: EntityId, kind: EntityType) -> Self {
+        Self {
+            entity,
+            kind,
+            before: snapshot(&world.db.pool, entity, kind).await,
+            counter_before: counter_of(&world.db.pool, entity).await,
+        }
+    }
+
+    /// Check the invariant, and return the parts that moved.
+    ///
+    /// `expect_change` is the second guard on the suite: an exercise that stops
+    /// writing anything — because a refusal crept in, or because the shape it
+    /// exercised moved — would otherwise satisfy the invariant trivially and go
+    /// on passing.
+    async fn close(self, world: &World, what: &str) -> HashSet<Part> {
+        let after = snapshot(&world.db.pool, self.entity, self.kind).await;
+        let moved = changed(&self.before, &after);
+        let counter = counter_of(&world.db.pool, self.entity).await;
+
+        assert!(
+            !moved.is_empty(),
+            "{what}: nothing about {:?} changed, so this exercise is asserting the \
+             invariant against an empty set and would pass however the write path behaved",
+            self.entity
+        );
+        assert!(
+            counter > self.counter_before,
+            "{what}: parts of {:?} moved ({:?}) and its counter did not, so no \
+             client can learn the write happened",
+            self.entity,
+            listed(&moved)
+        );
+
+        let recorded = recorded_at(&world.db.pool, self.entity, counter).await;
+        assert_eq!(
+            recorded,
+            moved,
+            "{what}: the parts recorded at counter {counter} are not the parts whose \
+             stored value changed.\n  recorded but unchanged: {:?}\n  changed but \
+             unrecorded: {:?}",
+            listed(&recorded.difference(&moved).cloned().collect()),
+            listed(&moved.difference(&recorded).cloned().collect())
+        );
+        moved
+    }
+
+    /// The other half: a write that changed nothing about this entity must
+    /// record nothing about it either.
+    async fn close_expecting_no_change(self, world: &World, what: &str) {
+        let after = snapshot(&world.db.pool, self.entity, self.kind).await;
+        let moved = changed(&self.before, &after);
+        assert!(
+            moved.is_empty(),
+            "{what}: expected nothing to change, but {:?} did",
+            listed(&moved)
+        );
+        let counter = counter_of(&world.db.pool, self.entity).await;
+        let recorded = recorded_at(&world.db.pool, self.entity, counter).await;
+        assert!(
+            recorded.is_empty(),
+            "{what}: nothing about {:?} changed, yet {:?} were recorded as having \
+             moved at counter {counter}. A later edit will read that as an overlap.",
+            self.entity,
+            listed(&recorded)
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared-model parts
+// ---------------------------------------------------------------------------
+
+fn note() -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Note(v1::NoteContent::default())
+}
+
+fn campaign(state: Option<v1::GuidanceState>) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Campaign(v1::CampaignContent {
+        state: state.map(|s| s as i32),
+        cleared: Vec::new(),
+    })
+}
+
+fn item(c: v1::ItemContent) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Item(c)
+}
+
+fn id_bytes(id: EntityId) -> Vec<u8> {
+    id.as_uuid().as_bytes().to_vec()
+}
+
+#[tokio::test]
+async fn an_edit_to_shared_content_records_exactly_what_changed() {
+    let world = World::new().await;
+    let id = world.note(&world.one, "before").await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    title: Some("after".into()),
+                    bulk: Some(true),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "title and bulk").await;
+    assert!(moved.contains(&Part::Content(ContentPart::Title)));
+    assert!(moved.contains(&Part::Content(ContentPart::Bulk)));
+}
+
+/// **A part addressed with the value it already holds did not move.** The write
+/// still applies and the counter still advances; what must not happen is the
+/// part being claimed.
+#[tokio::test]
+async fn a_write_addressing_a_part_without_changing_it_records_nothing() {
+    let world = World::new().await;
+    let id = world.note(&world.one, "unchanged").await;
+    let base = counter_of(&world.db.pool, id).await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    title: Some("unchanged".into()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    watch
+        .close_expecting_no_change(&world, "a title rewritten to itself")
+        .await;
+    assert_eq!(
+        counter_of(&world.db.pool, id).await,
+        base + 1,
+        "the counter must still advance, or no client learns there was a write"
+    );
+}
+
+/// Clearing is a change, and an empty part is a value like any other.
+#[tokio::test]
+async fn clearing_a_part_records_it_as_moved() {
+    let world = World::new().await;
+    let id = world.note(&world.one, "a title").await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    cleared: vec![ContentPart::Title.field_number()],
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "a cleared title").await;
+    assert_eq!(moved, HashSet::from([Part::Content(ContentPart::Title)]));
+}
+
+// ---------------------------------------------------------------------------
+// Type-specific parts, across three lanes
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_guidance_state_records_exactly_what_changed() {
+    let world = World::new().await;
+    let id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let watch = Watch::open(&world, id, EntityType::Campaign).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(campaign(Some(v1::GuidanceState::Working))),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "a campaign state").await;
+    assert_eq!(moved, HashSet::from([Part::Specific(1)]));
+}
+
+/// **The companion case.** An item's amount and the moment it was asserted move
+/// in one statement, and both are parts. Neither may go unrecorded.
+#[tokio::test]
+async fn an_item_amount_records_itself_and_its_companion() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, id, EntityType::Item).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(item(v1::ItemContent {
+                        asserted_amount: Some(v1::Decimal { units: 3, nanos: 0 }),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "an item amount").await;
+    assert!(moved.contains(&Part::Specific(1)), "the amount");
+    assert!(moved.contains(&Part::Specific(3)), "its assertion time");
+}
+
+/// A category's own nesting is type content like any other.
+#[tokio::test]
+async fn a_category_parent_records_exactly_what_changed() {
+    let world = World::new().await;
+    let outer = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let inner = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, inner, EntityType::Category).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                inner,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Category(
+                        v1::CategoryContent {
+                            parent_category_id: Some(id_bytes(outer)),
+                            ..Default::default()
+                        },
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "a category parent").await;
+    assert_eq!(moved, HashSet::from([Part::Specific(1)]));
+}
+
+// ---------------------------------------------------------------------------
+// Blocks
+// ---------------------------------------------------------------------------
+
+/// **A body is many parts, one per block**, and the invariant is the same one.
+/// Editing one paragraph of three must record that block and not its neighbours.
+#[tokio::test]
+async fn editing_one_block_of_a_body_records_that_block_alone() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Note(v1::NoteContent {
+                body: Some("one paragraph.\n\ntwo paragraph.\n\nthree paragraph.\n".into()),
+                cleared: Vec::new(),
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                        body: Some(
+                            "one paragraph.\n\ntwo paragraph, edited.\n\nthree paragraph.\n".into(),
+                        ),
+                        cleared: Vec::new(),
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "one block of three").await;
+    assert_eq!(
+        moved.len(),
+        1,
+        "only the edited block moved: {:?}",
+        listed(&moved)
+    );
+    assert!(
+        matches!(moved.iter().next(), Some(Part::Block(_))),
+        "the part that moved is a block, not {:?}",
+        listed(&moved)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The consequential writes — where "moved and unrecorded" actually lived
+// ---------------------------------------------------------------------------
+
+/// Entering a container places the entity at the end, and the position the
+/// instance assigns is a part the client never named.
+#[tokio::test]
+async fn a_position_the_instance_assigns_is_recorded_with_the_category() {
+    let world = World::new().await;
+    let category = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let id = world.note(&world.one, "filed").await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    category_id: Some(id_bytes(category)),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "entering a category").await;
+    assert!(moved.contains(&Part::Content(ContentPart::Category)));
+    assert!(
+        moved.contains(&Part::Content(ContentPart::CategoryPosition)),
+        "the instance assigned a position and it is a part like any other"
+    );
+}
+
+/// **The membership release.** Erasing a category moves two parts on every
+/// entity filed in it, and the write is to *those* entities rather than to the
+/// one the intent named.
+#[tokio::test]
+async fn erasing_a_category_records_what_it_moved_on_the_entities_it_released() {
+    let world = World::new().await;
+    let category = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let filed = world
+        .create(
+            &world.one,
+            note(),
+            v1::EntityContent {
+                title: Some("filed".into()),
+                category_id: Some(id_bytes(category)),
+                ..Default::default()
+            },
+        )
+        .await;
+    let watch = Watch::open(&world, filed, EntityType::Note).await;
+
+    world.submit(&world.one, erase(&[category])).await;
+
+    let moved = watch.close(&world, "erasing the category above it").await;
+    assert!(moved.contains(&Part::Content(ContentPart::Category)));
+    assert!(moved.contains(&Part::Content(ContentPart::CategoryPosition)));
+}
+
+/// **The type-specific release**, on both the things a location holds.
+#[tokio::test]
+async fn erasing_a_location_records_what_it_moved_on_what_it_held() {
+    let world = World::new().await;
+    let cupboard = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Location(v1::LocationContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let shelf = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Location(v1::LocationContent {
+                parent_location_id: Some(id_bytes(cupboard)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                location_id: Some(id_bytes(cupboard)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let on_shelf = Watch::open(&world, shelf, EntityType::Location).await;
+    let on_tin = Watch::open(&world, tin, EntityType::Item).await;
+
+    world.submit(&world.one, erase(&[cupboard])).await;
+
+    let moved = on_shelf.close(&world, "a child location released").await;
+    assert_eq!(moved, HashSet::from([Part::Specific(1)]));
+    let moved = on_tin.close(&world, "an item released").await;
+    assert_eq!(moved, HashSet::from([Part::Specific(4)]));
+}
+
+/// **The upward climb.** Starting a quest moves the state of every container
+/// above it, and those are writes to entities the intent never named.
+#[tokio::test]
+async fn the_upward_state_climb_records_what_it_moved_on_each_container() {
+    let world = World::new().await;
+    let campaign_id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let quest = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Quest(v1::QuestContent {
+                parent: Some(v1::quest_content::Parent::CampaignId(id_bytes(campaign_id))),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let on_campaign = Watch::open(&world, campaign_id, EntityType::Campaign).await;
+    let base = counter_of(&world.db.pool, quest).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                quest,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Quest(v1::QuestContent {
+                        state: Some(v1::GuidanceState::Working as i32),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = on_campaign
+        .close(&world, "a campaign moved by the climb")
+        .await;
+    assert_eq!(
+        moved,
+        HashSet::from([Part::Specific(1)]),
+        "the container's state moved and only its state"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The member, which is the third face of the same table
+// ---------------------------------------------------------------------------
+
+/// **A no-op write must not take ownership.** `member_id` is overwritten by
+/// whoever records last, and it crosses the wire in `conflict.theirs_member_id`
+/// for a client to render a name.
+#[tokio::test]
+async fn a_no_op_write_leaves_the_part_owned_by_whoever_changed_it() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            note(),
+            v1::EntityContent {
+                title: Some("start".into()),
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+    let base = counter_of(&world.db.pool, id).await;
+
+    // Two really changes it.
+    world
+        .submit(
+            &world.two,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    title: Some("agreed".into()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    // One, stale, submits the value that is already there.
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    title: Some("agreed".into()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    assert_eq!(
+        owner_of(&world.db.pool, id, &Part::Content(ContentPart::Title)).await,
+        Some(world.two.membership_id()),
+        "the member who wrote nothing took ownership of the part"
+    );
+}
+
+/// And the part each write does change is attributed to whoever wrote it, when
+/// two members move different parts of one entity.
+#[tokio::test]
+async fn each_part_is_owned_by_the_member_who_moved_that_part() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            note(),
+            v1::EntityContent {
+                title: Some("start".into()),
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+    let base = counter_of(&world.db.pool, id).await;
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    title: Some("one wrote this".into()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let base = counter_of(&world.db.pool, id).await;
+    world
+        .submit(
+            &world.two,
+            edit_entity(
+                id,
+                base as u64,
+                v1::EntityContent {
+                    bulk: Some(true),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    assert_eq!(
+        owner_of(&world.db.pool, id, &Part::Content(ContentPart::Title)).await,
+        Some(world.one.membership_id())
+    );
+    assert_eq!(
+        owner_of(&world.db.pool, id, &Part::Content(ContentPart::Bulk)).await,
+        Some(world.two.membership_id())
+    );
+}
+
+/// A part moved as a consequence is attributed to the member who caused it —
+/// the one who erased the container, not the one who filed the entity.
+#[tokio::test]
+async fn a_released_part_is_owned_by_the_member_who_erased_the_container() {
+    let world = World::new().await;
+    let category = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent {
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+    let filed = world
+        .create(
+            &world.two,
+            note(),
+            v1::EntityContent {
+                title: Some("theirs".into()),
+                category_id: Some(id_bytes(category)),
+                audience_member_ids: vec![world.one.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+    world.submit(&world.one, erase(&[category])).await;
+
+    assert_eq!(
+        owner_of(&world.db.pool, filed, &Part::Content(ContentPart::Category)).await,
+        Some(world.one.membership_id()),
+        "the release is attributed to whoever caused it"
+    );
+}
+
+/// The remaining shared-model parts, which are all list-shaped and none of which
+/// is a plain column.
+#[tokio::test]
+async fn the_list_shaped_content_parts_record_exactly_what_changed() {
+    let world = World::new().await;
+    let id = world.note(&world.one, "listy").await;
+    let watch = Watch::open(&world, id, EntityType::Note).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    dates: vec![v1::LabelledDate {
+                        label: "due".into(),
+                        when: Some(timestamp(chrono::Utc::now())),
+                        bring_forward: true,
+                    }],
+                    assigned_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                    audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "dates, assignments and audience").await;
+    assert!(moved.contains(&Part::Content(ContentPart::Dates)));
+    assert!(moved.contains(&Part::Content(ContentPart::Assignments)));
+    assert!(moved.contains(&Part::Content(ContentPart::Audience)));
+}
+
+/// Guidance's ladder: a parent and the position that moves with it.
+#[tokio::test]
+async fn a_ladder_parent_records_itself_and_the_position_it_moved() {
+    let world = World::new().await;
+    let campaign_id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let arc = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Arc(v1::ArcContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, arc, EntityType::Arc).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                arc,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Arc(v1::ArcContent {
+                        campaign_id: Some(id_bytes(campaign_id)),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch.close(&world, "an arc entering a campaign").await;
+    assert!(
+        moved.contains(&Part::Specific(2)),
+        "the campaign it entered"
+    );
+    assert!(
+        moved.contains(&Part::Specific(3)),
+        "the ladder position the instance assigned"
+    );
+}
+
+/// **The first thing this suite found, and it is a real hole rather than a
+/// too-strong invariant.**
+///
+/// A quest moving from an arc to a campaign clears `arc_id` in the same
+/// statement that sets `campaign_id` — the row may never hold two. The vacated
+/// column is a part like any other and its value changed, but only the addressed
+/// parent and the position are handed back as companions, so `arc_id` records
+/// nothing. A concurrent edit to the arc then merges silently instead of
+/// retaining both values, and *both values retained on a same-part conflict* is
+/// a standing constraint.
+///
+/// Run it and it fails with exactly:
+///
+/// ```text
+///   recorded but unchanged: []
+///   changed but unrecorded: ["Specific(2)"]
+/// ```
+///
+/// **Ignored rather than deleted or weakened.** The seam it needs is built — a
+/// type may return as many companions as it moved — and filling it in is
+/// `specific/guidance.rs`, which this lane does not own. The Guidance note that
+/// predicted this also names the trap in fixing it: hand the vacated parent back
+/// **only when the sibling column was actually non-null**, or the write records a
+/// part that did not move and a later unrelated edit reads it as an overlap. That
+/// direction of the invariant is covered by
+/// `a_write_addressing_a_part_without_changing_it_records_nothing`, so both
+/// mistakes are caught.
+///
+/// **LANE: Guidance.** Remove the `#[ignore]` when the vacated parent is handed
+/// back; nothing else about this test should need to change.
+#[tokio::test]
+#[ignore = "known hole: the vacated ladder parent records no provenance — Guidance's, on the widened seam"]
+async fn a_vacated_ladder_parent_records_that_it_moved() {
+    let world = World::new().await;
+    let campaign_id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let arc = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Arc(v1::ArcContent {
+                campaign_id: Some(id_bytes(campaign_id)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let quest = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Quest(v1::QuestContent {
+                parent: Some(v1::quest_content::Parent::ArcId(id_bytes(arc))),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, quest, EntityType::Quest).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                quest,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Quest(v1::QuestContent {
+                        parent: Some(v1::quest_content::Parent::CampaignId(id_bytes(campaign_id))),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    watch
+        .close(&world, "a quest moving from an arc to a campaign")
+        .await;
+}

--- a/crates/altaird/tests/part_provenance.rs
+++ b/crates/altaird/tests/part_provenance.rs
@@ -1059,10 +1059,15 @@ async fn a_ladder_parent_records_itself_and_the_position_it_moved() {
 /// `a_write_addressing_a_part_without_changing_it_records_nothing`, so both
 /// mistakes are caught.
 ///
-/// **LANE: Guidance.** Remove the `#[ignore]` when the vacated parent is handed
-/// back; nothing else about this test should need to change.
+/// **This test found the hole it now guards.** On its first run, against a tree
+/// where a quest moving from an arc to a campaign cleared `arc_id` in the same
+/// statement and recorded nothing for it, it failed with
+/// `changed but unrecorded: ["Specific(2)"]` — naming the part from behaviour.
+/// The Guidance lane had predicted the same hole hours earlier by reading the
+/// code, without knowing this suite existed. It was `#[ignore]`d rather than
+/// weakened while the fix was owed, and nothing about it changed when the fix
+/// landed, which is the whole claim of an invariant written before its subject.
 #[tokio::test]
-#[ignore = "known hole: the vacated ladder parent records no provenance — Guidance's, on the widened seam"]
 async fn a_vacated_ladder_parent_records_that_it_moved() {
     let world = World::new().await;
     let campaign_id = world

--- a/crates/altaird/tests/part_provenance.rs
+++ b/crates/altaird/tests/part_provenance.rs
@@ -52,6 +52,37 @@
 //! *stable*, because the only question asked of it is whether two readings of
 //! the same column differ.
 //!
+//! # Why the whole-set invariant is asserted on edits, not on creates
+//!
+//! **It does not hold on a create, and that is correct rather than a bug.**
+//! Measured, not assumed — a create that clears a title and states nothing else
+//! gives:
+//!
+//! ```text
+//! changed:  ["Content(Bulk)"]
+//! recorded: ["Content(Title)"]
+//! ```
+//!
+//! Both directions diverge, and each for a good reason. `bulk` changed because
+//! the row went from absent to the column's `false`, which nobody wrote — the
+//! entity came into existence, and recording provenance for every column that
+//! took a default would say a member edited things they never addressed.
+//! `title` was recorded because a create records what it applied without
+//! comparing, there being no prior value to compare against.
+//!
+//! Neither is reachable as a fault. Provenance written at counter 1 cannot
+//! produce a spurious conflict, because conflict detection runs only when an
+//! edit's base counter is *below* the entity's, and nothing can hold a base
+//! below the counter a create issues.
+//!
+//! So the whole-set invariant belongs to the edit path and to the consequential
+//! writes, where a prior value exists and provenance is actually read. **A
+//! create is not exempt from scrutiny** — it is asserted per part instead, where
+//! a specific claim is meaningful: see
+//! `a_companion_for_an_empty_sibling_is_not_recorded_on_creation`, which is the
+//! one path where a type handing back a companion it did not move reaches the
+//! store unfiltered.
+//!
 //! # Two guards on the suite itself
 //!
 //! - **Every exercise must write something.** A write path that refused
@@ -1054,10 +1085,19 @@ async fn a_ladder_parent_records_itself_and_the_position_it_moved() {
 /// `specific/guidance.rs`, which this lane does not own. The Guidance note that
 /// predicted this also names the trap in fixing it: hand the vacated parent back
 /// **only when the sibling column was actually non-null**, or the write records a
-/// part that did not move and a later unrelated edit reads it as an overlap. That
-/// direction of the invariant is covered by
-/// `a_write_addressing_a_part_without_changing_it_records_nothing`, so both
-/// mistakes are caught.
+/// part that did not move and a later unrelated edit reads it as an overlap.
+///
+/// That opposite direction is covered by
+/// `a_companion_for_an_empty_sibling_is_not_recorded_on_creation`, on the create
+/// path — which is the only path where it is observable, because the edit loop
+/// suppresses a phantom companion on its own. **An earlier version of this
+/// comment claimed the cover came from
+/// `a_write_addressing_a_part_without_changing_it_records_nothing`, and that was
+/// false**: that test rewrites an unchanged title, a content part, on the doubly
+/// guarded path. A cross-model review caught it with a mutation that escaped the
+/// whole suite. The claim is recorded here rather than quietly corrected,
+/// because a sentence asserting coverage that does not exist is worse than no
+/// sentence — it stops the next reader checking.
 ///
 /// **This test found the hole it now guards.** On its first run, against a tree
 /// where a quest moving from an arc to a campaign cleared `arc_id` in the same
@@ -1115,4 +1155,148 @@ async fn a_vacated_ladder_parent_records_that_it_moved() {
     watch
         .close(&world, "a quest moving from an arc to a campaign")
         .await;
+}
+
+/// **The other direction, on a companion: a part handed back that did not move.**
+///
+/// A quest with no parent at all gains an arc. `campaign_id` was already null
+/// and stays null, so it did not move and must not be recorded. A release or a
+/// placement that handed back the sibling unconditionally — clearing a column
+/// that was already clear — would write an `entity_part_counter` row claiming
+/// that part moved, and a later unrelated edit to the campaign would read it as
+/// an overlap. Nothing about the stored row would look wrong.
+///
+/// **On this path the invariant is protected twice**, and that is worth knowing
+/// rather than discovering. `write::entity`'s edit loop records a part only when
+/// its rendered value changed, so a phantom companion is suppressed here even if
+/// a type hands one back. This test therefore asserts a true thing that a
+/// mispaired companion alone cannot break — the create path is where that bites,
+/// and `a_companion_for_an_empty_sibling_is_not_recorded_on_creation` is the one
+/// that catches it.
+#[tokio::test]
+async fn a_companion_for_a_sibling_that_was_already_empty_is_not_recorded() {
+    let world = World::new().await;
+    let campaign_id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let arc = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Arc(v1::ArcContent {
+                campaign_id: Some(id_bytes(campaign_id)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    // A quest hanging from nothing: both ladder parents are null.
+    let quest = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Quest(v1::QuestContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let watch = Watch::open(&world, quest, EntityType::Quest).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                quest,
+                watch.counter_before as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Quest(v1::QuestContent {
+                        parent: Some(v1::quest_content::Parent::ArcId(id_bytes(arc))),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let moved = watch
+        .close(&world, "a parentless quest entering an arc")
+        .await;
+    assert!(moved.contains(&Part::Specific(2)), "the arc it entered");
+    assert!(moved.contains(&Part::Specific(5)), "the ladder position");
+    // `close` already asserts recorded == moved, so the campaign being absent
+    // from `moved` is what makes a phantom record fail. Stated too, because this
+    // is the whole point of the test rather than a detail of it.
+    assert!(
+        !moved.contains(&Part::Specific(3)),
+        "the campaign was already empty and did not move: {:?}",
+        listed(&moved)
+    );
+}
+
+/// **The same mistake on creation, which is where it is observable.**
+///
+/// `write::entity`'s *edit* loop records a part only when its rendered value
+/// changed, so a companion handed back for a sibling that did not move is
+/// suppressed there. Its *create* loop records every part it applies
+/// unconditionally — correctly, since on a create there is no prior value to
+/// compare against — so on that path **a type handing back a companion it did
+/// not move is the only thing standing between the store and a phantom
+/// `entity_part_counter` row**.
+///
+/// A quest created straight into an arc has never had a campaign. If the ladder
+/// handed back `campaign_id` regardless, the create would record `specific.3` as
+/// having moved, and a later unrelated edit to the campaign would read that as an
+/// overlap and retain two values for a part nobody touched twice.
+///
+/// # This is the mutation the cross-model review escaped
+///
+/// Dropping the `Some(_)` from the sibling guard in `guidance::parent_placement`
+/// makes the companion unconditional. Verified against this test: with the guard
+/// the create records `["Specific(2)", "Specific(5)"]`, and without it
+/// `["Specific(2)", "Specific(3)", "Specific(5)"]`.
+///
+/// It escaped because the only test asserting this direction did it on a
+/// **content** part — a title rewritten to itself, on the edit path, where the
+/// second guard makes it unfalsifiable for this fault. *The invariant is checked
+/// somewhere* is not the same claim as *the invariant is checked here*, and the
+/// suite exists to make it one claim.
+#[tokio::test]
+async fn a_companion_for_an_empty_sibling_is_not_recorded_on_creation() {
+    let world = World::new().await;
+    let campaign_id = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let arc = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Arc(v1::ArcContent {
+                campaign_id: Some(id_bytes(campaign_id)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    // Created straight into an arc: `campaign_id` is null and stays null.
+    let quest = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Quest(v1::QuestContent {
+                parent: Some(v1::quest_content::Parent::ArcId(id_bytes(arc))),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let counter = counter_of(&world.db.pool, quest).await;
+    let recorded = recorded_at(&world.db.pool, quest, counter).await;
+
+    assert!(
+        !recorded.contains(&Part::Specific(3)),
+        "the quest never had a campaign, so nothing moved it: recorded {:?}",
+        listed(&recorded)
+    );
+    // And the parts that did move are still there, so this cannot pass by the
+    // create having recorded nothing at all.
+    assert!(recorded.contains(&Part::Specific(2)), "the arc it entered");
+    assert!(recorded.contains(&Part::Specific(5)), "the ladder position");
 }

--- a/crates/altaird/tests/type_content_guidance.rs
+++ b/crates/altaird/tests/type_content_guidance.rs
@@ -25,6 +25,7 @@ use altaird::store::begin_write;
 use altaird::store::entity::EntityType;
 use altaird::store::ids::{EntityId, MemberId};
 use altaird::write::entity::Ctx;
+use altaird::write::parts::{Part, PartKey};
 use altaird::write::specific;
 use chrono::Utc;
 use common::*;
@@ -1679,9 +1680,15 @@ async fn restating_the_same_parent_vacates_nothing() {
 /// **Exercised directly because the dispatch still answers `NotBuilt`**, which
 /// is the one line between this and the wired erase path. `nesting::would_cycle`
 /// was tested the same way for the same reason, and the erase path itself is
-/// already written: it calls `specific::detach_contained`, hands the identities
+/// already written: it calls `specific::detach_contained`, hands what comes back
 /// to `store::entity::detached_from_container`, and emits a change entry each.
-async fn release_from(world: &World, container: EntityId, kind: EntityType) -> Vec<Uuid> {
+///
+/// **Each release carries the part that moved, and these tests assert it.** A
+/// release advances the child's counter, so it owes provenance, and provenance
+/// needs to know which field went away — a released arc lost its campaign, a
+/// released quest lost whichever of its two parents it had. Asserting the
+/// identity alone would let the wrong field number through silently.
+async fn release_from(world: &World, container: EntityId, kind: EntityType) -> Vec<(Uuid, String)> {
     let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
     let mut ctx = Ctx {
         tx: &mut tx,
@@ -1694,8 +1701,20 @@ async fn release_from(world: &World, container: EntityId, kind: EntityType) -> V
     };
     tx.commit().await.expect("commit");
     match answer {
-        specific::Detachment::Released(ids) => ids.into_iter().map(EntityId::as_uuid).collect(),
+        specific::Detachment::Released(rows) => rows
+            .into_iter()
+            .map(|r| (r.entity.as_uuid(), part_name(&r.part)))
+            .collect(),
         other => panic!("a ladder container releases what it held, got {other:?}"),
+    }
+}
+
+/// The spelling `entity_part_counter` and the `conflict` row both key a part by,
+/// which is what provenance will write.
+fn part_name(part: &Part) -> String {
+    match part.key() {
+        PartKey::Field(name) => name,
+        PartKey::Block(id) => panic!("a ladder parent is a field, not block {id}"),
     }
 }
 
@@ -1734,9 +1753,16 @@ async fn an_erased_campaign_releases_its_arcs_and_its_quests() {
         )
         .await;
 
+    // **The two kinds lost different fields.** An arc's campaign is field 2 of
+    // its message and a quest's is field 3, so one container releasing across
+    // two tables produces two different parts — which is exactly why the part
+    // has to travel with the identity rather than be inferred by the caller.
     let mut released = release_from(&world, c, EntityType::Campaign).await;
     released.sort();
-    let mut expected = vec![a.as_uuid(), q.as_uuid()];
+    let mut expected = vec![
+        (a.as_uuid(), "specific.2".to_owned()),
+        (q.as_uuid(), "specific.3".to_owned()),
+    ];
     expected.sort();
     assert_eq!(released, expected);
 
@@ -1776,9 +1802,10 @@ async fn an_erased_arc_releases_its_quests_without_promoting_them() {
         )
         .await;
 
+    // A quest's arc is field 2 of its message, where its campaign is field 3.
     assert_eq!(
         release_from(&world, a, EntityType::Arc).await,
-        vec![q.as_uuid()]
+        vec![(q.as_uuid(), "specific.2".to_owned())]
     );
 
     let row = quest_row(&world, q).await;
@@ -1860,7 +1887,7 @@ async fn a_child_the_eraser_cannot_see_is_still_released() {
     // One erases the campaign, and releases a child it was never entitled to see.
     assert_eq!(
         release_from(&world, c, EntityType::Campaign).await,
-        vec![hidden.as_uuid()]
+        vec![(hidden.as_uuid(), "specific.3".to_owned())]
     );
     let row = quest_row(&world, hidden).await;
     assert_eq!((row.campaign, row.position), (None, None));
@@ -1909,7 +1936,10 @@ async fn the_dispatch_has_not_been_pointed_at_this_yet() {
     assert_eq!(through_dispatch, specific::Detachment::NotBuilt);
     assert_eq!(
         through_module,
-        specific::Detachment::Released(vec![a]),
+        specific::Detachment::Released(vec![specific::Released {
+            entity: a,
+            part: Part::Specific(2),
+        }]),
         "the module releases; only the dispatch arm is still unpointed"
     );
 }

--- a/crates/altaird/tests/type_content_guidance.rs
+++ b/crates/altaird/tests/type_content_guidance.rs
@@ -1753,15 +1753,19 @@ async fn an_erased_campaign_releases_its_arcs_and_its_quests() {
         )
         .await;
 
-    // **The two kinds lost different fields.** An arc's campaign is field 2 of
-    // its message and a quest's is field 3, so one container releasing across
-    // two tables produces two different parts — which is exactly why the part
-    // has to travel with the identity rather than be inferred by the caller.
+    // **Two parts per child, and the numbers mean different things per type.**
+    // Each child lost its parent *and* its position, so each reports both. An
+    // arc's campaign is field 2 and its position field 3; a quest's campaign is
+    // field 3 and its position field 5 — so `specific.3` here names a position
+    // on the arc and a campaign on the quest. That is exactly why the part has
+    // to travel with the identity rather than be inferred by the caller.
     let mut released = release_from(&world, c, EntityType::Campaign).await;
     released.sort();
     let mut expected = vec![
         (a.as_uuid(), "specific.2".to_owned()),
+        (a.as_uuid(), "specific.3".to_owned()),
         (q.as_uuid(), "specific.3".to_owned()),
+        (q.as_uuid(), "specific.5".to_owned()),
     ];
     expected.sort();
     assert_eq!(released, expected);
@@ -1802,10 +1806,14 @@ async fn an_erased_arc_releases_its_quests_without_promoting_them() {
         )
         .await;
 
-    // A quest's arc is field 2 of its message, where its campaign is field 3.
+    // A quest's arc is field 2 of its message and its position field 5, and
+    // both moved.
     assert_eq!(
         release_from(&world, a, EntityType::Arc).await,
-        vec![(q.as_uuid(), "specific.2".to_owned())]
+        vec![
+            (q.as_uuid(), "specific.2".to_owned()),
+            (q.as_uuid(), "specific.5".to_owned()),
+        ]
     );
 
     let row = quest_row(&world, q).await;
@@ -1887,7 +1895,10 @@ async fn a_child_the_eraser_cannot_see_is_still_released() {
     // One erases the campaign, and releases a child it was never entitled to see.
     assert_eq!(
         release_from(&world, c, EntityType::Campaign).await,
-        vec![(hidden.as_uuid(), "specific.3".to_owned())]
+        vec![
+            (hidden.as_uuid(), "specific.3".to_owned()),
+            (hidden.as_uuid(), "specific.5".to_owned()),
+        ]
     );
     let row = quest_row(&world, hidden).await;
     assert_eq!((row.campaign, row.position), (None, None));
@@ -1938,12 +1949,109 @@ async fn the_dispatch_reaches_the_ladders_release() {
 
     assert_eq!(
         through_dispatch,
-        specific::Detachment::Released(vec![specific::Released {
-            entity: a,
-            part: Part::Specific(2),
-        }]),
+        specific::Detachment::Released(vec![
+            specific::Released {
+                entity: a,
+                part: Part::Specific(2),
+            },
+            specific::Released {
+                entity: a,
+                part: Part::Specific(3),
+            },
+        ]),
         "the dispatch reaches the ladder's release — this assertion read \
          `NotBuilt` while the arm was unpointed, which is what made the gap \
          visible rather than silent"
     );
+}
+
+/// **The consequence a release recording only its parent would hide.**
+///
+/// The erasure clears the child's parent *and* its ladder position. A member
+/// holding a base from before the erasure then moves that child under a new
+/// parent — which writes the position as a companion. Both writes changed the
+/// position, so both values are owed retention.
+///
+/// With only the parent recorded, `moved_since` reports the parent alone, the
+/// stale write touches the parent it is setting plus the position, the two sets
+/// do not intersect on anything, and a collision on the position merges in
+/// silence. *Both values retained on a same-part conflict* is a standing
+/// constraint, so that is a hole rather than a rough edge.
+///
+/// Asserted as the consequence rather than as "two parts are recorded", because
+/// the consequence is what the constraint is about and it is what fails first.
+#[tokio::test]
+async fn a_stale_move_after_a_release_conflicts_on_the_position() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), shared_with(&world))
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            shared_with(&world),
+        )
+        .await;
+    // Somewhere else for the stale write to put it.
+    let a = world
+        .create(&world.one, as_arc(arc(None, None)), shared_with(&world))
+        .await;
+    assert_eq!(quest_row(&world, q).await.position, Some(0));
+
+    // Two last saw the quest here.
+    let base = world.counter(q).await;
+
+    // One erases the campaign. The quest keeps existing and loses both its
+    // parent and its position.
+    world.submit(&world.one, erase(&[c])).await;
+    let row = quest_row(&world, q).await;
+    assert_eq!((row.campaign, row.position), (None, None));
+
+    // Two, still on the old base, moves the quest under an arc. Entering a
+    // container appends, so this writes a position as a companion — the same
+    // part the release cleared.
+    let ack = world
+        .submit(
+            &world.two,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(a)))),
+        )
+        .await;
+
+    let applied = applied(&ack);
+    let conflict = applied
+        .conflict
+        .as_ref()
+        .expect("the release and the move both changed the ladder position");
+    assert!(
+        conflict.specific_fields.contains(&5),
+        "the position is the conflicted part: {:?}",
+        conflict.specific_fields
+    );
+
+    let conflicts = world.conflicts(q).await;
+    let position = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.5"))
+        .expect("both positions are retained");
+    assert_eq!(
+        position.mine.as_deref(),
+        Some("0"),
+        "the arriving value: entering the arc appends at its end"
+    );
+    assert_eq!(
+        position.theirs, None,
+        "the value it displaced: the release had forgotten the position"
+    );
+    assert_eq!(position.mine_member, Some(world.two.membership_id()));
+    assert_eq!(
+        position.theirs_member,
+        Some(world.one.membership_id()),
+        "attributed to whoever erased the container, because that is who caused it"
+    );
+
+    // And the move still applied. A stale base is never a rejection.
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, Some(a.as_uuid()));
+    assert_eq!(row.position, Some(0));
 }

--- a/crates/altaird/tests/type_content_guidance.rs
+++ b/crates/altaird/tests/type_content_guidance.rs
@@ -21,7 +21,12 @@
 mod common;
 
 use altair_proto::v1;
-use altaird::store::ids::EntityId;
+use altaird::store::begin_write;
+use altaird::store::entity::EntityType;
+use altaird::store::ids::{EntityId, MemberId};
+use altaird::write::entity::Ctx;
+use altaird::write::specific;
+use chrono::Utc;
 use common::*;
 use sqlx::Row;
 use uuid::Uuid;
@@ -1570,7 +1575,10 @@ async fn a_concurrent_edit_to_the_vacated_parent_conflicts_rather_than_merging()
         .iter()
         .find(|c| c.field.as_deref() == Some("specific.2"))
         .expect("the arc is retained on both sides");
-    assert_eq!(vacated.mine.as_deref(), Some(second.as_uuid().to_string()).as_deref());
+    assert_eq!(
+        vacated.mine.as_deref(),
+        Some(second.as_uuid().to_string()).as_deref()
+    );
     assert_eq!(
         vacated.theirs, None,
         "the value it displaced was the arc the first write cleared"
@@ -1660,4 +1668,248 @@ async fn restating_the_same_parent_vacates_nothing() {
         "no arc was ever held, so none was vacated"
     );
     assert_eq!(quest_row(&world, q).await.position, Some(0));
+}
+
+// ---------------------------------------------------------------------------
+// What an erased ladder container lets go of
+// ---------------------------------------------------------------------------
+
+/// Call the release directly.
+///
+/// **Exercised directly because the dispatch still answers `NotBuilt`**, which
+/// is the one line between this and the wired erase path. `nesting::would_cycle`
+/// was tested the same way for the same reason, and the erase path itself is
+/// already written: it calls `specific::detach_contained`, hands the identities
+/// to `store::entity::detached_from_container`, and emits a change entry each.
+async fn release_from(world: &World, container: EntityId, kind: EntityType) -> Vec<Uuid> {
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    let answer = match specific::guidance::detach_contained(&mut ctx, container, kind).await {
+        Ok(answer) => answer,
+        Err(_) => panic!("the store was reachable"),
+    };
+    tx.commit().await.expect("commit");
+    match answer {
+        specific::Detachment::Released(ids) => ids.into_iter().map(EntityId::as_uuid).collect(),
+        other => panic!("a ladder container releases what it held, got {other:?}"),
+    }
+}
+
+/// **A campaign is one container over mixed kinds**, so it releases across both
+/// tables — and the position goes with the parent, in one statement, because
+/// the paired checks tie them together.
+#[tokio::test]
+async fn an_erased_campaign_releases_its_arcs_and_its_quests() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    // Something under a different campaign, which must not be touched.
+    let other = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let untouched = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(other))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let mut released = release_from(&world, c, EntityType::Campaign).await;
+    released.sort();
+    let mut expected = vec![a.as_uuid(), q.as_uuid()];
+    expected.sort();
+    assert_eq!(released, expected);
+
+    assert_eq!(arc_row(&world, a).await, (None, None));
+    let row = quest_row(&world, q).await;
+    assert_eq!((row.arc, row.campaign, row.position), (None, None, None));
+    assert_eq!(
+        arc_row(&world, untouched).await,
+        (Some(other.as_uuid()), Some(0)),
+        "another campaign's arc is not its business"
+    );
+}
+
+/// An erased arc releases its quests only. **A released quest is parentless,
+/// not promoted** — it does not inherit the arc's campaign, even though that
+/// campaign still exists. Promotion would be the system moving something into a
+/// container the person never put it in, and appending it at the end of an order
+/// they did not choose.
+#[tokio::test]
+async fn an_erased_arc_releases_its_quests_without_promoting_them() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_arc(a))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    assert_eq!(
+        release_from(&world, a, EntityType::Arc).await,
+        vec![q.as_uuid()]
+    );
+
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, None);
+    assert_eq!(
+        row.campaign, None,
+        "the quest is parentless; it did not inherit the arc's campaign"
+    );
+    assert_eq!(row.position, None, "and the position went with the parent");
+}
+
+/// An empty container releases nothing, which is an answer rather than an
+/// absence — the seam keeps `Released(vec![])` and `NotBuilt` apart precisely so
+/// this case cannot be mistaken for an unbuilt one.
+#[tokio::test]
+async fn an_empty_container_releases_nothing_and_says_so() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    assert!(
+        release_from(&world, c, EntityType::Campaign)
+            .await
+            .is_empty()
+    );
+}
+
+/// **A quest is a leaf of the ladder.** Nothing names one as a parent, so it is
+/// no container at all rather than an empty one.
+#[tokio::test]
+async fn a_quest_is_not_a_container() {
+    let world = World::new().await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, None)),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    let answer = specific::guidance::detach_contained(&mut ctx, q, EntityType::Quest).await;
+    let answer = match answer {
+        Ok(a) => a,
+        Err(_) => panic!("the store was reachable"),
+    };
+    tx.rollback().await.expect("rollback");
+    assert_eq!(answer, specific::Detachment::NoContainer);
+}
+
+/// **The release is unscoped, and this is the test that says so.**
+///
+/// A child owned by a member the eraser cannot see is still released. The
+/// container is gone for everybody, so leaving it behind would keep a dangling
+/// reference alive precisely where nobody can find it — the reason
+/// `uncategorise_all` gives, and no smaller here. A predicate added to the walk
+/// fails this.
+#[tokio::test]
+async fn a_child_the_eraser_cannot_see_is_still_released() {
+    let world = World::new().await;
+    // The campaign is shared, so member two can hang something beneath it.
+    let c = world
+        .create(&world.one, campaign(None), shared_with(&world))
+        .await;
+    // Two's own quest beneath it, private to two: one cannot see this.
+    let hidden = world
+        .create(
+            &world.two,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    // One erases the campaign, and releases a child it was never entitled to see.
+    assert_eq!(
+        release_from(&world, c, EntityType::Campaign).await,
+        vec![hidden.as_uuid()]
+    );
+    let row = quest_row(&world, hidden).await;
+    assert_eq!((row.campaign, row.position), (None, None));
+}
+
+/// The one line between this implementation and the erase path, pinned so it is
+/// visible rather than assumed.
+///
+/// `specific::detach_contained` still answers `NotBuilt` for Guidance's three
+/// types while `guidance::detach_contained` answers `Released`. `NotBuilt` is a
+/// distinct answer for exactly this reason: the erase path steps over it rather
+/// than treating it as nothing to do, so an arc goes on pointing at its
+/// tombstone visibly instead of silently.
+///
+/// **This assertion inverts when the dispatch arm calls the module.** Whoever
+/// wires it should delete the first half and keep the second.
+#[tokio::test]
+async fn the_dispatch_has_not_been_pointed_at_this_yet() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    let through_dispatch = specific::detach_contained(&mut ctx, c, EntityType::Campaign).await;
+    let through_module =
+        specific::guidance::detach_contained(&mut ctx, c, EntityType::Campaign).await;
+    let (through_dispatch, through_module) = match (through_dispatch, through_module) {
+        (Ok(d), Ok(m)) => (d, m),
+        _ => panic!("the store was reachable"),
+    };
+    tx.rollback().await.expect("rollback");
+
+    assert_eq!(through_dispatch, specific::Detachment::NotBuilt);
+    assert_eq!(
+        through_module,
+        specific::Detachment::Released(vec![a]),
+        "the module releases; only the dispatch arm is still unpointed"
+    );
 }

--- a/crates/altaird/tests/type_content_guidance.rs
+++ b/crates/altaird/tests/type_content_guidance.rs
@@ -1,0 +1,1455 @@
+//! Guidance's type content: the three states, the one upward movement, and the
+//! ladder.
+//!
+//! **Every assertion here reads the stored row.** An acknowledgement says a
+//! write was applied; it does not say anything landed in a column, and a type
+//! module that accepted a message and wrote nothing would satisfy every
+//! acknowledgement-shaped assertion in the suite. So state, ladder parent, and
+//! ladder position are read back out of `campaign`, `arc`, and `quest`
+//! throughout, including the cases where the right answer is null.
+//!
+//! Three groups, and the middle one is the domain behaviour:
+//!
+//! - **Round trips.** Every field of all three messages, through a create and
+//!   through an edit, set and cleared.
+//! - **The state machine and the one upward movement.** Each transition the
+//!   PRD's diagram draws, and one test per clause of the propagation rule's
+//!   narrowing.
+//! - **The ladder as a container.** Arrangement's rules, including the campaign
+//!   ordering arcs and quests together in a sequence that spans two tables.
+
+mod common;
+
+use altair_proto::v1;
+use altaird::store::ids::EntityId;
+use common::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Saying things to the instance
+// ---------------------------------------------------------------------------
+
+fn campaign(state: Option<v1::GuidanceState>) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Campaign(v1::CampaignContent {
+        state: state.map(|s| s as i32),
+        cleared: Vec::new(),
+    })
+}
+
+fn arc(state: Option<v1::GuidanceState>, campaign: Option<EntityId>) -> v1::ArcContent {
+    v1::ArcContent {
+        state: state.map(|s| s as i32),
+        campaign_id: campaign.map(|c| c.as_uuid().as_bytes().to_vec()),
+        ladder_position: None,
+        cleared: Vec::new(),
+    }
+}
+
+fn quest(
+    state: Option<v1::GuidanceState>,
+    parent: Option<v1::quest_content::Parent>,
+) -> v1::QuestContent {
+    v1::QuestContent {
+        state: state.map(|s| s as i32),
+        parent,
+        routine_id: None,
+        ladder_position: None,
+        cleared: Vec::new(),
+    }
+}
+
+fn beneath_arc(id: EntityId) -> Option<v1::quest_content::Parent> {
+    Some(v1::quest_content::Parent::ArcId(
+        id.as_uuid().as_bytes().to_vec(),
+    ))
+}
+
+fn beneath_campaign(id: EntityId) -> Option<v1::quest_content::Parent> {
+    Some(v1::quest_content::Parent::CampaignId(
+        id.as_uuid().as_bytes().to_vec(),
+    ))
+}
+
+fn as_arc(c: v1::ArcContent) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Arc(c)
+}
+
+fn as_quest(c: v1::QuestContent) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Quest(c)
+}
+
+/// An edit carrying one type message and nothing else.
+fn edit_specific(
+    id: EntityId,
+    base: i64,
+    specific: v1::entity_content::Specific,
+) -> v1::intent::Action {
+    edit_entity(
+        id,
+        base as u64,
+        v1::EntityContent {
+            specific: Some(specific),
+            ..Default::default()
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Reading the stored row
+// ---------------------------------------------------------------------------
+
+async fn state_of(world: &World, table: &str, id: EntityId) -> String {
+    let sql = format!("SELECT state::text AS s FROM {table} WHERE entity_id = $1");
+    sqlx::query(sqlx::AssertSqlSafe(sql))
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("the side-table row exists")
+        .try_get("s")
+        .expect("state")
+}
+
+/// An arc's stored placement: its campaign and its position beneath it.
+async fn arc_row(world: &World, id: EntityId) -> (Option<Uuid>, Option<i32>) {
+    let row = sqlx::query("SELECT campaign_id, ladder_position FROM arc WHERE entity_id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("the arc row exists");
+    (
+        row.try_get("campaign_id").unwrap(),
+        row.try_get("ladder_position").unwrap(),
+    )
+}
+
+/// A quest's stored placement: both parent columns, its routine, its position.
+struct QuestRow {
+    arc: Option<Uuid>,
+    campaign: Option<Uuid>,
+    routine: Option<Uuid>,
+    position: Option<i32>,
+}
+
+async fn quest_row(world: &World, id: EntityId) -> QuestRow {
+    let row = sqlx::query(
+        "SELECT arc_id, campaign_id, routine_id, ladder_position FROM quest WHERE entity_id = $1",
+    )
+    .bind(id.as_uuid())
+    .fetch_one(&world.db.pool)
+    .await
+    .expect("the quest row exists");
+    QuestRow {
+        arc: row.try_get("arc_id").unwrap(),
+        campaign: row.try_get("campaign_id").unwrap(),
+        routine: row.try_get("routine_id").unwrap(),
+        position: row.try_get("ladder_position").unwrap(),
+    }
+}
+
+/// How many change entries name this entity.
+async fn changes_naming(world: &World, id: EntityId) -> usize {
+    world
+        .changes()
+        .await
+        .iter()
+        .filter(|c| c.entity == Some(id.as_uuid()))
+        .count()
+}
+
+/// The counter a part last moved at, or nothing if it never recorded one.
+async fn part_counter(world: &World, id: EntityId, field: &str) -> Option<i64> {
+    sqlx::query("SELECT counter FROM entity_part_counter WHERE entity_id = $1 AND field_name = $2")
+        .bind(id.as_uuid())
+        .bind(field)
+        .fetch_optional(&world.db.pool)
+        .await
+        .expect("query")
+        .map(|r| r.try_get("counter").expect("counter"))
+}
+
+// ---------------------------------------------------------------------------
+// Building a ladder
+// ---------------------------------------------------------------------------
+
+/// A campaign, an arc beneath it, and a quest beneath the arc, all waiting.
+///
+/// Shared with member two throughout, because the propagation tests need a
+/// container the writing member can see and one of them needs to take that
+/// away.
+struct Chain {
+    campaign: EntityId,
+    arc: EntityId,
+    quest: EntityId,
+}
+
+fn shared_with(world: &World) -> v1::EntityContent {
+    v1::EntityContent {
+        audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+        ..Default::default()
+    }
+}
+
+async fn chain(world: &World) -> Chain {
+    let campaign_id = world
+        .create(&world.one, campaign(None), shared_with(world))
+        .await;
+    let arc_id = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(campaign_id))),
+            shared_with(world),
+        )
+        .await;
+    let quest_id = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_arc(arc_id))),
+            shared_with(world),
+        )
+        .await;
+    Chain {
+        campaign: campaign_id,
+        arc: arc_id,
+        quest: quest_id,
+    }
+}
+
+/// Move one entity's state, and take the acknowledgement.
+async fn set_state(
+    world: &World,
+    member: &altaird::auth::Member,
+    id: EntityId,
+    specific: impl Fn(Option<v1::GuidanceState>) -> v1::entity_content::Specific,
+    state: v1::GuidanceState,
+) -> v1::Acknowledgement {
+    let base = world.counter(id).await;
+    world
+        .submit(member, edit_specific(id, base, specific(Some(state))))
+        .await
+}
+
+fn quest_state(state: Option<v1::GuidanceState>) -> v1::entity_content::Specific {
+    as_quest(quest(state, None))
+}
+
+fn arc_state(state: Option<v1::GuidanceState>) -> v1::entity_content::Specific {
+    as_arc(arc(state, None))
+}
+
+// ---------------------------------------------------------------------------
+// Round trips: every field of every message, stored and read back
+// ---------------------------------------------------------------------------
+
+/// A bare create writes a row with the schema's defaults, and the defaults are
+/// what the store says they are rather than what the write path assumed.
+#[tokio::test]
+async fn a_bare_create_of_each_type_leaves_the_defaults_in_the_row() {
+    let world = World::new().await;
+
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    assert_eq!(state_of(&world, "campaign", c).await, "waiting");
+
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, None)),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(state_of(&world, "arc", a).await, "waiting");
+    assert_eq!(arc_row(&world, a).await, (None, None));
+
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, None)),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(state_of(&world, "quest", q).await, "waiting");
+    let row = quest_row(&world, q).await;
+    assert_eq!(
+        (row.arc, row.campaign, row.routine, row.position),
+        (None, None, None, None)
+    );
+}
+
+#[tokio::test]
+async fn an_arc_round_trips_every_field_through_a_create_and_an_edit() {
+    let world = World::new().await;
+    let first = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let second = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+
+    // Create: both fields stated, and the position the instance assigned.
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(Some(v1::GuidanceState::Worked), Some(first))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(state_of(&world, "arc", a).await, "worked");
+    assert_eq!(arc_row(&world, a).await, (Some(first.as_uuid()), Some(0)));
+
+    // Edit: both fields moved.
+    let base = world.counter(a).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                a,
+                base,
+                as_arc(arc(Some(v1::GuidanceState::Working), Some(second))),
+            ),
+        )
+        .await;
+    assert_eq!(state_of(&world, "arc", a).await, "working");
+    assert_eq!(arc_row(&world, a).await, (Some(second.as_uuid()), Some(0)));
+
+    // Cleared: the campaign goes, and the position goes with it.
+    let base = world.counter(a).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                a,
+                base,
+                as_arc(v1::ArcContent {
+                    cleared: vec![2],
+                    ..arc(None, None)
+                }),
+            ),
+        )
+        .await;
+    assert_eq!(arc_row(&world, a).await, (None, None));
+    assert_eq!(
+        state_of(&world, "arc", a).await,
+        "working",
+        "leaving a container is not a state change"
+    );
+}
+
+#[tokio::test]
+async fn a_quest_round_trips_every_field_through_a_create_and_an_edit() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let routine = Uuid::new_v4();
+
+    let q = world
+        .create(
+            &world.one,
+            as_quest(v1::QuestContent {
+                routine_id: Some(routine.as_bytes().to_vec()),
+                ..quest(Some(v1::GuidanceState::Worked), beneath_arc(a))
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(state_of(&world, "quest", q).await, "worked");
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, Some(a.as_uuid()));
+    assert_eq!(row.campaign, None);
+    assert_eq!(row.routine, Some(routine));
+    assert_eq!(row.position, Some(0));
+
+    // The routine is a column with no table behind it: stored, uninterpreted,
+    // and cleared like anything else. Recurrence is deferred by the scope.
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                q,
+                base,
+                as_quest(v1::QuestContent {
+                    cleared: vec![4],
+                    ..quest(Some(v1::GuidanceState::Working), None)
+                }),
+            ),
+        )
+        .await;
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.routine, None);
+    assert_eq!(
+        row.arc,
+        Some(a.as_uuid()),
+        "clearing a routine is not a move"
+    );
+    assert_eq!(state_of(&world, "quest", q).await, "working");
+}
+
+/// The state is a part, and a part that records no counter movement is
+/// invisible to conflict detection. So is a ladder parent, and so is the
+/// position that moved with it.
+#[tokio::test]
+async fn every_guidance_part_records_the_counter_it_moved_at() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(Some(v1::GuidanceState::Working), Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    assert_eq!(
+        part_counter(&world, a, "specific.1").await,
+        Some(1),
+        "state"
+    );
+    assert_eq!(
+        part_counter(&world, a, "specific.2").await,
+        Some(1),
+        "the campaign"
+    );
+    assert_eq!(
+        part_counter(&world, a, "specific.3").await,
+        Some(1),
+        "the position the instance assigned alongside it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The state machine
+// ---------------------------------------------------------------------------
+
+/// The five movements the PRD's diagram draws, on all three types.
+///
+/// `[*] → Waiting` is the sixth and is the column default, which
+/// `a_bare_create_of_each_type_leaves_the_defaults_in_the_row` covers.
+#[tokio::test]
+async fn every_transition_the_diagram_draws_holds() {
+    use v1::GuidanceState::{Waiting, Worked, Working};
+    let world = World::new().await;
+
+    for (from, to) in [
+        (Waiting, Working),
+        (Working, Worked),
+        (Working, Waiting),
+        (Worked, Working),
+        (Waiting, Worked),
+    ] {
+        for (table, of) in [
+            ("campaign", campaign as fn(Option<v1::GuidanceState>) -> _),
+            ("arc", arc_state),
+            ("quest", quest_state),
+        ] {
+            let id = world
+                .create(&world.one, of(Some(from)), v1::EntityContent::default())
+                .await;
+            assert_eq!(state_of(&world, table, id).await, store_name(from));
+
+            let ack = set_state(&world, &world.one, id, of, to).await;
+            assert!(
+                matches!(ack.outcome, Some(v1::acknowledgement::Outcome::Applied(_))),
+                "{table}: {from:?} to {to:?} was not applied: {:?}",
+                ack.outcome
+            );
+            assert_eq!(
+                state_of(&world, table, id).await,
+                store_name(to),
+                "{table}: {from:?} to {to:?}"
+            );
+        }
+    }
+}
+
+fn store_name(state: v1::GuidanceState) -> &'static str {
+    match state {
+        v1::GuidanceState::Waiting => "waiting",
+        v1::GuidanceState::Working => "working",
+        v1::GuidanceState::Worked => "worked",
+        v1::GuidanceState::Unspecified => unreachable!(),
+    }
+}
+
+/// **The movement the diagram does not draw is still not refused**, and this
+/// test is where that reading is visible rather than inferred from an absence
+/// of code.
+///
+/// Worked → waiting is the one ordered pair of distinct states the PRD's
+/// diagram leaves undrawn. Nothing in the prose forbids it, the substrate does
+/// not reject a well-formed write, and the spine's rule that clearing a state
+/// returns it to the column default performs exactly this movement — so a
+/// prohibition invented here would contradict behaviour the spine already
+/// tests.
+#[tokio::test]
+async fn the_movement_the_diagram_leaves_undrawn_is_not_refused() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            campaign(Some(v1::GuidanceState::Worked)),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let ack = set_state(&world, &world.one, id, campaign, v1::GuidanceState::Waiting).await;
+    assert!(
+        matches!(ack.outcome, Some(v1::acknowledgement::Outcome::Applied(_))),
+        "{:?}",
+        ack.outcome
+    );
+    assert_eq!(state_of(&world, "campaign", id).await, "waiting");
+}
+
+/// Restating the state something is already in is not a movement and not a
+/// refusal. Two members doing it are not divergent either, which the spine
+/// tests; this is the single-member half.
+#[tokio::test]
+async fn restating_the_state_something_is_already_in_is_accepted() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            campaign(Some(v1::GuidanceState::Working)),
+            v1::EntityContent::default(),
+        )
+        .await;
+    set_state(&world, &world.one, id, campaign, v1::GuidanceState::Working).await;
+    assert_eq!(state_of(&world, "campaign", id).await, "working");
+}
+
+// ---------------------------------------------------------------------------
+// The one upward movement, one test per clause of the narrowing
+// ---------------------------------------------------------------------------
+
+/// The rule itself: starting a quest moves the containers above it, silently,
+/// and it climbs the whole chain.
+#[tokio::test]
+async fn starting_a_quest_starts_the_whole_chain_above_it() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+
+    assert_eq!(state_of(&world, "quest", l.quest).await, "working");
+    assert_eq!(state_of(&world, "arc", l.arc).await, "working");
+    assert_eq!(state_of(&world, "campaign", l.campaign).await, "working");
+}
+
+/// **Attachment need not be adjacent.** A quest hanging directly off a campaign
+/// moves that campaign, with no arc in between.
+#[tokio::test]
+async fn a_quest_attached_directly_to_a_campaign_starts_it() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    set_state(
+        &world,
+        &world.one,
+        q,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+    assert_eq!(state_of(&world, "campaign", c).await, "working");
+}
+
+/// **Waiting to working only, and never in reverse.** A quest reaching the
+/// terminal state moves nothing, and neither does one going back to waiting.
+#[tokio::test]
+async fn the_movement_never_runs_in_reverse() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+
+    // The containers are working; the quest finishes.
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+    let arc_counter = world.counter(l.arc).await;
+    let campaign_counter = world.counter(l.campaign).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Worked,
+    )
+    .await;
+    assert_eq!(state_of(&world, "arc", l.arc).await, "working");
+    assert_eq!(state_of(&world, "campaign", l.campaign).await, "working");
+
+    // And going back to waiting does not drag them back either.
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Waiting,
+    )
+    .await;
+    assert_eq!(state_of(&world, "arc", l.arc).await, "working");
+    assert_eq!(state_of(&world, "campaign", l.campaign).await, "working");
+
+    // Nothing was written to them at all: no counter moved.
+    assert_eq!(world.counter(l.arc).await, arc_counter);
+    assert_eq!(world.counter(l.campaign).await, campaign_counter);
+}
+
+/// **Upward only. Nothing a container does moves a child.**
+#[tokio::test]
+async fn nothing_a_container_does_moves_a_child() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.campaign,
+        campaign,
+        v1::GuidanceState::Working,
+    )
+    .await;
+    assert_eq!(state_of(&world, "arc", l.arc).await, "waiting");
+    assert_eq!(state_of(&world, "quest", l.quest).await, "waiting");
+
+    set_state(
+        &world,
+        &world.one,
+        l.arc,
+        arc_state,
+        v1::GuidanceState::Worked,
+    )
+    .await;
+    assert_eq!(state_of(&world, "quest", l.quest).await, "waiting");
+}
+
+/// **It never touches a parent already in the terminal state**, because a stray
+/// child would silently reopen something the person deliberately closed.
+///
+/// The clauses are stated per parent, so the climb continues past the worked
+/// arc and the campaign above it still moves. Nothing in the PRD makes a
+/// campaign's movement depend on the state of the arc below it, and stopping
+/// there would be this suite deciding something the PRD did not.
+#[tokio::test]
+async fn it_never_reopens_a_container_already_worked_and_climbs_past_it() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+    set_state(
+        &world,
+        &world.one,
+        l.arc,
+        arc_state,
+        v1::GuidanceState::Worked,
+    )
+    .await;
+    let arc_counter = world.counter(l.arc).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+
+    assert_eq!(
+        state_of(&world, "arc", l.arc).await,
+        "worked",
+        "a stray child may not reopen what the person closed"
+    );
+    assert_eq!(
+        world.counter(l.arc).await,
+        arc_counter,
+        "and nothing was written to it"
+    );
+    assert_eq!(state_of(&world, "campaign", l.campaign).await, "working");
+}
+
+/// **It skips any container already working**, which means leaving it entirely
+/// alone rather than writing the value it already holds.
+#[tokio::test]
+async fn the_climb_skips_a_container_already_working() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+    set_state(
+        &world,
+        &world.one,
+        l.arc,
+        arc_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+    let arc_counter = world.counter(l.arc).await;
+    let arc_changes = changes_naming(&world, l.arc).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+
+    assert_eq!(state_of(&world, "arc", l.arc).await, "working");
+    assert_eq!(world.counter(l.arc).await, arc_counter);
+    assert_eq!(
+        changes_naming(&world, l.arc).await,
+        arc_changes,
+        "a container that was already working produced no change entry"
+    );
+    assert_eq!(
+        state_of(&world, "campaign", l.campaign).await,
+        "working",
+        "and the climb carried on past it"
+    );
+}
+
+/// A quest created already started moves its containers.
+///
+/// **This is why a parent is read off the wire before the state.** A create
+/// applies parts in the order the type's reader produced them; reading the
+/// state first would leave the quest parentless at the moment its state landed,
+/// and the movement would find nothing above it.
+#[tokio::test]
+async fn a_quest_created_already_started_starts_its_containers() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    world
+        .create(
+            &world.one,
+            as_quest(quest(Some(v1::GuidanceState::Working), beneath_arc(a))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    assert_eq!(state_of(&world, "arc", a).await, "working");
+    assert_eq!(state_of(&world, "campaign", c).await, "working");
+}
+
+/// A container this moves takes a counter and a change entry of its own.
+///
+/// Both are load-bearing: a part that does not record the counter it moved at
+/// is invisible to conflict detection, and a movement nothing records is one no
+/// client ever learns about. The audience did not change, so both sides of the
+/// change entry's pair are what it already was.
+#[tokio::test]
+async fn a_container_the_movement_starts_records_a_counter_and_a_change() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+    let before = world.counter(l.campaign).await;
+    let entries = changes_naming(&world, l.campaign).await;
+
+    set_state(
+        &world,
+        &world.one,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+
+    assert_eq!(world.counter(l.campaign).await, before + 1);
+    assert_eq!(
+        part_counter(&world, l.campaign, "specific.1").await,
+        Some(before + 1),
+        "the state part records the counter the instance moved it at"
+    );
+    assert_eq!(changes_naming(&world, l.campaign).await, entries + 1);
+
+    let last = world
+        .changes()
+        .await
+        .into_iter()
+        .rfind(|c| c.entity == Some(l.campaign.as_uuid()))
+        .expect("an entry for the campaign");
+    assert_eq!(last.kind, "entity_written");
+    assert_eq!(last.audience_before, last.audience_after);
+}
+
+/// **The climb stops at a container this member cannot see.** Moving a state on
+/// an entity the writer is not entitled to see would attribute a write, in
+/// provenance and in the change sequence, to a member who cannot see what they
+/// moved. The PRD already accepts that a container can drift out of step with
+/// the work beneath it; this is one more way, and it is the safe way.
+#[tokio::test]
+async fn the_climb_stops_at_a_container_the_writer_cannot_see() {
+    let world = World::new().await;
+    let l = chain(&world).await;
+
+    // One narrows the campaign to itself. Two can still see the arc and quest.
+    let base = world.counter(l.campaign).await;
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                l.campaign,
+                base as u64,
+                v1::EntityContent {
+                    cleared: vec![5],
+                    specific: Some(campaign(None)),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    set_state(
+        &world,
+        &world.two,
+        l.quest,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+
+    assert_eq!(state_of(&world, "arc", l.arc).await, "working");
+    assert_eq!(
+        state_of(&world, "campaign", l.campaign).await,
+        "waiting",
+        "the climb does not reach past a container the writer cannot see"
+    );
+}
+
+/// A quest with no ladder parent starts nothing, and says so by not failing.
+///
+/// **A recurrence is not a container for this**, and in v0 that clause is moot
+/// rather than implemented: `routine_id` is a column with no `routine` table
+/// behind it, nothing walks it, and so nothing can propagate through one. The
+/// quest here holds a routine and no ladder parent, which is the shape the
+/// clause is about.
+#[tokio::test]
+async fn a_quest_with_no_ladder_parent_starts_nothing() {
+    let world = World::new().await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(v1::QuestContent {
+                routine_id: Some(Uuid::new_v4().as_bytes().to_vec()),
+                ..quest(None, None)
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    set_state(
+        &world,
+        &world.one,
+        q,
+        quest_state,
+        v1::GuidanceState::Working,
+    )
+    .await;
+    assert_eq!(state_of(&world, "quest", q).await, "working");
+    assert_eq!(
+        world.changes().await.len(),
+        2,
+        "the create and the edit, and nothing the movement added"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The ladder as a container
+// ---------------------------------------------------------------------------
+
+/// **A campaign is one container over mixed kinds.** Arcs and quests beneath it
+/// are one sequence, so the order spans two tables and cannot be a constraint.
+#[tokio::test]
+async fn a_campaign_orders_arcs_and_quests_together_in_one_sequence() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+
+    let a1 = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q1 = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let a2 = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q2 = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    assert_eq!(arc_row(&world, a1).await.1, Some(0));
+    assert_eq!(quest_row(&world, q1).await.position, Some(1));
+    assert_eq!(arc_row(&world, a2).await.1, Some(2));
+    assert_eq!(
+        quest_row(&world, q2).await.position,
+        Some(3),
+        "the order is total across both kinds: a quest never reuses an arc's position"
+    );
+}
+
+/// **Leaving a container forgets the position**, and the gap it leaves is not
+/// reused. Nothing shifts to close it: the substrate's order is the one the
+/// person gave, and repairing it would move things they did not move.
+#[tokio::test]
+async fn leaving_forgets_the_position_and_nothing_is_repaired() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(arc_row(&world, a).await.1, Some(0));
+    assert_eq!(quest_row(&world, q).await.position, Some(1));
+
+    // The arc leaves.
+    let base = world.counter(a).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                a,
+                base,
+                as_arc(v1::ArcContent {
+                    cleared: vec![2],
+                    ..arc(None, None)
+                }),
+            ),
+        )
+        .await;
+    assert_eq!(arc_row(&world, a).await, (None, None));
+    assert_eq!(
+        quest_row(&world, q).await.position,
+        Some(1),
+        "nothing else moved to close the gap"
+    );
+
+    // And the next entrant appends past the gap.
+    let next = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(quest_row(&world, next).await.position, Some(2));
+}
+
+/// Restating the container something is already in is not an entry, so it does
+/// not append. The position the person can predict is the one it keeps.
+#[tokio::test]
+async fn restating_the_same_container_does_not_move_the_position() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let first = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let second = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(arc_row(&world, first).await.1, Some(0));
+
+    let base = world.counter(first).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(first, base, as_arc(arc(None, Some(c)))),
+        )
+        .await;
+    assert_eq!(
+        arc_row(&world, first).await,
+        (Some(c.as_uuid()), Some(0)),
+        "restating the container is not entering it again"
+    );
+    assert_eq!(arc_row(&world, second).await.1, Some(1));
+}
+
+/// **Entering a different container appends at the end of that one**, and the
+/// order does not survive the move. That is the substrate's accepted cost.
+#[tokio::test]
+async fn entering_a_different_container_appends_at_the_end_of_it() {
+    let world = World::new().await;
+    let from = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let to = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    // Something already sits in the destination.
+    world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(to))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(from))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(arc_row(&world, a).await.1, Some(0));
+
+    let base = world.counter(a).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(a, base, as_arc(arc(None, Some(to)))),
+        )
+        .await;
+    assert_eq!(arc_row(&world, a).await, (Some(to.as_uuid()), Some(1)));
+}
+
+/// **A parent and its position never move in separate statements**, and this is
+/// the test that would trip the table check if they did.
+///
+/// A quest moving from an arc to a campaign passes through no intermediate row.
+/// Either order in a sequence of two statements is refused by the schema:
+/// setting `campaign_id` first leaves both parents non-null, which
+/// `CHECK (num_nonnulls(arc_id, campaign_id) <= 1)` refuses; clearing `arc_id`
+/// first leaves a position with no parent, which
+/// `CHECK ((num_nonnulls(arc_id, campaign_id) = 0) = (ladder_position IS NULL))`
+/// refuses. A store fault rather than an acknowledgement is what this failing
+/// looks like.
+#[tokio::test]
+async fn a_quest_moving_between_an_arc_and_a_campaign_moves_in_one_statement() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_arc(a))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(quest_row(&world, q).await.arc, Some(a.as_uuid()));
+
+    // Arc to campaign. The arc is cleared in the same statement.
+    let base = world.counter(q).await;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_campaign(c)))),
+        )
+        .await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, None);
+    assert_eq!(row.campaign, Some(c.as_uuid()));
+    assert_eq!(
+        row.position,
+        Some(1),
+        "the arc beneath the campaign already holds 0"
+    );
+
+    // And back again.
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(a)))),
+        )
+        .await;
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, Some(a.as_uuid()));
+    assert_eq!(row.campaign, None);
+    assert_eq!(row.position, Some(0), "the arc was empty");
+}
+
+/// Leaving with nothing left to hold the position clears both, in one
+/// statement. Clearing the position alone would trip the same check.
+#[tokio::test]
+async fn a_quest_leaving_its_campaign_forgets_the_position_in_one_statement() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(quest_row(&world, q).await.position, Some(0));
+
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                q,
+                base,
+                as_quest(v1::QuestContent {
+                    cleared: vec![3],
+                    ..quest(None, None)
+                }),
+            ),
+        )
+        .await;
+    let row = quest_row(&world, q).await;
+    assert_eq!((row.arc, row.campaign, row.position), (None, None, None));
+}
+
+/// Clearing the parent a quest does not have leaves the one it does have alone.
+///
+/// The two parents are separate parts because the wire's `oneof` can only set
+/// one of them, and a clear of the empty one is not a request to detach from
+/// the other. Getting this wrong would strip a position the campaign gave.
+#[tokio::test]
+async fn clearing_the_parent_a_quest_does_not_have_leaves_the_other_alone() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    // Clear field 2, the arc, which this quest never had.
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                q,
+                base,
+                as_quest(v1::QuestContent {
+                    cleared: vec![2],
+                    ..quest(None, None)
+                }),
+            ),
+        )
+        .await;
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.campaign, Some(c.as_uuid()));
+    assert_eq!(
+        row.position,
+        Some(0),
+        "the campaign still holds the position"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// What a ladder parent has to be
+// ---------------------------------------------------------------------------
+
+async fn refusal_creating(world: &World, specific: v1::entity_content::Specific) -> v1::Refused {
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(specific),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    refused(&ack).clone()
+}
+
+/// **Refusal on audience is indistinguishable from refusal on nonexistence**,
+/// and from a parent of the wrong kind. All three are the same nothing.
+#[tokio::test]
+async fn a_ladder_parent_that_is_not_available_is_always_the_same_nothing() {
+    let world = World::new().await;
+
+    // Member two's campaign, which one cannot see.
+    let hidden = world
+        .create(&world.two, campaign(None), v1::EntityContent::default())
+        .await;
+    // A note is not a campaign.
+    let note = world.note(&world.one, "not a campaign").await;
+    let nothing = EntityId::from_uuid(Uuid::new_v4());
+
+    let mut answers = Vec::new();
+    for parent in [hidden, note, nothing] {
+        let refused = refusal_creating(&world, as_arc(arc(None, Some(parent)))).await;
+        answers.push((refused.reason, refused.detail));
+    }
+    assert_eq!(
+        answers[0].0,
+        v1::RefusalReason::NotAvailable as i32,
+        "{answers:?}"
+    );
+    assert!(
+        answers.windows(2).all(|w| w[0] == w[1]),
+        "the three answers differ, which is an oracle for what exists: {answers:?}"
+    );
+
+    // And the same for a quest's two parent fields.
+    for parent in [beneath_arc(hidden), beneath_campaign(note)] {
+        let refused = refusal_creating(&world, as_quest(quest(None, parent))).await;
+        assert_eq!(refused.reason, v1::RefusalReason::NotAvailable as i32);
+        assert_eq!(refused.detail, answers[0].1);
+    }
+}
+
+/// **An explicit ladder position is refused**, in the register of the three
+/// refusals Wave 2.1 makes that expire when a named lane lands. Appending is
+/// what this build implements; reordering is a deliberate act on a surface with
+/// the container in front of the person, and nothing reorders yet.
+#[tokio::test]
+async fn an_explicit_ladder_position_is_refused_with_the_reason_it_expires() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+
+    let stated = [
+        as_arc(v1::ArcContent {
+            ladder_position: Some(3),
+            ..arc(None, Some(c))
+        }),
+        as_quest(v1::QuestContent {
+            ladder_position: Some(3),
+            ..quest(None, beneath_campaign(c))
+        }),
+    ];
+    for specific in stated {
+        let refused = refusal_creating(&world, specific).await;
+        assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
+        assert!(
+            refused.detail.contains("appends on entry to a container")
+                && refused.detail.contains("not served yet"),
+            "{}",
+            refused.detail
+        );
+    }
+
+    // On an edit too, and nothing was written on the way to the refusal.
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(a).await;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_specific(
+                a,
+                base,
+                as_arc(v1::ArcContent {
+                    ladder_position: Some(7),
+                    state: Some(v1::GuidanceState::Working as i32),
+                    ..arc(None, None)
+                }),
+            ),
+        )
+        .await;
+    assert_eq!(
+        refused(&ack).reason,
+        v1::RefusalReason::Malformed as i32,
+        "{:?}",
+        ack.outcome
+    );
+    assert_eq!(
+        state_of(&world, "arc", a).await,
+        "waiting",
+        "the refusal rolled back the state that travelled with it"
+    );
+    assert_eq!(arc_row(&world, a).await, (Some(c.as_uuid()), Some(0)));
+}
+
+// ---------------------------------------------------------------------------
+// Conflict, on a part that is Guidance's own
+// ---------------------------------------------------------------------------
+
+/// A same-part conflict on a ladder parent retains both values, and the write
+/// still applies. **A stale base is never a rejection.**
+#[tokio::test]
+async fn a_same_part_conflict_on_a_ladder_parent_retains_both_values() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), shared_with(&world))
+        .await;
+    let first = world
+        .create(&world.one, as_arc(arc(None, Some(c))), shared_with(&world))
+        .await;
+    let second = world
+        .create(&world.one, as_arc(arc(None, Some(c))), shared_with(&world))
+        .await;
+    let q = world
+        .create(&world.one, as_quest(quest(None, None)), shared_with(&world))
+        .await;
+    let base = world.counter(q).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(first)))),
+        )
+        .await;
+    let ack = world
+        .submit(
+            &world.two,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(second)))),
+        )
+        .await;
+
+    let applied = applied(&ack);
+    let conflict = applied
+        .conflict
+        .as_ref()
+        .expect("two members moving one quest's arc is one part twice");
+    assert!(conflict.specific_fields.contains(&2));
+
+    let conflicts = world.conflicts(q).await;
+    let arc_conflict = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.2"))
+        .expect("the arc is the conflicted part");
+    assert_eq!(
+        arc_conflict.mine.as_deref(),
+        Some(second.as_uuid().to_string()).as_deref()
+    );
+    assert_eq!(
+        arc_conflict.theirs.as_deref(),
+        Some(first.as_uuid().to_string()).as_deref()
+    );
+    assert_eq!(
+        quest_row(&world, q).await.arc,
+        Some(second.as_uuid()),
+        "the write still applied"
+    );
+}
+
+/// Different parts of one type merge with nobody involved: one member moves the
+/// state, the other the parent, both from the same base.
+#[tokio::test]
+async fn two_members_moving_different_guidance_parts_merge() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), shared_with(&world))
+        .await;
+    let q = world
+        .create(&world.one, as_quest(quest(None, None)), shared_with(&world))
+        .await;
+    let base = world.counter(q).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                q,
+                base,
+                as_quest(quest(Some(v1::GuidanceState::Worked), None)),
+            ),
+        )
+        .await;
+    let ack = world
+        .submit(
+            &world.two,
+            edit_specific(q, base, as_quest(quest(None, beneath_campaign(c)))),
+        )
+        .await;
+
+    assert!(
+        applied(&ack).conflict.is_none(),
+        "different parts merge, and a stale base alone is never a rejection"
+    );
+    assert_eq!(state_of(&world, "quest", q).await, "worked");
+    assert_eq!(quest_row(&world, q).await.campaign, Some(c.as_uuid()));
+}

--- a/crates/altaird/tests/type_content_guidance.rs
+++ b/crates/altaird/tests/type_content_guidance.rs
@@ -1453,3 +1453,211 @@ async fn two_members_moving_different_guidance_parts_merge() {
     assert_eq!(state_of(&world, "quest", q).await, "worked");
     assert_eq!(quest_row(&world, q).await.campaign, Some(c.as_uuid()));
 }
+
+// ---------------------------------------------------------------------------
+// The parent a move vacated
+// ---------------------------------------------------------------------------
+
+/// **The vacated parent records the counter it moved at.**
+///
+/// A quest holds at most one ladder parent, so setting an arc clears the
+/// campaign in the same statement. That vacated column is a part like any
+/// other, and a part that records no counter movement is invisible to conflict
+/// detection.
+#[tokio::test]
+async fn a_quest_moving_between_parents_records_the_parent_it_vacated() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_arc(a))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_campaign(c)))),
+        )
+        .await;
+    let after = world.counter(q).await;
+
+    assert_eq!(
+        part_counter(&world, q, "specific.3").await,
+        Some(after),
+        "the campaign it entered"
+    );
+    assert_eq!(
+        part_counter(&world, q, "specific.2").await,
+        Some(after),
+        "the arc it left, which nothing addressed and the statement still cleared"
+    );
+    assert_eq!(
+        part_counter(&world, q, "specific.5").await,
+        Some(after),
+        "the position that moved with them"
+    );
+}
+
+/// The payoff, and the reason the vacated parent is worth recording at all.
+///
+/// One member moves the quest off its arc and onto a campaign. Another, from
+/// the same base, sets a different arc. Both writes are about which parent the
+/// quest has, so **both values are retained** rather than the second silently
+/// winning. Without the vacated parent in provenance this merges with nobody
+/// involved, and a standing constraint is quietly broken.
+#[tokio::test]
+async fn a_concurrent_edit_to_the_vacated_parent_conflicts_rather_than_merging() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), shared_with(&world))
+        .await;
+    let first = world
+        .create(&world.one, as_arc(arc(None, Some(c))), shared_with(&world))
+        .await;
+    let second = world
+        .create(&world.one, as_arc(arc(None, Some(c))), shared_with(&world))
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_arc(first))),
+            shared_with(&world),
+        )
+        .await;
+    let base = world.counter(q).await;
+
+    // One moves it off the arc and onto the campaign, vacating `arc_id`.
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_campaign(c)))),
+        )
+        .await;
+    // Two, still on the base it last saw, points the arc somewhere else.
+    let ack = world
+        .submit(
+            &world.two,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(second)))),
+        )
+        .await;
+
+    let applied = applied(&ack);
+    let conflict = applied
+        .conflict
+        .as_ref()
+        .expect("both writes moved the quest's arc, which is one part twice");
+    assert!(
+        conflict.specific_fields.contains(&2),
+        "the vacated arc is the conflicted part: {:?}",
+        conflict.specific_fields
+    );
+
+    let conflicts = world.conflicts(q).await;
+    let vacated = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.2"))
+        .expect("the arc is retained on both sides");
+    assert_eq!(vacated.mine.as_deref(), Some(second.as_uuid().to_string()).as_deref());
+    assert_eq!(
+        vacated.theirs, None,
+        "the value it displaced was the arc the first write cleared"
+    );
+    assert_eq!(vacated.mine_member, Some(world.two.membership_id()));
+    assert_eq!(vacated.theirs_member, Some(world.one.membership_id()));
+
+    // And the write still applied.
+    let row = quest_row(&world, q).await;
+    assert_eq!(row.arc, Some(second.as_uuid()));
+    assert_eq!(row.campaign, None);
+}
+
+/// **A companion is owed only when the part genuinely moved.**
+///
+/// A quest that had no campaign gains an arc. Nothing was vacated, so nothing
+/// about `campaign_id` is recorded. Recording it would not manufacture a
+/// conflict — arriving equals stored — but it would leave an
+/// `entity_part_counter` row claiming that part moved, which a later unrelated
+/// edit reads as an overlap. Silent, and exactly what the per-part counter
+/// exists to prevent.
+#[tokio::test]
+async fn a_parent_that_was_already_empty_records_nothing() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let a = world
+        .create(
+            &world.one,
+            as_arc(arc(None, Some(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, None)),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_arc(a)))),
+        )
+        .await;
+
+    assert_eq!(part_counter(&world, q, "specific.2").await, Some(base + 1));
+    assert_eq!(part_counter(&world, q, "specific.5").await, Some(base + 1));
+    assert_eq!(
+        part_counter(&world, q, "specific.3").await,
+        None,
+        "a campaign that was never there did not move"
+    );
+}
+
+/// Restating the container something is already in vacates nothing either, and
+/// the sibling that was already empty stays unrecorded.
+#[tokio::test]
+async fn restating_the_same_parent_vacates_nothing() {
+    let world = World::new().await;
+    let c = world
+        .create(&world.one, campaign(None), v1::EntityContent::default())
+        .await;
+    let q = world
+        .create(
+            &world.one,
+            as_quest(quest(None, beneath_campaign(c))),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let base = world.counter(q).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(q, base, as_quest(quest(None, beneath_campaign(c)))),
+        )
+        .await;
+
+    assert_eq!(
+        part_counter(&world, q, "specific.2").await,
+        None,
+        "no arc was ever held, so none was vacated"
+    );
+    assert_eq!(quest_row(&world, q).await.position, Some(0));
+}

--- a/crates/altaird/tests/type_content_guidance.rs
+++ b/crates/altaird/tests/type_content_guidance.rs
@@ -1905,7 +1905,7 @@ async fn a_child_the_eraser_cannot_see_is_still_released() {
 /// **This assertion inverts when the dispatch arm calls the module.** Whoever
 /// wires it should delete the first half and keep the second.
 #[tokio::test]
-async fn the_dispatch_has_not_been_pointed_at_this_yet() {
+async fn the_dispatch_reaches_the_ladders_release() {
     let world = World::new().await;
     let c = world
         .create(&world.one, campaign(None), v1::EntityContent::default())
@@ -1924,22 +1924,26 @@ async fn the_dispatch_has_not_been_pointed_at_this_yet() {
         member: MemberId::for_test(world.one.membership_id()),
         at: Utc::now(),
     };
-    let through_dispatch = specific::detach_contained(&mut ctx, c, EntityType::Campaign).await;
-    let through_module =
-        specific::guidance::detach_contained(&mut ctx, c, EntityType::Campaign).await;
-    let (through_dispatch, through_module) = match (through_dispatch, through_module) {
-        (Ok(d), Ok(m)) => (d, m),
-        _ => panic!("the store was reachable"),
+    // **Once, not twice.** While the arm was unpointed this called the dispatch
+    // and then the module, because the dispatch was a no-op and the module could
+    // still find the arc to release. Now that the arm is wired the first call
+    // does the release and the second correctly finds nothing left, so asking
+    // both in one transaction measures the order of the calls rather than the
+    // dispatch.
+    let Ok(through_dispatch) = specific::detach_contained(&mut ctx, c, EntityType::Campaign).await
+    else {
+        panic!("the store was reachable")
     };
     tx.rollback().await.expect("rollback");
 
-    assert_eq!(through_dispatch, specific::Detachment::NotBuilt);
     assert_eq!(
-        through_module,
+        through_dispatch,
         specific::Detachment::Released(vec![specific::Released {
             entity: a,
             part: Part::Specific(2),
         }]),
-        "the module releases; only the dispatch arm is still unpointed"
+        "the dispatch reaches the ladder's release — this assertion read \
+         `NotBuilt` while the arm was unpointed, which is what made the gap \
+         visible rather than silent"
     );
 }

--- a/crates/altaird/tests/type_content_knowledge.rs
+++ b/crates/altaird/tests/type_content_knowledge.rs
@@ -1,0 +1,874 @@
+//! Knowledge's type content, and categories.
+//!
+//! The lane's name oversells it and the suite is arranged to say so. A note has
+//! no fields of its own — migration one refuses it a table on purpose — and a
+//! file has one field this wave can serve, its media type. **The substance is
+//! categories**, and inside categories it is the creation-default audience,
+//! which is three separate claims that look like one sentence:
+//!
+//! - it acts **once, at creation**, so a later move into the category applies
+//!   nothing;
+//! - it is **not a standing rule**, so editing it reaches nothing already
+//!   placed;
+//! - it is **never inherited**, so a child category has only its own.
+//!
+//! Each has a test, because each could break without the other two noticing.
+//! The whole point of the narrowness is that a category never sets an audience
+//! as a standing rule, and a default that quietly became one would be a leak
+//! rather than a bug.
+//!
+//! The second half is cycle prevention in nested categories, which migration
+//! one records as its gap (h) and cannot close: a constraint sees one row. The
+//! interesting cases are two hops and longer; self-reference passes for free
+//! and proves nothing on its own.
+
+mod common;
+
+use altair_proto::v1;
+use altaird::store::entity::EntityType;
+use altaird::store::ids::EntityId;
+use altaird::write::specific::{self, Held};
+use common::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Saying a category
+// ---------------------------------------------------------------------------
+
+fn category_content(
+    parent: Option<EntityId>,
+    default: &[Uuid],
+    cleared: Vec<u32>,
+) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Category(v1::CategoryContent {
+        parent_category_id: parent.map(|p| p.as_uuid().as_bytes().to_vec()),
+        creation_default_audience_member_ids: default
+            .iter()
+            .map(|m| m.as_bytes().to_vec())
+            .collect(),
+        cleared,
+    })
+}
+
+/// A plain category, visible to its author alone.
+async fn category(world: &World, parent: Option<EntityId>, default: &[Uuid]) -> EntityId {
+    world
+        .create(
+            &world.one,
+            category_content(parent, default, Vec::new()),
+            v1::EntityContent::default(),
+        )
+        .await
+}
+
+/// A category both members can see, which is what makes a concurrent edit to
+/// one possible at all.
+async fn shared_category(world: &World, default: &[Uuid]) -> EntityId {
+    world
+        .create(
+            &world.one,
+            category_content(None, default, Vec::new()),
+            v1::EntityContent {
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+/// Edit a category's own content, from the counter it currently holds.
+async fn edit_category(
+    world: &World,
+    id: EntityId,
+    specific: v1::entity_content::Specific,
+) -> v1::Acknowledgement {
+    let base = world.counter(id).await as u64;
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base,
+                v1::EntityContent {
+                    specific: Some(specific),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// Reading the store back
+// ---------------------------------------------------------------------------
+
+async fn parent_of(world: &World, id: EntityId) -> Option<Uuid> {
+    sqlx::query("SELECT parent_category_id AS p FROM category WHERE entity_id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("category row")
+        .try_get("p")
+        .expect("parent")
+}
+
+async fn creation_default_of(world: &World, id: EntityId) -> Vec<Uuid> {
+    sqlx::query("SELECT creation_default_audience AS a FROM category WHERE entity_id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("category row")
+        .try_get("a")
+        .expect("default")
+}
+
+/// The audience an entity actually ended up with.
+///
+/// A test may read this column directly. `tests/one_predicate.rs` exempts test
+/// sources from the column check deliberately: an assertion that both paths
+/// call one predicate has to be able to see past it, and ground truth that came
+/// through the audience-scoped surface would be checking the predicate against
+/// itself.
+async fn audience_of(world: &World, id: EntityId) -> Vec<Uuid> {
+    sqlx::query("SELECT audience_member_ids AS a FROM entity WHERE id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("entity")
+        .try_get("a")
+        .expect("audience")
+}
+
+/// A note created inside a category, which is the thing a creation default acts
+/// on.
+async fn note_in(world: &World, category: EntityId) -> EntityId {
+    world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            v1::EntityContent {
+                title: Some("placed".into()),
+                category_id: Some(category.as_uuid().as_bytes().to_vec()),
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// A category's two fields, through create and edit
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_categorys_nesting_and_creation_default_round_trip_through_a_create() {
+    let world = World::new().await;
+    let top = category(&world, None, &[]).await;
+    let two = world.two.membership_id();
+
+    let nested = category(&world, Some(top), &[two]).await;
+
+    assert_eq!(parent_of(&world, nested).await, Some(top.as_uuid()));
+    assert_eq!(creation_default_of(&world, nested).await, vec![two]);
+    assert_eq!(
+        parent_of(&world, top).await,
+        None,
+        "the top nests in nothing"
+    );
+    assert!(creation_default_of(&world, top).await.is_empty());
+}
+
+#[tokio::test]
+async fn an_edit_moves_both_fields_and_advances_the_counter() {
+    let world = World::new().await;
+    let first = category(&world, None, &[]).await;
+    let second = category(&world, None, &[]).await;
+    let moving = category(&world, Some(first), &[]).await;
+    let base = world.counter(moving).await;
+
+    let ack = edit_category(
+        &world,
+        moving,
+        category_content(Some(second), &[world.one.membership_id()], Vec::new()),
+    )
+    .await;
+
+    assert_eq!(applied(&ack).counter, (base + 1) as u64);
+    assert_eq!(parent_of(&world, moving).await, Some(second.as_uuid()));
+    assert_eq!(
+        creation_default_of(&world, moving).await,
+        vec![world.one.membership_id()]
+    );
+}
+
+#[tokio::test]
+async fn clearing_a_parent_returns_a_category_to_the_top() {
+    let world = World::new().await;
+    let top = category(&world, None, &[]).await;
+    let nested = category(&world, Some(top), &[]).await;
+
+    edit_category(&world, nested, category_content(None, &[], vec![1])).await;
+
+    assert_eq!(parent_of(&world, nested).await, None);
+}
+
+/// **Emptying is how a repeated field is cleared**, and the column is
+/// `NOT NULL DEFAULT '{}'`, so a category that never had a default and one
+/// whose default was emptied are the same category rather than two states.
+#[tokio::test]
+async fn emptying_a_creation_default_clears_it() {
+    let world = World::new().await;
+    let id = category(&world, None, &[world.two.membership_id()]).await;
+
+    edit_category(&world, id, category_content(None, &[], vec![2])).await;
+
+    assert!(creation_default_of(&world, id).await.is_empty());
+}
+
+/// `entity_part_counter` is per part and conflict detection asks which parts
+/// moved between two counter values. A part that does not record its movement
+/// is invisible to that, and the failure is silent.
+#[tokio::test]
+async fn both_category_parts_record_the_counter_they_moved_at() {
+    let world = World::new().await;
+    let top = category(&world, None, &[]).await;
+    let id = category(&world, Some(top), &[world.two.membership_id()]).await;
+
+    let rows = sqlx::query(
+        "SELECT field_name, counter FROM entity_part_counter \
+         WHERE entity_id = $1 ORDER BY field_name",
+    )
+    .bind(id.as_uuid())
+    .fetch_all(&world.db.pool)
+    .await
+    .expect("query");
+
+    let named: Vec<String> = rows
+        .iter()
+        .map(|r| r.try_get::<String, _>("field_name").unwrap())
+        .collect();
+    assert!(
+        named.contains(&"specific.1".to_owned()) && named.contains(&"specific.2".to_owned()),
+        "both parts record their movement, or nothing can conflict on them: {named:?}"
+    );
+}
+
+/// Both values retained on a same-part conflict, and the acknowledgement names
+/// the type message's own field number.
+#[tokio::test]
+async fn a_same_part_conflict_on_a_creation_default_retains_both_values() {
+    let world = World::new().await;
+    let id = shared_category(&world, &[]).await;
+    let base = world.counter(id).await;
+
+    let one = world.one.membership_id();
+    let two = world.two.membership_id();
+
+    for (member, stated) in [(&world.one, one), (&world.two, two)] {
+        world
+            .submit(
+                member,
+                edit_entity(
+                    id,
+                    base as u64,
+                    v1::EntityContent {
+                        specific: Some(category_content(None, &[stated], Vec::new())),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+    }
+
+    let conflicts = world.conflicts(id).await;
+    assert_eq!(conflicts.len(), 1);
+    let c = &conflicts[0];
+    assert_eq!(c.field.as_deref(), Some("specific.2"));
+    assert_eq!(c.mine.as_deref(), Some(two.to_string().as_str()));
+    assert_eq!(c.theirs.as_deref(), Some(one.to_string().as_str()));
+    assert_eq!(creation_default_of(&world, id).await, vec![two]);
+}
+
+/// **A set has no order and the wire carries it as a list.** Two clients naming
+/// the same two members in different orders agree, and forming a conflict out
+/// of agreement is the machinery working against its own purpose.
+#[tokio::test]
+async fn the_same_two_members_in_either_order_are_the_same_default() {
+    let world = World::new().await;
+    let id = shared_category(&world, &[]).await;
+    let base = world.counter(id).await;
+    let one = world.one.membership_id();
+    let two = world.two.membership_id();
+
+    for (member, stated) in [(&world.one, [one, two]), (&world.two, [two, one])] {
+        world
+            .submit(
+                member,
+                edit_entity(
+                    id,
+                    base as u64,
+                    v1::EntityContent {
+                        specific: Some(category_content(None, &stated, Vec::new())),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+    }
+
+    assert!(
+        world.conflicts(id).await.is_empty(),
+        "writes producing the same value are not divergent"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The creation default: three claims, three tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn an_entity_created_in_a_category_takes_its_creation_default() {
+    let world = World::new().await;
+    let two = world.two.membership_id();
+    let holder = category(&world, None, &[two]).await;
+
+    let placed = note_in(&world, holder).await;
+
+    assert_eq!(audience_of(&world, placed).await, vec![two]);
+}
+
+/// **It acts at creation only.** Moving something into the category afterwards
+/// is an edit, and an edit never asks the category what it defaults — otherwise
+/// tidying would broaden an audience, silently, on somebody else's entity.
+#[tokio::test]
+async fn moving_an_existing_entity_into_a_category_applies_nothing() {
+    let world = World::new().await;
+    let holder = category(&world, None, &[world.two.membership_id()]).await;
+    let loose = world.note(&world.one, "captured outside").await;
+    assert!(audience_of(&world, loose).await.is_empty());
+
+    let base = world.counter(loose).await;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_entity(
+                loose,
+                base as u64,
+                v1::EntityContent {
+                    category_id: Some(holder.as_uuid().as_bytes().to_vec()),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+
+    assert!(
+        audience_of(&world, loose).await.is_empty(),
+        "the default acts once, at creation; a later move is not a creation"
+    );
+}
+
+/// **It is not a standing rule.** The value is copied at creation and never
+/// consulted again, so editing it reaches nothing already placed. A category
+/// that broadened its contents retroactively would be a category setting an
+/// audience, which the substrate says it never does.
+#[tokio::test]
+async fn editing_a_creation_default_does_not_reach_entities_already_placed() {
+    let world = World::new().await;
+    let holder = category(&world, None, &[]).await;
+    let placed = note_in(&world, holder).await;
+    assert!(audience_of(&world, placed).await.is_empty());
+
+    edit_category(
+        &world,
+        holder,
+        category_content(None, &[world.two.membership_id()], Vec::new()),
+    )
+    .await;
+
+    assert!(
+        audience_of(&world, placed).await.is_empty(),
+        "a default is not a standing rule; it does not reach backwards"
+    );
+}
+
+/// **It is never inherited.** A child with no default of its own has none, and
+/// the read walks no ancestry to find one.
+#[tokio::test]
+async fn a_child_category_does_not_inherit_its_parents_creation_default() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[world.two.membership_id()]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    let placed = note_in(&world, child).await;
+
+    assert!(
+        audience_of(&world, placed).await.is_empty(),
+        "a default is never inherited, at any depth"
+    );
+}
+
+/// An audience the write states outranks the default. Clearing it is stating
+/// it: the wire says empty and not cleared means untouched, and cleared means
+/// private to the author.
+#[tokio::test]
+async fn an_audience_the_write_states_outranks_the_default() {
+    let world = World::new().await;
+    let holder = category(&world, None, &[world.two.membership_id()]).await;
+
+    let placed = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Note(v1::NoteContent::default()),
+            v1::EntityContent {
+                category_id: Some(holder.as_uuid().as_bytes().to_vec()),
+                cleared: vec![5],
+                ..Default::default()
+            },
+        )
+        .await;
+
+    assert!(audience_of(&world, placed).await.is_empty());
+}
+
+/// **A foreign key cannot reach inside an array**, which is why this is a
+/// write-path check and is on the schema's owed list. A member id naming no
+/// membership is refused rather than stored and discovered later by whatever
+/// tries to resolve it.
+#[tokio::test]
+async fn a_creation_default_naming_no_membership_is_refused() {
+    let world = World::new().await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(category_content(None, &[Uuid::new_v4()], Vec::new())),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+}
+
+// ---------------------------------------------------------------------------
+// Cycle prevention, where the schema cannot see it
+// ---------------------------------------------------------------------------
+
+/// The refusal a closed loop gets, or a panic naming what came back instead.
+async fn nesting_refusal(world: &World, child: EntityId, parent: EntityId) -> String {
+    let ack = edit_category(
+        world,
+        child,
+        category_content(Some(parent), &[], Vec::new()),
+    )
+    .await;
+    let refused = refused(&ack);
+    assert_eq!(
+        refused.reason,
+        v1::RefusalReason::Malformed as i32,
+        "{refused:?}"
+    );
+    refused.detail.clone()
+}
+
+#[tokio::test]
+async fn a_category_cannot_be_its_own_parent() {
+    let world = World::new().await;
+    let a = category(&world, None, &[]).await;
+
+    let detail = nesting_refusal(&world, a, a).await;
+    assert!(detail.contains("close a loop"), "{detail}");
+    assert_eq!(parent_of(&world, a).await, None);
+}
+
+/// Two hops is the first case the schema cannot see. Its only check is
+/// `parent_category_id <> entity_id`, which a loop of length two satisfies at
+/// every row.
+#[tokio::test]
+async fn a_two_hop_loop_is_refused() {
+    let world = World::new().await;
+    let a = category(&world, None, &[]).await;
+    let b = category(&world, Some(a), &[]).await;
+
+    let detail = nesting_refusal(&world, a, b).await;
+    assert!(detail.contains("close a loop"), "{detail}");
+    assert_eq!(parent_of(&world, a).await, None, "and nothing was written");
+}
+
+#[tokio::test]
+async fn a_longer_loop_is_refused_too() {
+    let world = World::new().await;
+    let a = category(&world, None, &[]).await;
+    let b = category(&world, Some(a), &[]).await;
+    let c = category(&world, Some(b), &[]).await;
+
+    nesting_refusal(&world, a, c).await;
+    assert_eq!(parent_of(&world, a).await, None);
+    // And the chain that was legal is untouched.
+    assert_eq!(parent_of(&world, b).await, Some(a.as_uuid()));
+    assert_eq!(parent_of(&world, c).await, Some(b.as_uuid()));
+}
+
+#[tokio::test]
+async fn an_ordinary_nesting_is_accepted() {
+    let world = World::new().await;
+    let a = category(&world, None, &[]).await;
+    let b = category(&world, Some(a), &[]).await;
+    let c = category(&world, None, &[]).await;
+
+    edit_category(&world, c, category_content(Some(b), &[], Vec::new())).await;
+
+    assert_eq!(parent_of(&world, c).await, Some(b.as_uuid()));
+}
+
+// ---------------------------------------------------------------------------
+// A parent that is not there, one that cannot be seen, and one of the wrong
+// type are the same nothing
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_parent_that_is_not_there_is_refused_as_unavailable() {
+    let world = World::new().await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(category_content(
+                        Some(EntityId::from_uuid(Uuid::new_v4())),
+                        &[],
+                        Vec::new(),
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+}
+
+/// **Refusal on audience is indistinguishable from refusal on nonexistence.**
+/// Member two's private category and a category that was never created answer
+/// with the same nothing, or the refusal is an oracle for what the household
+/// holds.
+#[tokio::test]
+async fn a_parent_the_member_cannot_see_answers_exactly_as_one_that_is_not_there() {
+    let world = World::new().await;
+    // Two's own category, which one cannot see: audience is private to the
+    // author by default.
+    let hidden = world
+        .create(
+            &world.two,
+            category_content(None, &[], Vec::new()),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let mine = category(&world, None, &[]).await;
+
+    let hidden_ack = edit_category(
+        &world,
+        mine,
+        category_content(Some(hidden), &[], Vec::new()),
+    )
+    .await;
+    let absent_ack = edit_category(
+        &world,
+        mine,
+        category_content(Some(EntityId::from_uuid(Uuid::new_v4())), &[], Vec::new()),
+    )
+    .await;
+
+    // Both refuse as unavailable, and then the stronger claim: the two answers
+    // are the same answer. Equality alone would pass if both had drifted to
+    // some other single reason, so the reason is pinned first.
+    assert!(is_not_available(&hidden_ack), "{:?}", hidden_ack.outcome);
+    assert!(is_not_available(&absent_ack), "{:?}", absent_ack.outcome);
+    assert_eq!(
+        format!("{:?}", hidden_ack.outcome),
+        format!("{:?}", absent_ack.outcome),
+        "a category the member cannot see and one that is not there are the same nothing, \
+         down to the detail; anything else is an oracle for what the household holds"
+    );
+    assert_eq!(parent_of(&world, mine).await, None);
+}
+
+/// A parent that exists and is not a category is the same nothing again. The
+/// schema's composite foreign key would refuse it too, but as a constraint
+/// violation that takes the transaction down and says which entity is there.
+#[tokio::test]
+async fn a_parent_that_is_not_a_category_is_the_same_nothing() {
+    let world = World::new().await;
+    let mine = category(&world, None, &[]).await;
+    let note = world.note(&world.one, "not a container").await;
+
+    let ack = edit_category(&world, mine, category_content(Some(note), &[], Vec::new())).await;
+
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+    assert_eq!(parent_of(&world, mine).await, None);
+}
+
+/// 2.1 refuses an explicit position pending whatever first reorders, and
+/// nothing in this lane reorders. Nested categories carry no position at all —
+/// migration one's gap (g) — so a category gaining a parent gains nothing to
+/// order it by.
+#[tokio::test]
+async fn an_explicit_position_is_still_refused() {
+    let world = World::new().await;
+    let holder = category(&world, None, &[]).await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Note(
+                        v1::NoteContent::default(),
+                    )),
+                    category_id: Some(holder.as_uuid().as_bytes().to_vec()),
+                    category_position: Some(0),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let refused = refused(&ack);
+    assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
+    assert!(refused.detail.contains("position"), "{}", refused.detail);
+}
+
+// ---------------------------------------------------------------------------
+// A note has no fields of its own
+// ---------------------------------------------------------------------------
+
+/// Migration one: *"There is no note table. A note holds a body beyond the
+/// shared set, a body is its blocks in order, and there is no second
+/// representation of the same content for them to disagree with."* So the
+/// declaration is one field, it is a body, and it is not a column.
+#[test]
+fn a_notes_only_field_is_its_body_and_it_has_no_table() {
+    let fields = specific::fields(EntityType::Note);
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].number, 1);
+    assert!(matches!(fields[0].held, Held::Body));
+    assert!(
+        specific::side_table(EntityType::Note).is_none(),
+        "a note's content is its body; a second representation is what would disagree"
+    );
+}
+
+/// **Nothing in this lane writes a block.** Bodies are their own lane and their
+/// own module; a note created without one holds none, and neither a category
+/// nor a file goes anywhere near the table.
+#[tokio::test]
+async fn nothing_in_this_lane_writes_a_block() {
+    let world = World::new().await;
+    let holder = category(&world, None, &[world.two.membership_id()]).await;
+    let placed = note_in(&world, holder).await;
+
+    for id in [holder, placed] {
+        assert_eq!(world.rows_for("block", "entity_id", id).await, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A file, which is one served field and two refusals that expire
+// ---------------------------------------------------------------------------
+
+/// A file entity, made by hand.
+///
+/// **Scaffolding standing in for Wave 2.3.** A file cannot be created through
+/// the public path — the create refuses one, because the schema requires a body
+/// and `PutBody` is not served — so the only way to have a file to edit is to
+/// put one there. The rows are the minimum the schema demands; 2.3 replaces
+/// this with an upload.
+async fn a_file(world: &World) -> EntityId {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO entity (id, type, author_member_id, created_at, updated_at, capture_method) \
+         VALUES ($1, 'file', $2, now(), now(), 'test')",
+    )
+    .bind(id)
+    .bind(world.one.membership_id())
+    .execute(&world.db.pool)
+    .await
+    .expect("entity");
+    sqlx::query("INSERT INTO file (entity_id, body_id) VALUES ($1, $2)")
+        .bind(id)
+        .bind(Uuid::new_v4())
+        .execute(&world.db.pool)
+        .await
+        .expect("file");
+    EntityId::from_uuid(id)
+}
+
+async fn media_type_of(world: &World, id: EntityId) -> Option<String> {
+    sqlx::query("SELECT media_type AS m FROM file WHERE entity_id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("file row")
+        .try_get("m")
+        .expect("media type")
+}
+
+fn file_content(media_type: Option<&str>, cleared: Vec<u32>) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::File(v1::FileContent {
+        media_type: media_type.map(ToOwned::to_owned),
+        cleared,
+        ..Default::default()
+    })
+}
+
+async fn edit_file(
+    world: &World,
+    id: EntityId,
+    specific: v1::entity_content::Specific,
+) -> v1::Acknowledgement {
+    let base = world.counter(id).await as u64;
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base,
+                v1::EntityContent {
+                    specific: Some(specific),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await
+}
+
+/// The whole of a v0 file's own content. The scope's v0 files are entities with
+/// a title and relations; a media type is what display follows.
+#[tokio::test]
+async fn a_files_media_type_round_trips() {
+    let world = World::new().await;
+    let id = a_file(&world).await;
+    assert_eq!(media_type_of(&world, id).await, None);
+
+    let ack = edit_file(&world, id, file_content(Some("image/png"), Vec::new())).await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    assert_eq!(
+        media_type_of(&world, id).await.as_deref(),
+        Some("image/png")
+    );
+
+    edit_file(&world, id, file_content(None, vec![2])).await;
+    assert_eq!(media_type_of(&world, id).await, None, "and it clears");
+}
+
+/// A media type is a machine label rather than the person's words, so it stays
+/// out of the text a literal search matches. The title still reaches it.
+#[tokio::test]
+async fn a_media_type_does_not_reach_search_text() {
+    let world = World::new().await;
+    let id = a_file(&world).await;
+    let base = world.counter(id).await as u64;
+    world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base,
+                v1::EntityContent {
+                    title: Some("the receipt".into()),
+                    specific: Some(file_content(Some("image/png"), Vec::new())),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+
+    let text: String = sqlx::query("SELECT search_text FROM entity WHERE id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("entity")
+        .try_get("search_text")
+        .expect("search_text");
+    assert_eq!(text, "the receipt");
+}
+
+/// **Bytes before the record.** There is no identity to name until `PutBody`
+/// is served, and the refusal says which lane a client is waiting on rather
+/// than that its message was wrong.
+#[tokio::test]
+async fn a_files_body_id_is_refused_because_put_body_is_not_served() {
+    let world = World::new().await;
+    let id = a_file(&world).await;
+    let ack = edit_file(
+        &world,
+        id,
+        v1::entity_content::Specific::File(v1::FileContent {
+            body_id: Some(Uuid::new_v4().as_bytes().to_vec()),
+            ..Default::default()
+        }),
+    )
+    .await;
+    let refused = refused(&ack);
+    assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
+    assert!(refused.detail.contains("PutBody"), "{}", refused.detail);
+}
+
+/// `altair-v0-scope.md` defers text extraction from files, and it governs the
+/// implementation plan where the two disagree. A person's correction to
+/// extracted text has nothing to outrank while extraction does not exist.
+#[tokio::test]
+async fn a_files_extracted_text_is_refused_because_extraction_is_deferred() {
+    let world = World::new().await;
+    let id = a_file(&world).await;
+    let ack = edit_file(
+        &world,
+        id,
+        v1::entity_content::Specific::File(v1::FileContent {
+            extracted_text: Some("what the picture says".into()),
+            ..Default::default()
+        }),
+    )
+    .await;
+    let refused = refused(&ack);
+    assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
+    assert!(
+        refused.detail.contains("deferred in v0"),
+        "{}",
+        refused.detail
+    );
+}
+
+/// And the create still refuses, which is 2.1's refusal and 2.3's to expire.
+/// Serving `media_type` does not make a file creatable, and quietly making one
+/// would put a record in front of its bytes.
+#[tokio::test]
+async fn a_file_still_cannot_be_created() {
+    let world = World::new().await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(file_content(Some("image/png"), Vec::new())),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let refused = refused(&ack);
+    assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
+    assert!(refused.detail.contains("PutBody"), "{}", refused.detail);
+}

--- a/crates/altaird/tests/type_content_knowledge.rs
+++ b/crates/altaird/tests/type_content_knowledge.rs
@@ -25,9 +25,13 @@
 mod common;
 
 use altair_proto::v1;
+use altaird::store::begin_write;
 use altaird::store::entity::EntityType;
-use altaird::store::ids::EntityId;
-use altaird::write::specific::{self, Held};
+use altaird::store::ids::{EntityId, MemberId};
+use altaird::write::entity::Ctx;
+use altaird::write::parts::Part;
+use altaird::write::specific::{self, Detachment, Held};
+use chrono::Utc;
 use common::*;
 use sqlx::Row;
 use uuid::Uuid;
@@ -1018,4 +1022,219 @@ async fn a_file_still_cannot_be_created() {
     let refused = refused(&ack);
     assert_eq!(refused.reason, v1::RefusalReason::Malformed as i32);
     assert!(refused.detail.contains("PutBody"), "{}", refused.detail);
+}
+
+// ---------------------------------------------------------------------------
+// What an erased category lets go of, one level up from membership
+// ---------------------------------------------------------------------------
+//
+// **A category is a container in two senses and only one was ever released.**
+// Membership — an entity filed *in* a category — is the `entity` row's
+// `category_id`, and `uncategorise_all` has released it since Wave 2.1.
+// Nesting — a category sitting *under* another — is this type's own
+// `parent_category_id`, and nothing released it: the erase path's comment names
+// "the ladder and nested locations" and silently omits the third case.
+//
+// Reached directly here, by the module path rather than the dispatch, because
+// `specific::detach_contained`'s `Category` arm still answers `NotBuilt`.
+// Wiring that arm is one line in a file this lane does not own.
+// `the_dispatch_still_answers_not_built` below is the test to invert when it
+// lands, and it is written to say so.
+
+/// Run the release against a category, outside any write of its own.
+async fn detach(world: &World, container: EntityId) -> Detachment {
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    let answer = specific::category::detach_contained(&mut ctx, container)
+        .await
+        .unwrap_or_else(|_| panic!("the store was reachable"));
+    tx.commit().await.expect("commit");
+    answer
+}
+
+fn released_ids(answer: &Detachment) -> Vec<EntityId> {
+    match answer {
+        Detachment::Released(rows) => {
+            let mut ids: Vec<EntityId> = rows.iter().map(|r| r.entity).collect();
+            ids.sort_by_key(|e: &EntityId| e.as_uuid());
+            ids
+        }
+        other => panic!("expected a release, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn an_erased_category_releases_the_categories_nested_under_it() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let mut children = [
+        category(&world, Some(parent), &[]).await,
+        category(&world, Some(parent), &[]).await,
+    ];
+    children.sort_by_key(|e: &EntityId| e.as_uuid());
+
+    let answer = detach(&world, parent).await;
+
+    assert_eq!(released_ids(&answer), children.to_vec());
+    for child in children {
+        assert_eq!(
+            parent_of(&world, child).await,
+            None,
+            "a released child points at nothing"
+        );
+    }
+}
+
+/// **A release is a write, so it owes provenance**, and which part moved is the
+/// type's knowledge. A child category lost its parent — field 1 — rather than
+/// its shelf.
+#[tokio::test]
+async fn a_release_names_the_part_that_moved() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    let Detachment::Released(rows) = detach(&world, parent).await else {
+        panic!("expected a release");
+    };
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].entity, child);
+    assert_eq!(rows[0].part, Part::Specific(1));
+}
+
+/// **Parentless, not promoted.** A child does not inherit its erased parent's
+/// parent. Guidance settled this for the ladder and the reasoning carries:
+/// promotion would be the system moving something into a container the person
+/// never put it in.
+#[tokio::test]
+async fn a_child_is_left_parentless_rather_than_promoted() {
+    let world = World::new().await;
+    let grandparent = category(&world, None, &[]).await;
+    let parent = category(&world, Some(grandparent), &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    detach(&world, parent).await;
+
+    assert_eq!(parent_of(&world, child).await, None);
+    assert_eq!(
+        parent_of(&world, grandparent).await,
+        None,
+        "and the grandparent is untouched"
+    );
+}
+
+/// **Deliberately unscoped**, for `uncategorise_all`'s reason and no smaller
+/// here: the container is gone for everybody, so a child the erasing member
+/// cannot see must still be released — otherwise the dangling reference
+/// survives precisely where nobody can find it.
+#[tokio::test]
+async fn a_child_the_erasing_member_cannot_see_is_still_released() {
+    let world = World::new().await;
+    // The container is visible to two, or two could not nest under it at all.
+    let parent = shared_category(&world, &[]).await;
+    // The child is two's own and states no audience, so it is private to two
+    // and member one cannot see it.
+    let hidden = world
+        .create(
+            &world.two,
+            category_content(Some(parent), &[], Vec::new()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert!(
+        audience_of(&world, hidden).await.is_empty(),
+        "the child is private to its author, or this proves nothing"
+    );
+
+    // The release runs as member one, who cannot see it.
+    let answer = detach(&world, parent).await;
+
+    assert_eq!(released_ids(&answer), vec![hidden]);
+    assert_eq!(parent_of(&world, hidden).await, None);
+}
+
+/// An empty container releases nothing, and that is an answer rather than an
+/// omission — distinct from a type that has no container and from one whose
+/// release is unbuilt.
+#[tokio::test]
+async fn a_category_with_nothing_nested_under_it_releases_nothing() {
+    let world = World::new().await;
+    let lonely = category(&world, None, &[]).await;
+
+    assert_eq!(
+        detach(&world, lonely).await,
+        Detachment::Released(Vec::new())
+    );
+}
+
+/// **The two senses do not double-count.** A category nested under the erased
+/// one *and* filed in it is released once by each, of two different columns,
+/// and ends with neither a parent nor a filing. Nothing is written twice
+/// because nothing writes the same column twice.
+#[tokio::test]
+async fn nesting_and_membership_are_different_sets() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    // Nested under it and filed in it at the same time.
+    let both = world
+        .create(
+            &world.one,
+            category_content(Some(parent), &[], Vec::new()),
+            v1::EntityContent {
+                category_id: Some(parent.as_uuid().as_bytes().to_vec()),
+                ..Default::default()
+            },
+        )
+        .await;
+    // Filed in it but not nested under it.
+    let filed = note_in(&world, parent).await;
+
+    let answer = detach(&world, parent).await;
+
+    assert_eq!(
+        released_ids(&answer),
+        vec![both],
+        "nesting releases the nested one only; the filed note is membership's"
+    );
+    assert_eq!(parent_of(&world, both).await, None);
+    // Membership is still the shared model's and is untouched by this call.
+    assert!(
+        world.category_position(filed).await.is_some(),
+        "the filed note is still filed until uncategorise_all runs"
+    );
+}
+
+/// **The one line this lane could not write.** `specific/mod.rs` is another
+/// lane's file, so the dispatch still answers `NotBuilt` for a category and the
+/// release above is unreachable from the erase path. Invert this the moment the
+/// arm calls `category::detach_contained`, and the end-to-end assertions — a
+/// change entry per released child, and removal releasing nothing — belong
+/// beside it.
+#[tokio::test]
+async fn the_dispatch_still_answers_not_built() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    let answer = specific::detach_contained(&mut ctx, parent, EntityType::Category)
+        .await
+        .unwrap_or_else(|_| panic!("the store was reachable"));
+    tx.rollback().await.expect("rollback");
+
+    assert_eq!(answer, Detachment::NotBuilt);
+    assert_eq!(
+        parent_of(&world, child).await,
+        Some(parent.as_uuid()),
+        "so an erase still leaves a nested category pointing at a tombstone"
+    );
 }

--- a/crates/altaird/tests/type_content_knowledge.rs
+++ b/crates/altaird/tests/type_content_knowledge.rs
@@ -772,6 +772,153 @@ async fn a_files_media_type_round_trips() {
     assert_eq!(media_type_of(&world, id).await, None, "and it clears");
 }
 
+// ---------------------------------------------------------------------------
+// A note's words reach the one place a literal search can find them
+// ---------------------------------------------------------------------------
+
+async fn search_text_of(world: &World, id: EntityId) -> String {
+    sqlx::query("SELECT search_text FROM entity WHERE id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("entity")
+        .try_get("search_text")
+        .expect("search_text")
+}
+
+/// A note with a title and a body, through the ordinary write path.
+async fn note_with_body(world: &World, title: &str, body: &str) -> EntityId {
+    world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Note(v1::NoteContent {
+                body: Some(body.into()),
+                cleared: Vec::new(),
+            }),
+            v1::EntityContent {
+                title: Some(title.into()),
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+async fn edit_body(world: &World, id: EntityId, body: Option<&str>, cleared: Vec<u32>) {
+    let base = world.counter(id).await as u64;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_entity(
+                id,
+                base,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                        body: body.map(ToOwned::to_owned),
+                        cleared,
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(
+        matches!(ack.outcome, Some(v1::acknowledgement::Outcome::Applied(_))),
+        "{:?}",
+        ack.outcome
+    );
+}
+
+/// **The whole of a note's literal searchability.** Both literal indexes are on
+/// the `entity` row and `block` carries none, so a body that does not reach
+/// `search_text` reaches no index by any route — and the standing claim that a
+/// just-captured entity is findable by its words would be false for exactly the
+/// type whose whole content is words.
+#[tokio::test]
+async fn a_notes_body_reaches_search_text() {
+    let world = World::new().await;
+    let id = note_with_body(
+        &world,
+        "descaling",
+        "The kettle is descaled twice a year.\n\nVinegar, an hour, then two rinses.",
+    )
+    .await;
+
+    let text = search_text_of(&world, id).await;
+    assert!(
+        text.contains("descaling"),
+        "the title is still there: {text}"
+    );
+    assert!(
+        text.contains("Vinegar") && text.contains("rinses"),
+        "a word from the body is findable: {text}"
+    );
+}
+
+/// **In the order the body reads.** A set of paragraphs is not a body, and the
+/// column holds text a person may read and an export may carry.
+#[tokio::test]
+async fn the_blocks_reach_it_in_order() {
+    let world = World::new().await;
+    let id = note_with_body(
+        &world,
+        "steps",
+        "First step.\n\nSecond step.\n\nThird step.",
+    )
+    .await;
+
+    let text = search_text_of(&world, id).await;
+    let first = text.find("First").expect("first block");
+    let second = text.find("Second").expect("second block");
+    let third = text.find("Third").expect("third block");
+    assert!(first < second && second < third, "out of order: {text}");
+}
+
+/// **It refreshes when the body changes**, not only at creation. A word the
+/// person deleted must stop being findable, or the index outlives the text.
+#[tokio::test]
+async fn editing_a_body_moves_what_is_searchable() {
+    let world = World::new().await;
+    let id = note_with_body(&world, "descaling", "Vinegar, an hour, then two rinses.").await;
+    assert!(search_text_of(&world, id).await.contains("Vinegar"));
+
+    edit_body(
+        &world,
+        id,
+        Some("Citric acid, an hour, then two rinses."),
+        Vec::new(),
+    )
+    .await;
+
+    let text = search_text_of(&world, id).await;
+    assert!(text.contains("Citric"), "the new words arrived: {text}");
+    assert!(
+        !text.contains("Vinegar"),
+        "a deleted word is still findable: {text}"
+    );
+    assert!(text.contains("descaling"), "the title survived: {text}");
+}
+
+/// Clearing a body takes its words with it and leaves the title standing.
+#[tokio::test]
+async fn clearing_a_body_leaves_the_title_alone() {
+    let world = World::new().await;
+    let id = note_with_body(&world, "descaling", "Vinegar, an hour.").await;
+
+    edit_body(&world, id, None, vec![1]).await;
+
+    assert_eq!(search_text_of(&world, id).await, "descaling");
+}
+
+/// **No body is no contribution, not an empty one.** `concat_ws` drops a null,
+/// so a note without a body keeps exactly the `search_text` it had before this
+/// seam was filled in — no separator, no trailing space.
+#[tokio::test]
+async fn a_note_with_no_body_is_exactly_its_title() {
+    let world = World::new().await;
+    let id = world.note(&world.one, "just a title").await;
+    assert_eq!(search_text_of(&world, id).await, "just a title");
+}
+
 /// A media type is a machine label rather than the person's words, so it stays
 /// out of the text a literal search matches. The title still reaches it.
 #[tokio::test]

--- a/crates/altaird/tests/type_content_knowledge.rs
+++ b/crates/altaird/tests/type_content_knowledge.rs
@@ -1035,11 +1035,12 @@ async fn a_file_still_cannot_be_created() {
 // `parent_category_id`, and nothing released it: the erase path's comment names
 // "the ladder and nested locations" and silently omits the third case.
 //
-// Reached directly here, by the module path rather than the dispatch, because
-// `specific::detach_contained`'s `Category` arm still answers `NotBuilt`.
-// Wiring that arm is one line in a file this lane does not own.
-// `the_dispatch_still_answers_not_built` below is the test to invert when it
-// lands, and it is written to say so.
+// The release below is reached two ways, deliberately. Most of these call it by
+// the module path, because that is where its own rules live and a direct call
+// keeps the assertion about the release rather than about the erase. The last
+// two go through `Erase` end to end, because the arm is wired now and the
+// things only the erase path can show — a change entry per released child, and
+// removal releasing nothing — are exactly the things a direct call cannot.
 
 /// Run the release against a category, outside any write of its own.
 async fn detach(world: &World, container: EntityId) -> Detachment {
@@ -1208,14 +1209,13 @@ async fn nesting_and_membership_are_different_sets() {
     );
 }
 
-/// **The one line this lane could not write.** `specific/mod.rs` is another
-/// lane's file, so the dispatch still answers `NotBuilt` for a category and the
-/// release above is unreachable from the erase path. Invert this the moment the
-/// arm calls `category::detach_contained`, and the end-to-end assertions — a
-/// change entry per released child, and removal releasing nothing — belong
-/// beside it.
+/// The dispatch reaches the release, which is the line that turns everything
+/// above from a function nobody calls into behaviour.
+///
+/// This was the inverse assertion while `specific/mod.rs` still answered
+/// `NotBuilt` — the gap recorded as a passing test so it could not be forgotten.
 #[tokio::test]
-async fn the_dispatch_still_answers_not_built() {
+async fn the_dispatch_reaches_the_release() {
     let world = World::new().await;
     let parent = category(&world, None, &[]).await;
     let child = category(&world, Some(parent), &[]).await;
@@ -1229,12 +1229,131 @@ async fn the_dispatch_still_answers_not_built() {
     let answer = specific::detach_contained(&mut ctx, parent, EntityType::Category)
         .await
         .unwrap_or_else(|_| panic!("the store was reachable"));
-    tx.rollback().await.expect("rollback");
+    tx.commit().await.expect("commit");
 
-    assert_eq!(answer, Detachment::NotBuilt);
+    assert_eq!(released_ids(&answer), vec![child]);
+    assert_eq!(parent_of(&world, child).await, None);
+}
+
+// ---------------------------------------------------------------------------
+// End to end, through the erase path
+// ---------------------------------------------------------------------------
+
+/// **A change entry per released category.** A child that silently loses its
+/// parent is a change no client ever learns about — the counter moved, so a
+/// poller holding the old one has to be told, and the entry is what tells it.
+#[tokio::test]
+async fn erasing_a_parent_category_releases_its_children_and_says_so() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+    let before = world.counter(child).await;
+
+    let ack = world.submit(&world.one, erase(&[parent])).await;
+    assert!(matches!(
+        ack.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+
+    assert_eq!(
+        parent_of(&world, child).await,
+        None,
+        "the child no longer names the tombstone"
+    );
+    assert!(
+        world.counter(child).await > before,
+        "a release is a write to the child, so its counter moves"
+    );
+    assert!(
+        world
+            .changes()
+            .await
+            .iter()
+            .any(|c| c.entity == Some(child.as_uuid()) && c.kind != "entity_gone"),
+        "the release owes the child a change entry of its own"
+    );
+}
+
+/// **A release records which part moved.** The counter advanced, and a part
+/// that moves a counter without recording itself is invisible to conflict
+/// detection — a later stale edit naming the same field would merge silently,
+/// losing the fact that the container went away underneath it.
+#[tokio::test]
+async fn a_released_child_records_the_part_that_moved() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    world.submit(&world.one, erase(&[parent])).await;
+
+    let moved: Vec<String> = sqlx::query(
+        "SELECT field_name FROM entity_part_counter WHERE entity_id = $1 AND field_name IS NOT NULL",
+    )
+    .bind(child.as_uuid())
+    .fetch_all(&world.db.pool)
+    .await
+    .expect("query")
+    .iter()
+    .map(|r| r.try_get::<String, _>("field_name").expect("field_name"))
+    .collect();
+
+    assert!(
+        moved.contains(&"specific.1".to_owned()),
+        "the released parent field is recorded as having moved: {moved:?}"
+    );
+}
+
+/// **Erasure only, never removal.** Removal is recoverable and grouped, and
+/// restoring the group is meant to put back what was there. A child detached on
+/// removal would come back parentless, so the release would quietly destroy
+/// exactly what the deletion group exists to preserve.
+#[tokio::test]
+async fn removing_a_parent_category_releases_nothing() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let child = category(&world, Some(parent), &[]).await;
+
+    world.submit(&world.one, remove(&[parent], &[])).await;
+
     assert_eq!(
         parent_of(&world, child).await,
         Some(parent.as_uuid()),
-        "so an erase still leaves a nested category pointing at a tombstone"
+        "removal is recoverable, so the nesting is kept for the restore"
+    );
+
+    // And it survives the round trip, which is the point of keeping it.
+    world.submit(&world.one, restore(parent, true)).await;
+    assert_eq!(parent_of(&world, child).await, Some(parent.as_uuid()));
+}
+
+/// The two senses stay separate through the erase path too: the nested category
+/// loses its parent and the filed note loses its filing, each by its own
+/// release, and the entity that is both loses both.
+#[tokio::test]
+async fn an_erase_releases_nesting_and_membership_without_either_doing_the_others_work() {
+    let world = World::new().await;
+    let parent = category(&world, None, &[]).await;
+    let both = world
+        .create(
+            &world.one,
+            category_content(Some(parent), &[], Vec::new()),
+            v1::EntityContent {
+                category_id: Some(parent.as_uuid().as_bytes().to_vec()),
+                ..Default::default()
+            },
+        )
+        .await;
+    let filed = note_in(&world, parent).await;
+
+    world.submit(&world.one, erase(&[parent])).await;
+
+    assert_eq!(parent_of(&world, both).await, None, "nesting released");
+    assert!(
+        world.category_position(both).await.is_none(),
+        "and membership released, by the other half"
+    );
+    assert!(
+        world.category_position(filed).await.is_none(),
+        "the note was only ever filed, and is uncategorised"
     );
 }

--- a/crates/altaird/tests/type_content_tracking.rs
+++ b/crates/altaird/tests/type_content_tracking.rs
@@ -23,7 +23,12 @@
 mod common;
 
 use altair_proto::v1;
-use altaird::store::ids::EntityId;
+use altaird::store::begin_write;
+use altaird::store::entity::EntityType;
+use altaird::store::ids::{EntityId, MemberId};
+use altaird::write::entity::Ctx;
+use altaird::write::specific::{self, Detachment};
+use chrono::Utc;
 use common::*;
 use sqlx::Row;
 use uuid::Uuid;
@@ -1577,4 +1582,256 @@ async fn a_shopping_lists_entries_are_still_refused_with_the_reason() {
             },
         )
         .await;
+}
+
+// ---------------------------------------------------------------------------
+// What an erased location lets go of
+// ---------------------------------------------------------------------------
+//
+// **Reached directly, because nothing calls it yet.** The seam belongs to this
+// wave and the call belongs in the erase path, which this lane does not own —
+// the same split `type_content.rs` used for `would_cycle` before either
+// container had a caller. When the call is wired,
+// `an_erase_does_not_yet_release_what_a_location_held` below is the test that
+// has to be inverted, and it is written to say so.
+
+/// Run the release against a location, outside any write of its own.
+async fn detach(world: &World, container: EntityId, kind: EntityType) -> Detachment {
+    let mut tx = begin_write(&world.db.pool).await.expect("a transaction");
+    let mut ctx = Ctx {
+        tx: &mut tx,
+        member: MemberId::for_test(world.one.membership_id()),
+        at: Utc::now(),
+    };
+    let answer = specific::detach_contained(&mut ctx, container, kind)
+        .await
+        .unwrap_or_else(|_| panic!("the store was reachable"));
+    tx.commit().await.expect("commit");
+    answer
+}
+
+fn released(answer: &Detachment) -> Vec<EntityId> {
+    match answer {
+        Detachment::Released(ids) => {
+            let mut ids = ids.clone();
+            ids.sort_by_key(|i| i.as_uuid());
+            ids
+        }
+        other => panic!("expected a release, got {other:?}"),
+    }
+}
+
+/// **Both kinds of thing a location holds, not just the nested one.**
+///
+/// The child-location case is the one that gets remembered, because the
+/// container and the contained are the same type. The items shelved in it are
+/// easier to forget and are the larger set, and both point back by identity.
+#[tokio::test]
+async fn an_erased_location_releases_its_children_and_its_items() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    let elsewhere = a_location(&world, &world.one, "the garage").await;
+
+    assert!(matches!(
+        nest(&world, shelf, cupboard).await.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+
+    let tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                location_id: Some(id_bytes(cupboard)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    // An item somewhere else, which must be left exactly where it is.
+    let other_tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                location_id: Some(id_bytes(elsewhere)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let answer = detach(&world, cupboard, EntityType::Location).await;
+    let mut expected = vec![shelf, tin];
+    expected.sort_by_key(|i| i.as_uuid());
+    assert_eq!(released(&answer), expected);
+
+    // The shelf is now a top-level location, which is a complete state.
+    assert_eq!(location_row(&world, shelf).await.0, None);
+    // The tin has no location, which is also complete.
+    assert_eq!(item_row(&world, tin).await.location, None);
+    // And nothing else moved.
+    assert_eq!(
+        item_row(&world, other_tin).await.location,
+        Some(elsewhere.as_uuid())
+    );
+}
+
+/// A released entity's counter advances, because losing a container is an
+/// accepted write to it. A client holding the old counter has to learn the
+/// container went away.
+#[tokio::test]
+async fn releasing_an_entity_advances_its_counter() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    nest(&world, shelf, cupboard).await;
+
+    let before = world.counter(shelf).await;
+    detach(&world, cupboard, EntityType::Location).await;
+    assert_eq!(world.counter(shelf).await, before + 1);
+}
+
+/// An empty container releases nothing, and that is an answer rather than an
+/// absence — which is why it is a different variant from the one a lane that
+/// has not built its release returns.
+#[tokio::test]
+async fn an_empty_location_releases_nothing_and_says_so() {
+    let world = World::new().await;
+    let empty = a_location(&world, &world.one, "the empty drawer").await;
+    assert_eq!(
+        detach(&world, empty, EntityType::Location).await,
+        Detachment::Released(Vec::new())
+    );
+}
+
+/// An item is a leaf, and a shopping list's entries are blocks of its own body
+/// rather than entities pointing at it.
+#[tokio::test]
+async fn a_type_that_contains_nothing_says_it_has_no_container() {
+    let world = World::new().await;
+    let tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(
+        detach(&world, tin, EntityType::Item).await,
+        Detachment::NoContainer
+    );
+
+    let list = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::ShoppingList(v1::ShoppingListContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(
+        detach(&world, list, EntityType::ShoppingList).await,
+        Detachment::NoContainer
+    );
+}
+
+/// **The distinction the third variant exists for.** Guidance's three types are
+/// containers whose release is not built, and they must not answer the way an
+/// empty container answers — otherwise wiring the call would leave every arc and
+/// quest pointing at a tombstone with the suite green.
+///
+/// **LANE: Guidance.** When that lane builds the release, this test changes to
+/// assert a `Released`, and its failure here is the reminder.
+#[tokio::test]
+async fn guidances_containers_report_their_release_is_not_built() {
+    let world = World::new().await;
+    for (kind, specific) in [
+        (
+            EntityType::Campaign,
+            v1::entity_content::Specific::Campaign(v1::CampaignContent::default()),
+        ),
+        (
+            EntityType::Arc,
+            v1::entity_content::Specific::Arc(v1::ArcContent::default()),
+        ),
+        (
+            EntityType::Quest,
+            v1::entity_content::Specific::Quest(v1::QuestContent::default()),
+        ),
+    ] {
+        let id = world
+            .create(&world.one, specific, v1::EntityContent::default())
+            .await;
+        assert_eq!(
+            detach(&world, id, kind).await,
+            Detachment::NotBuilt,
+            "{kind:?} answered as though it held nothing"
+        );
+    }
+}
+
+/// A category's release is the shared model's and Wave 2.1 already built it —
+/// the erase path calls `uncategorise_all` directly, so nothing is owed on this
+/// seam. A note and a file hold nothing at all.
+#[tokio::test]
+async fn the_types_whose_release_is_not_this_seams_owe_it_nothing() {
+    let world = World::new().await;
+    let category = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    assert_eq!(
+        detach(&world, category, EntityType::Category).await,
+        Detachment::NoContainer
+    );
+
+    let note = world.note(&world.one, "holds nothing").await;
+    assert_eq!(
+        detach(&world, note, EntityType::Note).await,
+        Detachment::NoContainer
+    );
+}
+
+/// **The seam is declared and not wired, and this says so out loud.**
+///
+/// `write/entity.rs` erases the side-table row and calls `uncategorise_all` for
+/// a category, and nothing releases a type-specific container. So an erased
+/// location still leaves its children and its items pointing at the tombstone.
+///
+/// This is a characterisation test rather than an approval: it pins the current
+/// behaviour so that wiring the call is a visible, deliberate change rather than
+/// something that quietly alters what erasure does. **When the call is wired,
+/// invert this** — the assertions become `None`.
+#[tokio::test]
+async fn an_erase_does_not_yet_release_what_a_location_held() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    nest(&world, shelf, cupboard).await;
+    let tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                location_id: Some(id_bytes(cupboard)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    world.submit(&world.one, erase(&[cupboard])).await;
+    assert_eq!(world.lifecycle(cupboard).await, "erased");
+
+    assert_eq!(
+        location_row(&world, shelf).await.0,
+        Some(cupboard.as_uuid()),
+        "wired already? invert this test — the release is no longer pending"
+    );
+    assert_eq!(
+        item_row(&world, tin).await.location,
+        Some(cupboard.as_uuid()),
+        "wired already? invert this test — the release is no longer pending"
+    );
 }

--- a/crates/altaird/tests/type_content_tracking.rs
+++ b/crates/altaird/tests/type_content_tracking.rs
@@ -536,49 +536,246 @@ async fn re_asserting_the_same_amount_moves_the_time() {
     );
 }
 
-/// The assertion time is the instance's to set, and the refusal says what a
-/// client is waiting on rather than that its message was wrong.
+/// **A client's own assertion time is honoured, not replaced.**
+///
+/// The wire carries `asserted_at` so a client can say when the person looked,
+/// and acceptance is local and durable with the outbox replaying later — so a
+/// count taken at nine and reaching the instance at six must read nine. Wave 2.1
+/// settled the same question for a create's `created_at`; substituting the
+/// instance's clock tells a client its capture landed with a time it never sent.
 #[tokio::test]
-async fn stating_an_assertion_time_is_refused_with_the_reason() {
+async fn a_client_stated_assertion_time_is_what_the_store_keeps() {
+    let world = World::new().await;
+    let stated = "2026-03-04T09:15:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                asserted_at: Some(timestamp(stated)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("3.000000000"));
+    assert_eq!(
+        row.asserted_at,
+        Some(stated),
+        "the instance substituted its own clock for a time the client sent"
+    );
+}
+
+/// And on an edit, which is the path a replayed outbox actually takes.
+#[tokio::test]
+async fn a_client_stated_assertion_time_is_honoured_on_an_edit_too() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(1, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+    let stated = "2026-03-04T09:15:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    asserted_amount: Some(decimal(7, 0)),
+                    asserted_at: Some(timestamp(stated)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("7.000000000"));
+    assert_eq!(row.asserted_at, Some(stated));
+}
+
+/// **Stating the time alone still works, when there is an amount for it to
+/// belong to.** *I looked again, still three* — the count is unchanged and only
+/// the freshness moved.
+#[tokio::test]
+async fn an_assertion_time_may_be_restated_alone_when_an_amount_is_already_there() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+    let looked_again = "2026-05-01T18:00:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    asserted_at: Some(timestamp(looked_again)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.asserted_at, Some(looked_again));
+    assert_eq!(
+        row.amount.as_deref(),
+        Some("3.000000000"),
+        "restating the time must not disturb the count"
+    );
+}
+
+/// **The refusal that remains, and it is about the row rather than the field.**
+///
+/// The table's check refuses a time with no amount beside it. All three of these
+/// name that row: a time on an item that holds no amount, a time in the same
+/// message that clears the amount, and clearing the time while an amount stands.
+/// Each is malformed rather than a constraint violation that takes the whole
+/// transaction down with a message nobody can act on.
+#[tokio::test]
+async fn an_assertion_time_with_no_amount_to_belong_to_is_malformed() {
     let world = World::new().await;
     let at = timestamp(chrono::Utc::now());
 
-    // Alone, and alongside the amount it belongs to. Both are the same refusal.
-    for content in [
-        v1::ItemContent {
-            asserted_at: Some(at),
-            ..Default::default()
-        },
-        v1::ItemContent {
-            asserted_amount: Some(decimal(3, 0)),
-            asserted_at: Some(at),
-            ..Default::default()
-        },
-        v1::ItemContent {
-            cleared: vec![3],
-            ..Default::default()
-        },
-    ] {
-        let ack = world
-            .submit(
-                &world.one,
-                create_entity(
-                    Uuid::new_v4(),
-                    v1::EntityContent {
-                        specific: Some(item(content)),
+    // On a fresh item that states no amount.
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(item(v1::ItemContent {
+                        asserted_at: Some(at),
                         ..Default::default()
-                    },
-                ),
-            )
-            .await;
-        let r = refused(&ack);
-        assert_eq!(r.reason, v1::RefusalReason::Malformed as i32, "{r:?}");
-        assert!(
-            r.detail.contains("the amount's own") && r.detail.contains("not served yet"),
-            "{}",
-            r.detail
-        );
-    }
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let r = refused(&ack);
+    assert_eq!(r.reason, v1::RefusalReason::Malformed as i32, "{r:?}");
+    assert!(r.detail.contains("belongs to an amount"), "{}", r.detail);
+
+    // Clearing the amount and stating a time in one message.
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(item(v1::ItemContent {
+                        asserted_at: Some(at),
+                        cleared: vec![1],
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert_eq!(
+        refused(&ack).reason,
+        v1::RefusalReason::Malformed as i32,
+        "clearing the amount while stating a time was accepted"
+    );
+
+    // And clearing the time out from under an amount that stands.
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    cleared: vec![3],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+    // The refusal left the row alone.
+    assert!(item_row(&world, id).await.asserted_at.is_some());
+}
+
+/// **The stated time reaches the store in one statement with the amount, and
+/// records its movement exactly once.**
+///
+/// The client states field 3 and the instance also moves it as the amount's
+/// companion, so the same part is touched twice in one write. Provenance upserts
+/// and `detect` drops a comparison where arriving equals stored, so the result
+/// must be one counter row and no phantom conflict — this is the test that says
+/// the redundancy is harmless rather than assuming it.
+#[tokio::test]
+async fn a_stated_time_and_its_companion_record_one_movement_and_no_conflict() {
+    let world = World::new().await;
+    let stated = "2026-03-04T09:15:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                asserted_at: Some(timestamp(stated)),
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+    let moved = moved_parts(&world, id).await;
+    let times: Vec<_> = moved.iter().filter(|(n, _)| n == "specific.3").collect();
+    assert_eq!(
+        times.len(),
+        1,
+        "the assertion time recorded twice: {moved:?}"
+    );
+    assert!(world.conflicts(id).await.is_empty());
 }
 
 /// Both halves of the pair record their movement.
@@ -1679,6 +1876,11 @@ async fn an_erased_location_releases_its_children_and_its_items() {
 /// A released entity's counter advances, because losing a container is an
 /// accepted write to it. A client holding the old counter has to learn the
 /// container went away.
+///
+/// **The bump is `store::entity::detached_from_container`'s, not the seam's** —
+/// it happens on the same statement that reads the audience a change entry
+/// needs, and that statement may only live in the store layer. So this goes
+/// through the erase path rather than calling the seam directly.
 #[tokio::test]
 async fn releasing_an_entity_advances_its_counter() {
     let world = World::new().await;
@@ -1687,7 +1889,7 @@ async fn releasing_an_entity_advances_its_counter() {
     nest(&world, shelf, cupboard).await;
 
     let before = world.counter(shelf).await;
-    detach(&world, cupboard, EntityType::Location).await;
+    world.submit(&world.one, erase(&[cupboard])).await;
     assert_eq!(world.counter(shelf).await, before + 1);
 }
 
@@ -1794,18 +1996,14 @@ async fn the_types_whose_release_is_not_this_seams_owe_it_nothing() {
     );
 }
 
-/// **The seam is declared and not wired, and this says so out loud.**
+/// **Wired.** An erased location releases what it held, and the change sequence
+/// learns about each one.
 ///
-/// `write/entity.rs` erases the side-table row and calls `uncategorise_all` for
-/// a category, and nothing releases a type-specific container. So an erased
-/// location still leaves its children and its items pointing at the tombstone.
-///
-/// This is a characterisation test rather than an approval: it pins the current
-/// behaviour so that wiring the call is a visible, deliberate change rather than
-/// something that quietly alters what erasure does. **When the call is wired,
-/// invert this** — the assertions become `None`.
+/// This is the test that was a characterisation of the unwired state one commit
+/// ago; the assertions inverted when the call landed, which is exactly what it
+/// was written to make visible.
 #[tokio::test]
-async fn an_erase_does_not_yet_release_what_a_location_held() {
+async fn an_erase_releases_what_a_location_held_and_says_so_in_the_change_sequence() {
     let world = World::new().await;
     let cupboard = a_location(&world, &world.one, "the cupboard").await;
     let shelf = a_location(&world, &world.one, "the shelf").await;
@@ -1824,14 +2022,135 @@ async fn an_erase_does_not_yet_release_what_a_location_held() {
     world.submit(&world.one, erase(&[cupboard])).await;
     assert_eq!(world.lifecycle(cupboard).await, "erased");
 
+    // Neither points at the tombstone. Both states are complete rather than
+    // damaged: a top-level location, and an item with no location.
+    assert_eq!(location_row(&world, shelf).await.0, None);
+    assert_eq!(item_row(&world, tin).await.location, None);
+
+    // **A change nobody learns about is the hole this closes.** Each released
+    // entity gets an entry of its own, the way an uncategorised one does.
+    let changes = world.changes().await;
+    for released in [shelf, tin] {
+        assert!(
+            changes
+                .iter()
+                .any(|c| c.entity == Some(released.as_uuid()) && c.kind == "entity_written"),
+            "{released:?} lost its container with no change entry"
+        );
+    }
+}
+
+/// An erased location that held nothing releases nothing, and the erase is
+/// unaffected.
+#[tokio::test]
+async fn erasing_an_empty_location_releases_nothing() {
+    let world = World::new().await;
+    let empty = a_location(&world, &world.one, "the empty drawer").await;
+    world.submit(&world.one, erase(&[empty])).await;
+    assert_eq!(world.lifecycle(empty).await, "erased");
+}
+
+/// **The release reaches entities the erasing member cannot see.**
+///
+/// Deliberately unscoped, for the reason `uncategorise_all` gives: the container
+/// is gone for everybody, so leaving the rows one member cannot see still
+/// pointing at it would keep a dangling reference alive precisely where nobody
+/// can find it.
+#[tokio::test]
+async fn the_release_is_unscoped_because_the_container_is_gone_for_everybody() {
+    let world = World::new().await;
+    // One owns the cupboard and can erase it; two shelves inside it are two's
+    // own and private, so one cannot see them.
+    let cupboard = a_location(&world, &world.one, "the shared cupboard").await;
+    let theirs = world
+        .create(
+            &world.two,
+            location(v1::LocationContent::default()),
+            v1::EntityContent {
+                title: Some("their shelf".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    // Placed by its own member, so the nesting is legitimate.
+    sqlx::query("UPDATE location SET parent_location_id = $2 WHERE entity_id = $1")
+        .bind(theirs.as_uuid())
+        .bind(cupboard.as_uuid())
+        .execute(&world.db.pool)
+        .await
+        .expect("nest");
+
+    world.submit(&world.one, erase(&[cupboard])).await;
+
     assert_eq!(
-        location_row(&world, shelf).await.0,
-        Some(cupboard.as_uuid()),
-        "wired already? invert this test — the release is no longer pending"
+        location_row(&world, theirs).await.0,
+        None,
+        "a child the erasing member cannot see kept pointing at the tombstone"
     );
+}
+
+/// **Where the companion's value actually matters: the conflict comparison.**
+///
+/// A client states the time, and the instance also moves that part as the
+/// amount's companion. Both sides of the conflict render through the same code,
+/// so the companion must carry *the client's* instant — if it carried the
+/// instance's clock instead, this write would touch the part twice with two
+/// different arriving values and retain a value the client never sent.
+///
+/// Two members, one stale base, both stating their own times.
+#[tokio::test]
+async fn a_conflict_on_a_client_stated_time_retains_the_time_the_client_sent() {
+    let world = World::new().await;
+    let id = shared_item(
+        &world,
+        v1::ItemContent {
+            asserted_amount: Some(decimal(1, 0)),
+            ..Default::default()
+        },
+    )
+    .await;
+    let base = world.counter(id).await;
+    let theirs = "2026-03-04T09:00:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+    let mine = "2026-03-05T17:30:00Z"
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .unwrap();
+
+    for (member, amount, at) in [
+        (&world.one, decimal(2, 0), theirs),
+        (&world.two, decimal(5, 0), mine),
+    ] {
+        world
+            .submit(
+                member,
+                edit_specific(
+                    id,
+                    base,
+                    item(v1::ItemContent {
+                        asserted_amount: Some(amount),
+                        asserted_at: Some(timestamp(at)),
+                        ..Default::default()
+                    }),
+                ),
+            )
+            .await;
+    }
+
+    let conflicts = world.conflicts(id).await;
+    let time = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.3"))
+        .expect("two members asserted at different times from one base");
+    // Exactly one row for this part, and both sides are times a client sent.
     assert_eq!(
-        item_row(&world, tin).await.location,
-        Some(cupboard.as_uuid()),
-        "wired already? invert this test — the release is no longer pending"
+        conflicts
+            .iter()
+            .filter(|c| c.field.as_deref() == Some("specific.3"))
+            .count(),
+        1
     );
+    assert_eq!(time.mine.as_deref(), Some(mine.to_rfc3339().as_str()));
+    assert_eq!(time.theirs.as_deref(), Some(theirs.to_rfc3339().as_str()));
+    assert_eq!(item_row(&world, id).await.asserted_at, Some(mine));
 }

--- a/crates/altaird/tests/type_content_tracking.rs
+++ b/crates/altaird/tests/type_content_tracking.rs
@@ -1945,39 +1945,98 @@ async fn a_type_that_contains_nothing_says_it_has_no_container() {
     );
 }
 
-/// **The distinction the third variant exists for.** Guidance's three types are
-/// containers whose release is not built, and they must not answer the way an
-/// empty container answers — otherwise wiring the call would leave every arc and
-/// quest pointing at a tombstone with the suite green.
+/// **Every container is built, and this is what says so.**
 ///
-/// **LANE: Guidance.** When that lane builds the release, this test changes to
-/// assert a `Released`, and its failure here is the reminder.
+/// This replaces two tests that asserted Guidance's types and a category's
+/// nesting each answered `NotBuilt`. They were right while those releases were
+/// owed and they are wrong now, and the honest replacement is not to delete the
+/// idea but to invert it: **no type may report an unbuilt release.**
+///
+/// # Why the variant stays, when nothing answers it
+///
+/// `NotBuilt` never changed behaviour — the erase path steps over it exactly as
+/// it steps over `NoContainer`, and it always did. Its whole value was being
+/// *visible*: a container whose release was owed said so, in a form a test could
+/// assert and a comment could not drift away from. It caught two gaps that way,
+/// both of them this lane's own.
+///
+/// With every container built it has no inhabitant, and an uninhabited variant
+/// is the kind of thing a later reader removes as obviously dead. So this test
+/// is what keeps it alive and honest: it fails the moment a type starts
+/// answering `NotBuilt` again, which is exactly when somebody has added a
+/// container and not yet released it. That is a fine state to be in while
+/// building — the point is that it must be **stated here deliberately** rather
+/// than discovered at a merge.
+///
+/// # What this does not cover
+///
+/// The list is written out. A new `EntityType` must gain an arm in
+/// `detach_contained` — the match is exhaustive, so the compiler forces that —
+/// but it will not appear here until someone adds it. That is a real gap and it
+/// is smaller than the one it replaces.
 #[tokio::test]
-async fn guidances_containers_report_their_release_is_not_built() {
+async fn no_type_reports_an_unbuilt_release() {
     let world = World::new().await;
-    for (kind, specific) in [
-        (
-            EntityType::Campaign,
-            v1::entity_content::Specific::Campaign(v1::CampaignContent::default()),
-        ),
-        (
-            EntityType::Arc,
-            v1::entity_content::Specific::Arc(v1::ArcContent::default()),
-        ),
-        (
-            EntityType::Quest,
-            v1::entity_content::Specific::Quest(v1::QuestContent::default()),
-        ),
+    // `detach_contained` dispatches on the type rather than reading the entity,
+    // so an identity that names nothing is enough to ask every arm the question.
+    let nobody = EntityId::from_uuid(Uuid::new_v4());
+    for kind in [
+        EntityType::Campaign,
+        EntityType::Arc,
+        EntityType::Quest,
+        EntityType::Note,
+        EntityType::File,
+        EntityType::Item,
+        EntityType::Location,
+        EntityType::ShoppingList,
+        EntityType::Category,
+        EntityType::Routine,
+        EntityType::FocusSession,
+        EntityType::CheckIn,
     ] {
-        let id = world
-            .create(&world.one, specific, v1::EntityContent::default())
-            .await;
-        assert_eq!(
-            detach(&world, id, kind).await,
+        assert_ne!(
+            detach(&world, nobody, kind).await,
             Detachment::NotBuilt,
-            "{kind:?} answered as though it held nothing"
+            "{kind:?} reports its release is not built. If that is true, it is a \
+             container whose contents will point at a tombstone — say so here \
+             deliberately rather than letting a merge find it."
         );
     }
+}
+
+/// Guidance's ladder releases what it held. The positive half of what the
+/// `NotBuilt` assertion used to stand in for.
+#[tokio::test]
+async fn an_erased_campaign_releases_the_arc_beneath_it() {
+    let world = World::new().await;
+    let campaign = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Campaign(v1::CampaignContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let arc = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Arc(v1::ArcContent {
+                campaign_id: Some(id_bytes(campaign)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    world.submit(&world.one, erase(&[campaign])).await;
+
+    let parent: Option<Uuid> = sqlx::query("SELECT campaign_id AS c FROM arc WHERE entity_id = $1")
+        .bind(arc.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("arc row")
+        .try_get("c")
+        .expect("campaign_id");
+    assert_eq!(parent, None, "the arc still points at its erased campaign");
 }
 
 /// A note and a file hold nothing at all, which is an answer.
@@ -1991,28 +2050,37 @@ async fn the_types_that_hold_nothing_say_they_have_no_container() {
     );
 }
 
-/// **A category is a container twice over and only one half is built.**
+/// A category is a container in two senses and **both are now released**:
+/// `uncategorise_all` for its membership, and the type-content seam for its
+/// nesting.
 ///
-/// `uncategorise_all` releases its *membership* — the entities filed in it — and
-/// Wave 2.1 built that. Its *nesting* is released by nobody, so erasing a parent
-/// category still leaves its children pointing at a tombstone. Answering
-/// `NotBuilt` is what stops that being invisible.
-///
-/// **LANE: Knowledge and categories.** `category.rs` is not this lane's;
-/// this asserts the gap is reported rather than closing it.
+/// This asserts the second, which was the half nothing handled for a wave.
 #[tokio::test]
-async fn a_categorys_nesting_reports_its_release_is_not_built() {
+async fn a_nested_category_is_released_when_its_parent_is_erased() {
     let world = World::new().await;
-    let category = world
+    let outer = world
         .create(
             &world.one,
             v1::entity_content::Specific::Category(v1::CategoryContent::default()),
             v1::EntityContent::default(),
         )
         .await;
+    let inner = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent {
+                parent_category_id: Some(id_bytes(outer)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let released = released(&detach(&world, outer, EntityType::Category).await);
     assert_eq!(
-        detach(&world, category, EntityType::Category).await,
-        Detachment::NotBuilt
+        released,
+        vec![inner],
+        "the nested category was not released"
     );
 }
 
@@ -2433,24 +2501,21 @@ async fn a_no_op_write_still_advances_the_entitys_counter() {
     assert_eq!(world.counter(id).await, before + 1);
 }
 
-/// **What the unbuilt half actually leaves behind**, pinned so the fix is
-/// visible when it lands.
+/// **Inverted, as its own message said to be.**
 ///
-/// Erase category A with category B nested inside it. A's `category` row goes,
-/// A's `entity` row survives as a tombstone so the composite foreign key stays
-/// satisfied, and B's `parent_category_id` names A for ever. No client can
-/// repair it: re-parenting B means naming A, and `available_for_write` on an
-/// erased A refuses.
+/// This was a characterisation test. It pinned what an erased parent category
+/// left behind — the child's `parent_category_id` naming a tombstone for ever,
+/// unrepairable because re-parenting means naming the erased one and
+/// `available_for_write` refuses it, and silent because `would_cycle` reads the
+/// deleted row, finds none and returns false. A coherence problem is the quieter
+/// kind, which is why it survived a wave.
 ///
-/// It is not a hang — `would_cycle` reads A's deleted row, finds none, and
-/// returns false — which is why it went unnoticed. A coherence problem is the
-/// quieter kind.
-///
-/// **LANE: Knowledge and categories.** This is a characterisation test, not an
-/// approval. When that lane implements the release, **invert this** — the
-/// assertion becomes `None`, exactly as the location one did.
+/// It failed the moment the categories lane wired the release, with the message
+/// it was written to carry. **The assertion is now `None`** and nothing else
+/// about the test changed, which is the whole point of writing the pin rather
+/// than a comment: the fix had to walk past it.
 #[tokio::test]
-async fn erasing_a_parent_category_still_strands_its_nested_children() {
+async fn erasing_a_parent_category_releases_its_nested_children() {
     let world = World::new().await;
     let outer = world
         .create(
@@ -2479,7 +2544,7 @@ async fn erasing_a_parent_category_still_strands_its_nested_children() {
     world.submit(&world.one, erase(&[outer])).await;
     assert_eq!(world.lifecycle(outer).await, "erased");
 
-    let stranded: Option<Uuid> =
+    let parent: Option<Uuid> =
         sqlx::query("SELECT parent_category_id AS p FROM category WHERE entity_id = $1")
             .bind(inner.as_uuid())
             .fetch_one(&world.db.pool)
@@ -2488,8 +2553,7 @@ async fn erasing_a_parent_category_still_strands_its_nested_children() {
             .try_get("p")
             .expect("parent");
     assert_eq!(
-        stranded,
-        Some(outer.as_uuid()),
-        "wired already? invert this test — nested categories are released now"
+        parent, None,
+        "the nested category still points at its erased parent"
     );
 }

--- a/crates/altaird/tests/type_content_tracking.rs
+++ b/crates/altaird/tests/type_content_tracking.rs
@@ -1801,9 +1801,15 @@ async fn detach(world: &World, container: EntityId, kind: EntityType) -> Detachm
         member: MemberId::for_test(world.one.membership_id()),
         at: Utc::now(),
     };
+    // Either a store fault or a refusal. A release refuses when a column it
+    // clears is declared by no field of the type, which is a mispairing rather
+    // than anything a client sent — so the message must not claim the store
+    // failed.
     let answer = specific::detach_contained(&mut ctx, container, kind)
         .await
-        .unwrap_or_else(|_| panic!("the store was reachable"));
+        .unwrap_or_else(|_| {
+            panic!("the release of a {kind:?} neither answered nor reached the store")
+        });
     tx.commit().await.expect("commit");
     answer
 }

--- a/crates/altaird/tests/type_content_tracking.rs
+++ b/crates/altaird/tests/type_content_tracking.rs
@@ -1,0 +1,1580 @@
+//! Tracking's type content: an item, a location, and what a template does not
+//! own.
+//!
+//! **LANE: Tracking.** The spine's own suite is `type_content.rs` and proves a
+//! type-specific part reaches every mechanism the shared model reaches. This one
+//! proves the three things about this domain that a plausible implementation
+//! gets wrong:
+//!
+//! - **An amount and the time it was asserted move in one statement.** The
+//!   table refuses the state in between, so a sequence of two writes fails
+//!   whichever order it is in.
+//! - **The assertion time is the amount's own.** An unrelated edit must not
+//!   advance it, or a count from March looks fresh — which the PRD says is worse
+//!   than showing nothing.
+//! - **A loop in nested locations is refused where the schema cannot see it.**
+//!   Self-reference passes for free and proves nothing; two hops and three are
+//!   the cases that matter.
+//!
+//! And two the scope decides rather than this lane: property values survive a
+//! template being detached, keyed by the names they had, and a shopping list's
+//! entries are still refused with the reason they are deferred.
+
+mod common;
+
+use altair_proto::v1;
+use altaird::store::ids::EntityId;
+use common::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Building the two messages
+// ---------------------------------------------------------------------------
+
+fn item(c: v1::ItemContent) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Item(c)
+}
+
+fn location(c: v1::LocationContent) -> v1::entity_content::Specific {
+    v1::entity_content::Specific::Location(c)
+}
+
+fn decimal(units: i64, nanos: i32) -> v1::Decimal {
+    v1::Decimal { units, nanos }
+}
+
+fn property(name: &str, value: &str) -> v1::PropertyValue {
+    v1::PropertyValue {
+        name: name.into(),
+        value: value.into(),
+    }
+}
+
+fn id_bytes(id: EntityId) -> Vec<u8> {
+    id.as_uuid().as_bytes().to_vec()
+}
+
+/// An edit carrying one type message and nothing else.
+fn edit_specific(
+    id: EntityId,
+    base: i64,
+    specific: v1::entity_content::Specific,
+) -> v1::intent::Action {
+    edit_entity(
+        id,
+        base as u64,
+        v1::EntityContent {
+            specific: Some(specific),
+            ..Default::default()
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Reading the store back
+// ---------------------------------------------------------------------------
+
+/// One item row, as text, so a numeric keeps the precision it was written with.
+struct ItemRow {
+    amount: Option<String>,
+    unit: Option<String>,
+    asserted_at: Option<chrono::DateTime<chrono::Utc>>,
+    location: Option<Uuid>,
+    template: Option<Uuid>,
+}
+
+async fn item_row(world: &World, id: EntityId) -> ItemRow {
+    let r = sqlx::query(
+        "SELECT asserted_amount::text AS amount, unit, asserted_at, location_id, template_id \
+         FROM item WHERE entity_id = $1",
+    )
+    .bind(id.as_uuid())
+    .fetch_one(&world.db.pool)
+    .await
+    .expect("item row");
+    ItemRow {
+        amount: r.try_get("amount").unwrap(),
+        unit: r.try_get("unit").unwrap(),
+        asserted_at: r.try_get("asserted_at").unwrap(),
+        location: r.try_get("location_id").unwrap(),
+        template: r.try_get("template_id").unwrap(),
+    }
+}
+
+async fn location_row(world: &World, id: EntityId) -> (Option<Uuid>, Option<Uuid>) {
+    let r = sqlx::query(
+        "SELECT parent_location_id AS p, template_id AS t FROM location WHERE entity_id = $1",
+    )
+    .bind(id.as_uuid())
+    .fetch_one(&world.db.pool)
+    .await
+    .expect("location row");
+    (r.try_get("p").unwrap(), r.try_get("t").unwrap())
+}
+
+/// Every property value on an entity, by name.
+async fn properties_of(world: &World, id: EntityId) -> Vec<(String, Option<String>)> {
+    sqlx::query("SELECT name, value FROM entity_property_value WHERE entity_id = $1 ORDER BY name")
+        .bind(id.as_uuid())
+        .fetch_all(&world.db.pool)
+        .await
+        .expect("property values")
+        .iter()
+        .map(|r| (r.try_get("name").unwrap(), r.try_get("value").unwrap()))
+        .collect()
+}
+
+async fn search_text(world: &World, id: EntityId) -> String {
+    sqlx::query("SELECT search_text AS s FROM entity WHERE id = $1")
+        .bind(id.as_uuid())
+        .fetch_one(&world.db.pool)
+        .await
+        .expect("entity")
+        .try_get("s")
+        .expect("search_text")
+}
+
+/// The counters `entity_part_counter` recorded, by part name.
+async fn moved_parts(world: &World, id: EntityId) -> Vec<(String, i64)> {
+    sqlx::query(
+        "SELECT field_name, counter FROM entity_part_counter \
+         WHERE entity_id = $1 AND field_name IS NOT NULL ORDER BY field_name",
+    )
+    .bind(id.as_uuid())
+    .fetch_all(&world.db.pool)
+    .await
+    .expect("part counters")
+    .iter()
+    .map(|r| {
+        (
+            r.try_get("field_name").unwrap(),
+            r.try_get("counter").unwrap(),
+        )
+    })
+    .collect()
+}
+
+/// A template with the property names it contributes.
+///
+/// Declared by hand: nothing on the wire creates a template yet, and a template
+/// contributes names rather than content, so what matters below is only that the
+/// row exists to be followed and detached.
+async fn declare_template(world: &World, name: &str, properties: &[(&str, &str)]) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO template (id, name, created_at) VALUES ($1, $2, now())")
+        .bind(id)
+        .bind(name)
+        .execute(&world.db.pool)
+        .await
+        .expect("template");
+    for (ordinal, (property, kind)) in properties.iter().enumerate() {
+        sqlx::query(
+            "INSERT INTO template_property (template_id, name, kind, ordinal) \
+             VALUES ($1, $2, $3::property_kind, $4)",
+        )
+        .bind(id)
+        .bind(property)
+        .bind(kind)
+        .bind(ordinal as i32)
+        .execute(&world.db.pool)
+        .await
+        .expect("template property");
+    }
+    id
+}
+
+async fn a_location(world: &World, member: &altaird::auth::Member, title: &str) -> EntityId {
+    world
+        .create(
+            member,
+            location(v1::LocationContent::default()),
+            v1::EntityContent {
+                title: Some(title.into()),
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// An item's fields, there and back
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn every_item_field_reaches_the_store_on_creation() {
+    let world = World::new().await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    let template = declare_template(&world, "filament", &[("diameter", "text")]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 250_000_000)),
+                unit: Some("rolls".into()),
+                location_id: Some(id_bytes(shelf)),
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("diameter", "1.75mm"), property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("black filament".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("3.250000000"));
+    assert_eq!(row.unit.as_deref(), Some("rolls"));
+    assert_eq!(row.location, Some(shelf.as_uuid()));
+    assert_eq!(row.template, Some(template));
+    assert!(row.asserted_at.is_some());
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![
+            ("diameter".to_owned(), Some("1.75mm".to_owned())),
+            ("material".to_owned(), Some("PLA".to_owned())),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn every_item_field_moves_on_an_edit() {
+    let world = World::new().await;
+    let first = a_location(&world, &world.one, "the shelf").await;
+    let second = a_location(&world, &world.one, "the garage").await;
+    let template = declare_template(&world, "filament", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(1, 0)),
+                unit: Some("roll".into()),
+                location_id: Some(id_bytes(first)),
+                property_values: vec![property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    asserted_amount: Some(decimal(12, 500_000_000)),
+                    unit: Some("rolls".into()),
+                    location_id: Some(id_bytes(second)),
+                    template_id: Some(template.as_bytes().to_vec()),
+                    property_values: vec![property("material", "PETG")],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("12.500000000"));
+    assert_eq!(row.unit.as_deref(), Some("rolls"));
+    assert_eq!(row.location, Some(second.as_uuid()));
+    assert_eq!(row.template, Some(template));
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![("material".to_owned(), Some("PETG".to_owned()))]
+    );
+}
+
+/// Clearing empties every one of them, and the store holds nothing rather than
+/// an empty string.
+#[tokio::test]
+async fn clearing_every_item_field_empties_it() {
+    let world = World::new().await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    let template = declare_template(&world, "filament", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                unit: Some("rolls".into()),
+                location_id: Some(id_bytes(shelf)),
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    // Every field but the assertion time, which is not one a client states.
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    cleared: vec![1, 2, 4, 5, 6],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount, None);
+    assert_eq!(row.unit, None);
+    assert_eq!(row.location, None);
+    assert_eq!(row.template, None);
+    assert_eq!(row.asserted_at, None, "the time goes with the amount");
+    assert!(properties_of(&world, id).await.is_empty());
+}
+
+/// **No required fields.** An item with a name and nothing else is a complete
+/// item, and so is one with no name at all.
+#[tokio::test]
+async fn an_item_with_a_name_and_nothing_else_is_complete() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent::default()),
+            v1::EntityContent {
+                title: Some("the good screwdriver".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount, None);
+    assert_eq!(row.asserted_at, None);
+    assert_eq!(row.unit, None);
+    assert_eq!(row.location, None);
+}
+
+// ---------------------------------------------------------------------------
+// The amount and its own timestamp
+// ---------------------------------------------------------------------------
+
+/// **The pair, written in one statement.**
+///
+/// `CHECK ((asserted_amount IS NULL) = (asserted_at IS NULL))` refuses the state
+/// in between, so an implementation that wrote the two columns in sequence would
+/// fail whichever order it chose — the amount alone leaves the time null, and
+/// the time alone leaves the amount null. Both of these submissions would have
+/// been a store fault rather than an acknowledgement, so the assertion is that
+/// they landed at all as much as it is the values.
+#[tokio::test]
+async fn an_amount_and_its_time_are_written_together_or_the_table_refuses_it() {
+    let world = World::new().await;
+
+    // Setting: both arrive.
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("3.000000000"));
+    assert!(row.asserted_at.is_some());
+
+    // Clearing: both leave.
+    let base = world.counter(id).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    cleared: vec![1],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount, None);
+    assert_eq!(row.asserted_at, None);
+}
+
+/// **The requirement most easily broken by a plausible implementation.**
+///
+/// The assertion time is the amount's own and not a general modified time.
+/// Renaming an item or correcting its notes does not confirm what is on the
+/// shelf, and a timestamp that moves when those happen makes a stale count look
+/// fresh — which the PRD calls worse than showing nothing.
+#[tokio::test]
+async fn an_unrelated_edit_leaves_the_assertion_time_alone() {
+    let world = World::new().await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    let template = declare_template(&world, "filament", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let asserted = item_row(&world, id).await.asserted_at.expect("a time");
+
+    // Everything an item has that is not its amount, one edit at a time.
+    let unrelated = [
+        v1::EntityContent {
+            title: Some("black filament".into()),
+            ..Default::default()
+        },
+        v1::EntityContent {
+            specific: Some(item(v1::ItemContent {
+                unit: Some("rolls".into()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+        v1::EntityContent {
+            specific: Some(item(v1::ItemContent {
+                location_id: Some(id_bytes(shelf)),
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+        v1::EntityContent {
+            specific: Some(item(v1::ItemContent {
+                template_id: Some(template.as_bytes().to_vec()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+        v1::EntityContent {
+            specific: Some(item(v1::ItemContent {
+                property_values: vec![property("material", "PLA")],
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+    ];
+
+    for content in unrelated {
+        let base = world.counter(id).await;
+        world
+            .submit(&world.one, edit_entity(id, base as u64, content))
+            .await;
+        assert_eq!(
+            item_row(&world, id).await.asserted_at,
+            Some(asserted),
+            "an edit that is not the amount moved the time the amount was asserted"
+        );
+    }
+
+    assert_eq!(
+        item_row(&world, id).await.amount.as_deref(),
+        Some("3.000000000"),
+        "and the amount itself is untouched"
+    );
+}
+
+/// The other half of the same rule. *I looked again, still three* is a real act,
+/// and it is how the freshness of a count is recorded.
+#[tokio::test]
+async fn re_asserting_the_same_amount_moves_the_time() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let first = item_row(&world, id).await.asserted_at.expect("a time");
+
+    let base = world.counter(id).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    asserted_amount: Some(decimal(3, 0)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let row = item_row(&world, id).await;
+    assert_eq!(row.amount.as_deref(), Some("3.000000000"));
+    assert!(
+        row.asserted_at.expect("a time") > first,
+        "counting again is an assertion, even when the answer is the same"
+    );
+}
+
+/// The assertion time is the instance's to set, and the refusal says what a
+/// client is waiting on rather than that its message was wrong.
+#[tokio::test]
+async fn stating_an_assertion_time_is_refused_with_the_reason() {
+    let world = World::new().await;
+    let at = timestamp(chrono::Utc::now());
+
+    // Alone, and alongside the amount it belongs to. Both are the same refusal.
+    for content in [
+        v1::ItemContent {
+            asserted_at: Some(at),
+            ..Default::default()
+        },
+        v1::ItemContent {
+            asserted_amount: Some(decimal(3, 0)),
+            asserted_at: Some(at),
+            ..Default::default()
+        },
+        v1::ItemContent {
+            cleared: vec![3],
+            ..Default::default()
+        },
+    ] {
+        let ack = world
+            .submit(
+                &world.one,
+                create_entity(
+                    Uuid::new_v4(),
+                    v1::EntityContent {
+                        specific: Some(item(content)),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        let r = refused(&ack);
+        assert_eq!(r.reason, v1::RefusalReason::Malformed as i32, "{r:?}");
+        assert!(
+            r.detail.contains("the amount's own") && r.detail.contains("not served yet"),
+            "{}",
+            r.detail
+        );
+    }
+}
+
+/// Both halves of the pair record their movement.
+///
+/// `entity_part_counter` is per part and conflict detection asks which parts
+/// moved between two counter values. A part that does not record its movement is
+/// invisible to that, and the failure is silent.
+#[tokio::test]
+async fn the_amount_and_its_time_each_record_the_counter_they_moved_at() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                unit: Some("tins".into()),
+                property_values: vec![property("brand", "Heinz")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let moved = moved_parts(&world, id).await;
+    for part in ["specific.1", "specific.2", "specific.3", "specific.6"] {
+        assert!(
+            moved
+                .iter()
+                .any(|(name, counter)| name == part && *counter == 1),
+            "{part} recorded no movement, so nothing can conflict on it: {moved:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The number a household's stock is carried in
+// ---------------------------------------------------------------------------
+
+/// Binary floating point is the wrong place for this, so nothing rounds on the
+/// way through the store either.
+#[tokio::test]
+async fn an_amount_keeps_its_precision_through_the_store() {
+    let world = World::new().await;
+    for (units, nanos, text) in [
+        (0_i64, 1_i32, "0.000000001"),
+        (1, 750_000_000, "1.750000000"),
+        (999_999_999, 999_999_999, "999999999.999999999"),
+        (0, 0, "0.000000000"),
+    ] {
+        let id = world
+            .create(
+                &world.one,
+                item(v1::ItemContent {
+                    asserted_amount: Some(decimal(units, nanos)),
+                    ..Default::default()
+                }),
+                v1::EntityContent::default(),
+            )
+            .await;
+        assert_eq!(item_row(&world, id).await.amount.as_deref(), Some(text));
+    }
+}
+
+/// **Not clamped.** A garbled number is a message that cannot be read, and
+/// absorbing one would store something the client never sent — the same failure
+/// as the base counter that was clamped and silently skipped conflict detection.
+#[tokio::test]
+async fn an_amount_out_of_range_is_refused_rather_than_clamped() {
+    let world = World::new().await;
+    for (units, nanos) in [(0_i64, 1_000_000_000_i32), (1, -1), (-1, 1)] {
+        let ack = world
+            .submit(
+                &world.one,
+                create_entity(
+                    Uuid::new_v4(),
+                    v1::EntityContent {
+                        specific: Some(item(v1::ItemContent {
+                            asserted_amount: Some(decimal(units, nanos)),
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        let r = refused(&ack);
+        assert_eq!(
+            r.reason,
+            v1::RefusalReason::Malformed as i32,
+            "{units} units and {nanos} nanos was absorbed: {r:?}"
+        );
+        assert!(r.detail.contains("decimal"), "{}", r.detail);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// An item's location is a typed foreign key
+// ---------------------------------------------------------------------------
+
+/// The column is `FOREIGN KEY (location_id, location_type) REFERENCES entity`,
+/// so pointing at something that is not a location is a refusal rather than a
+/// cast — and rather than a constraint violation taking the transaction down.
+#[tokio::test]
+async fn an_items_location_must_actually_be_a_location() {
+    let world = World::new().await;
+    let note = world.note(&world.one, "not a place").await;
+
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(item(v1::ItemContent {
+                        location_id: Some(id_bytes(note)),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+}
+
+/// **Refusal on audience and refusal on nonexistence are the same nothing.** A
+/// location the member cannot see, one that does not exist, and one that is not
+/// a location all answer identically — reason and detail alike.
+#[tokio::test]
+async fn a_location_that_is_hidden_and_one_that_does_not_exist_are_indistinguishable() {
+    let world = World::new().await;
+    // Private to two, so one cannot see it.
+    let hidden = a_location(&world, &world.two, "the other shelf").await;
+    let never = EntityId::from_uuid(Uuid::new_v4());
+    let note = world.note(&world.one, "not a place").await;
+
+    let mut answers = Vec::new();
+    for target in [hidden, never, note] {
+        let ack = world
+            .submit(
+                &world.one,
+                create_entity(
+                    Uuid::new_v4(),
+                    v1::EntityContent {
+                        specific: Some(item(v1::ItemContent {
+                            location_id: Some(id_bytes(target)),
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        let r = refused(&ack);
+        answers.push((r.reason, r.detail.clone()));
+    }
+
+    assert_eq!(answers[0].0, v1::RefusalReason::NotAvailable as i32);
+    assert!(
+        answers.windows(2).all(|w| w[0] == w[1]),
+        "the three refusals differ, so one of them answers a question about what exists: \
+         {answers:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A location's fields, there and back
+// ---------------------------------------------------------------------------
+
+/// **The guarantee the spine's stub list used to carry, for this type.**
+///
+/// That list asserted a type refused rather than accepting a write and storing
+/// nothing. Once a type is built the claim inverts, and the honest form of it is
+/// this: every field the message addressed is in the row afterwards. Asserting
+/// the stored value rather than the wording of a refusal is what makes it a
+/// guarantee rather than a description.
+#[tokio::test]
+async fn every_location_field_reaches_the_store_on_creation() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let template = declare_template(&world, "hosting account", &[("renews", "date")]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                parent_location_id: Some(id_bytes(cupboard)),
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("shelf", "third"), property("depth", "40cm")],
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("the shelf".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    assert_eq!(
+        location_row(&world, id).await,
+        (Some(cupboard.as_uuid()), Some(template))
+    );
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![
+            ("depth".to_owned(), Some("40cm".to_owned())),
+            ("shelf".to_owned(), Some("third".to_owned())),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn every_location_field_moves_on_an_edit() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let garage = a_location(&world, &world.one, "the garage").await;
+    let template = declare_template(&world, "hosting account", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                parent_location_id: Some(id_bytes(cupboard)),
+                property_values: vec![property("shelf", "third")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                location(v1::LocationContent {
+                    parent_location_id: Some(id_bytes(garage)),
+                    template_id: Some(template.as_bytes().to_vec()),
+                    property_values: vec![property("shelf", "second")],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert_eq!(
+        location_row(&world, id).await,
+        (Some(garage.as_uuid()), Some(template))
+    );
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![("shelf".to_owned(), Some("second".to_owned()))]
+    );
+}
+
+#[tokio::test]
+async fn clearing_every_location_field_empties_it() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let template = declare_template(&world, "hosting account", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                parent_location_id: Some(id_bytes(cupboard)),
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("shelf", "third")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                location(v1::LocationContent {
+                    cleared: vec![1, 2, 3],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert_eq!(location_row(&world, id).await, (None, None));
+    assert!(properties_of(&world, id).await.is_empty());
+}
+
+/// **No required fields**, on this type too. A location with a name and nothing
+/// else is a complete location, and the row holds nothing rather than a default
+/// somebody invented for it.
+#[tokio::test]
+async fn a_location_with_a_name_and_nothing_else_is_complete() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent::default()),
+            v1::EntityContent {
+                title: Some("the drawer".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert_eq!(location_row(&world, id).await, (None, None));
+    assert!(properties_of(&world, id).await.is_empty());
+}
+
+/// A location's parts record their movement, so conflict detection can see them.
+/// The same silent failure as the item's, on the type that has no companion.
+#[tokio::test]
+async fn a_locations_parts_record_the_counter_they_moved_at() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let template = declare_template(&world, "hosting account", &[]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                parent_location_id: Some(id_bytes(cupboard)),
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("shelf", "third")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let moved = moved_parts(&world, id).await;
+    for part in ["specific.1", "specific.2", "specific.3"] {
+        assert!(
+            moved
+                .iter()
+                .any(|(name, counter)| name == part && *counter == 1),
+            "{part} recorded no movement, so nothing can conflict on it: {moved:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Nesting, and the loop the schema cannot see
+// ---------------------------------------------------------------------------
+
+/// Refused through the write path, which is the caller migration one's gap (h)
+/// was waiting for.
+async fn nest(world: &World, child: EntityId, parent: EntityId) -> v1::Acknowledgement {
+    let base = world.counter(child).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                child,
+                base,
+                location(v1::LocationContent {
+                    parent_location_id: Some(id_bytes(parent)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await
+}
+
+fn is_a_loop(ack: &v1::Acknowledgement) -> bool {
+    match &ack.outcome {
+        Some(v1::acknowledgement::Outcome::Refused(r)) => {
+            r.reason == v1::RefusalReason::Malformed as i32
+                && r.detail.contains("nested inside itself")
+        }
+        _ => false,
+    }
+}
+
+/// Self-reference passes for free — the schema already refuses it — so it is
+/// here only to show it still does through this path.
+#[tokio::test]
+async fn a_location_cannot_be_its_own_parent() {
+    let world = World::new().await;
+    let a = a_location(&world, &world.one, "the cupboard").await;
+    let ack = nest(&world, a, a).await;
+    assert!(is_a_loop(&ack), "{:?}", ack.outcome);
+}
+
+/// **The case that matters.** Two hops, which no constraint can see.
+#[tokio::test]
+async fn a_two_hop_loop_in_nested_locations_is_refused() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+
+    // The shelf goes in the cupboard, and then the cupboard is put on the shelf.
+    assert!(matches!(
+        nest(&world, shelf, cupboard).await.outcome,
+        Some(v1::acknowledgement::Outcome::Applied(_))
+    ));
+    let ack = nest(&world, cupboard, shelf).await;
+    assert!(is_a_loop(&ack), "{:?}", ack.outcome);
+    assert_eq!(
+        location_row(&world, cupboard).await.0,
+        None,
+        "the refusal left nothing behind"
+    );
+}
+
+#[tokio::test]
+async fn a_longer_loop_in_nested_locations_is_refused() {
+    let world = World::new().await;
+    let house = a_location(&world, &world.one, "the house").await;
+    let room = a_location(&world, &world.one, "the room").await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+
+    for (child, parent) in [(room, house), (cupboard, room), (shelf, cupboard)] {
+        assert!(matches!(
+            nest(&world, child, parent).await.outcome,
+            Some(v1::acknowledgement::Outcome::Applied(_))
+        ));
+    }
+
+    // Four hops back up to the top.
+    let ack = nest(&world, house, shelf).await;
+    assert!(is_a_loop(&ack), "{:?}", ack.outcome);
+}
+
+/// **Nesting exists and is never required**, and the depth is nowhere bounded.
+/// A flat set of locations is complete rather than degraded.
+#[tokio::test]
+async fn nesting_is_optional_and_its_depth_is_not_bounded() {
+    let world = World::new().await;
+    let flat = a_location(&world, &world.one, "the drawer").await;
+    assert_eq!(location_row(&world, flat).await.0, None);
+
+    let mut previous: Option<EntityId> = None;
+    for depth in 0..8 {
+        let here = a_location(&world, &world.one, &format!("level {depth}")).await;
+        if let Some(parent) = previous {
+            assert!(
+                matches!(
+                    nest(&world, here, parent).await.outcome,
+                    Some(v1::acknowledgement::Outcome::Applied(_))
+                ),
+                "nesting stopped being allowed at depth {depth}"
+            );
+            assert_eq!(location_row(&world, here).await.0, Some(parent.as_uuid()));
+        }
+        previous = Some(here);
+    }
+}
+
+/// A parent the member cannot see answers before anything about ancestry is
+/// read, so the cycle refusal — which says more than nothing — is never reachable
+/// for a location they were not entitled to know about.
+#[tokio::test]
+async fn a_parent_the_member_cannot_see_is_the_same_nothing() {
+    let world = World::new().await;
+    let hidden = a_location(&world, &world.two, "theirs").await;
+    let mine = a_location(&world, &world.one, "mine").await;
+
+    let base = world.counter(mine).await;
+    let ack = world
+        .submit(
+            &world.one,
+            edit_specific(
+                mine,
+                base,
+                location(v1::LocationContent {
+                    parent_location_id: Some(id_bytes(hidden)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+}
+
+// ---------------------------------------------------------------------------
+// Templates and property values
+// ---------------------------------------------------------------------------
+
+/// **Detaching is always available and never destructive.** The entity stops
+/// following the template and keeps every value it holds, with the names it had
+/// at that moment — which is why the store keys a value by name rather than by a
+/// reference to the template's property.
+#[tokio::test]
+async fn a_property_value_survives_its_template_being_detached() {
+    let world = World::new().await;
+    let template = declare_template(
+        &world,
+        "filament",
+        &[("diameter", "text"), ("material", "text")],
+    )
+    .await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("diameter", "1.75mm"), property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let base = world.counter(id).await;
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    cleared: vec![5],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert_eq!(item_row(&world, id).await.template, None);
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![
+            ("diameter".to_owned(), Some("1.75mm".to_owned())),
+            ("material".to_owned(), Some("PLA".to_owned())),
+        ],
+        "detaching a template took the values with it"
+    );
+}
+
+/// **Following is live, not a copy**, so a value is not re-keyed when the
+/// template's property is renamed. It keeps the name it had, which is the whole
+/// reason for keying by name.
+#[tokio::test]
+async fn a_stored_value_keeps_the_name_it_had_when_the_template_renames_its_property() {
+    let world = World::new().await;
+    let template = declare_template(&world, "filament", &[("material", "text")]).await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    sqlx::query("UPDATE template_property SET name = $2 WHERE template_id = $1 AND name = $3")
+        .bind(template)
+        .bind("polymer")
+        .bind("material")
+        .execute(&world.db.pool)
+        .await
+        .expect("rename");
+
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![("material".to_owned(), Some("PLA".to_owned()))]
+    );
+}
+
+/// One shared set reaches items *and* locations. A hosting account is a place a
+/// virtual machine lives and also a thing with credentials and a renewal date,
+/// and whether it is tracked as an item or a location is the person's call.
+#[tokio::test]
+async fn a_template_reaches_a_location_too() {
+    let world = World::new().await;
+    let template = declare_template(&world, "hosting account", &[("renews", "date")]).await;
+
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![property("account", "vps-1")],
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("the VPS".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    assert_eq!(location_row(&world, id).await.1, Some(template));
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![("account".to_owned(), Some("vps-1".to_owned()))]
+    );
+}
+
+/// A template that was never declared is a refusal, not a foreign-key violation
+/// that takes the transaction down with a message nobody can act on.
+#[tokio::test]
+async fn a_template_that_does_not_exist_is_refused() {
+    let world = World::new().await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(item(v1::ItemContent {
+                        template_id: Some(Uuid::new_v4().as_bytes().to_vec()),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    assert!(is_not_available(&ack), "{:?}", ack.outcome);
+}
+
+/// **A kind is not a constraint.** No lengths, no ranges, no patterns, and
+/// nothing required. A number property holding *about a dozen* is a real answer,
+/// because an approximate amount is a real answer.
+#[tokio::test]
+async fn a_property_kind_constrains_nothing() {
+    let world = World::new().await;
+    let template = declare_template(
+        &world,
+        "stock",
+        &[("count", "number"), ("bought", "date"), ("open", "boolean")],
+    )
+    .await;
+
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                template_id: Some(template.as_bytes().to_vec()),
+                property_values: vec![
+                    property("count", "about a dozen"),
+                    property("bought", "some time last spring"),
+                    property("open", "half"),
+                    // And a name the template never declared, which is not the
+                    // template's business either.
+                    property("undeclared", ""),
+                ],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![
+            (
+                "bought".to_owned(),
+                Some("some time last spring".to_owned())
+            ),
+            ("count".to_owned(), Some("about a dozen".to_owned())),
+            ("open".to_owned(), Some("half".to_owned())),
+            ("undeclared".to_owned(), Some(String::new())),
+        ]
+    );
+}
+
+/// The list is the value, so it is replaced whole rather than merged. Anything
+/// nested is replaced whole; the proto says so of a routine's occurrences and
+/// the reasoning is the same.
+#[tokio::test]
+async fn property_values_are_replaced_whole_rather_than_merged() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                property_values: vec![property("a", "1"), property("b", "2")],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    property_values: vec![property("b", "two"), property("c", "3")],
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert_eq!(
+        properties_of(&world, id).await,
+        vec![
+            ("b".to_owned(), Some("two".to_owned())),
+            ("c".to_owned(), Some("3".to_owned())),
+        ]
+    );
+}
+
+/// The store keys a value by name, so one name twice is two instructions with no
+/// reading that honours both — and the store's own upsert would silently keep
+/// whichever came last.
+#[tokio::test]
+async fn one_property_name_given_two_values_is_malformed() {
+    let world = World::new().await;
+    for values in [
+        vec![property("material", "PLA"), property("material", "PETG")],
+        vec![property("", "nameless")],
+    ] {
+        let ack = world
+            .submit(
+                &world.one,
+                create_entity(
+                    Uuid::new_v4(),
+                    v1::EntityContent {
+                        specific: Some(item(v1::ItemContent {
+                            property_values: values,
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await;
+        let r = refused(&ack);
+        assert_eq!(r.reason, v1::RefusalReason::Malformed as i32, "{r:?}");
+        assert!(r.detail.contains("keyed by its name"), "{}", r.detail);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conflict, on the parts this lane added
+// ---------------------------------------------------------------------------
+
+async fn shared_item(world: &World, content: v1::ItemContent) -> EntityId {
+    world
+        .create(
+            &world.one,
+            item(content),
+            v1::EntityContent {
+                audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                ..Default::default()
+            },
+        )
+        .await
+}
+
+#[tokio::test]
+async fn a_same_part_conflict_on_an_amount_retains_both_values() {
+    let world = World::new().await;
+    let id = shared_item(
+        &world,
+        v1::ItemContent {
+            asserted_amount: Some(decimal(3, 0)),
+            ..Default::default()
+        },
+    )
+    .await;
+    let base = world.counter(id).await;
+
+    for (member, amount) in [(&world.one, decimal(2, 0)), (&world.two, decimal(5, 0))] {
+        world
+            .submit(
+                member,
+                edit_specific(
+                    id,
+                    base,
+                    item(v1::ItemContent {
+                        asserted_amount: Some(amount),
+                        ..Default::default()
+                    }),
+                ),
+            )
+            .await;
+    }
+
+    let conflicts = world.conflicts(id).await;
+    let amount = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.1"))
+        .expect("two people counted the same shelf and got different answers");
+    assert_eq!(amount.mine.as_deref(), Some("5.000000000"));
+    assert_eq!(amount.theirs.as_deref(), Some("2.000000000"));
+    assert_eq!(amount.mine_member, Some(world.two.membership_id()));
+    assert_eq!(
+        item_row(&world, id).await.amount.as_deref(),
+        Some("5.000000000")
+    );
+}
+
+/// **Writes producing the same value are not divergent.** Two people counting
+/// the same shelf and agreeing is the likely case, and forming a conflict out of
+/// agreement is the machinery working against its own purpose.
+#[tokio::test]
+async fn two_members_asserting_the_same_amount_do_not_conflict_on_it() {
+    let world = World::new().await;
+    let id = shared_item(&world, v1::ItemContent::default()).await;
+    let base = world.counter(id).await;
+
+    for member in [&world.one, &world.two] {
+        world
+            .submit(
+                member,
+                edit_specific(
+                    id,
+                    base,
+                    item(v1::ItemContent {
+                        asserted_amount: Some(decimal(4, 0)),
+                        unit: Some("tins".into()),
+                        ..Default::default()
+                    }),
+                ),
+            )
+            .await;
+    }
+
+    let conflicts = world.conflicts(id).await;
+    assert!(
+        !conflicts
+            .iter()
+            .any(|c| c.field.as_deref() == Some("specific.1")),
+        "agreement about the amount was recorded as a disagreement: {:?}",
+        conflicts
+            .iter()
+            .map(|c| c.field.clone())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !conflicts
+            .iter()
+            .any(|c| c.field.as_deref() == Some("specific.2")),
+        "agreement about the unit was recorded as a disagreement"
+    );
+    assert_eq!(
+        item_row(&world, id).await.amount.as_deref(),
+        Some("4.000000000")
+    );
+}
+
+/// **A stale base is never a rejection**, and different parts merge with nobody
+/// involved. One counts the tins, the other names the unit.
+#[tokio::test]
+async fn a_stale_base_over_different_item_parts_merges_and_is_never_a_rejection() {
+    let world = World::new().await;
+    let id = shared_item(&world, v1::ItemContent::default()).await;
+    let base = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    unit: Some("tins".into()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+    let ack = world
+        .submit(
+            &world.two,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    asserted_amount: Some(decimal(6, 0)),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert!(
+        applied(&ack).conflict.is_none(),
+        "different parts merge; a stale base alone is not a conflict and never a rejection"
+    );
+    let row = item_row(&world, id).await;
+    assert_eq!(row.unit.as_deref(), Some("tins"));
+    assert_eq!(row.amount.as_deref(), Some("6.000000000"));
+}
+
+// ---------------------------------------------------------------------------
+// What Tracking contributes to searchable text
+// ---------------------------------------------------------------------------
+
+/// The person's own words, so a just-captured item is findable by them before
+/// any derivation runs — which is what makes the literal arm a permanent arm
+/// rather than a fallback.
+#[tokio::test]
+async fn an_items_unit_and_property_values_reach_its_searchable_text() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                asserted_amount: Some(decimal(3, 0)),
+                unit: Some("rolls".into()),
+                property_values: vec![property("material", "PLA")],
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("black filament".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    let text = search_text(&world, id).await;
+    for word in ["black filament", "rolls", "material", "PLA"] {
+        assert!(text.contains(word), "{word} is not in {text:?}");
+    }
+    // Not the amount, which is a value rather than a word, and not the
+    // assertion time.
+    assert!(
+        !text.contains("3.0"),
+        "the amount reached search text: {text:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_locations_property_values_reach_its_searchable_text() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            location(v1::LocationContent {
+                property_values: vec![property("renews", "March")],
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("the VPS".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    let text = search_text(&world, id).await;
+    assert!(
+        text.contains("the VPS") && text.contains("renews") && text.contains("March"),
+        "{text:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The refusal that is not this lane's to lift
+// ---------------------------------------------------------------------------
+
+/// `altair-v0-scope.md` defers shopping lists deliberately rather than
+/// incidentally, and it governs the implementation plan where the two disagree.
+/// Building item and location content does not touch that, and this is the test
+/// that says so.
+#[tokio::test]
+async fn a_shopping_lists_entries_are_still_refused_with_the_reason() {
+    let world = World::new().await;
+    let ack = world
+        .submit(
+            &world.one,
+            create_entity(
+                Uuid::new_v4(),
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::ShoppingList(
+                        v1::ShoppingListContent {
+                            body: Some("milk\nbread".into()),
+                            cleared: Vec::new(),
+                        },
+                    )),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    let r = refused(&ack);
+    assert_eq!(r.reason, v1::RefusalReason::Malformed as i32, "{r:?}");
+    assert!(
+        r.detail.contains("deferred in v0") && r.detail.contains("anchor granularity"),
+        "{}",
+        r.detail
+    );
+
+    // And the list itself is still a thing that can be created.
+    world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::ShoppingList(v1::ShoppingListContent::default()),
+            v1::EntityContent {
+                title: Some("the weekly shop".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+}

--- a/crates/altaird/tests/type_content_tracking.rs
+++ b/crates/altaird/tests/type_content_tracking.rs
@@ -27,6 +27,7 @@ use altaird::store::begin_write;
 use altaird::store::entity::EntityType;
 use altaird::store::ids::{EntityId, MemberId};
 use altaird::write::entity::Ctx;
+use altaird::write::parts::Part;
 use altaird::write::specific::{self, Detachment};
 use chrono::Utc;
 use common::*;
@@ -1809,11 +1810,19 @@ async fn detach(world: &World, container: EntityId, kind: EntityType) -> Detachm
 
 fn released(answer: &Detachment) -> Vec<EntityId> {
     match answer {
-        Detachment::Released(ids) => {
-            let mut ids = ids.clone();
+        Detachment::Released(rows) => {
+            let mut ids: Vec<EntityId> = rows.iter().map(|r| r.entity).collect();
             ids.sort_by_key(|i| i.as_uuid());
             ids
         }
+        other => panic!("expected a release, got {other:?}"),
+    }
+}
+
+/// Which part each released entity reports as having moved.
+fn released_parts(answer: &Detachment) -> Vec<(EntityId, Part)> {
+    match answer {
+        Detachment::Released(rows) => rows.iter().map(|r| (r.entity, r.part.clone())).collect(),
         other => panic!("expected a release, got {other:?}"),
     }
 }
@@ -1971,11 +1980,28 @@ async fn guidances_containers_report_their_release_is_not_built() {
     }
 }
 
-/// A category's release is the shared model's and Wave 2.1 already built it —
-/// the erase path calls `uncategorise_all` directly, so nothing is owed on this
-/// seam. A note and a file hold nothing at all.
+/// A note and a file hold nothing at all, which is an answer.
 #[tokio::test]
-async fn the_types_whose_release_is_not_this_seams_owe_it_nothing() {
+async fn the_types_that_hold_nothing_say_they_have_no_container() {
+    let world = World::new().await;
+    let note = world.note(&world.one, "holds nothing").await;
+    assert_eq!(
+        detach(&world, note, EntityType::Note).await,
+        Detachment::NoContainer
+    );
+}
+
+/// **A category is a container twice over and only one half is built.**
+///
+/// `uncategorise_all` releases its *membership* — the entities filed in it — and
+/// Wave 2.1 built that. Its *nesting* is released by nobody, so erasing a parent
+/// category still leaves its children pointing at a tombstone. Answering
+/// `NotBuilt` is what stops that being invisible.
+///
+/// **LANE: Knowledge and categories.** `category.rs` is not this lane's;
+/// this asserts the gap is reported rather than closing it.
+#[tokio::test]
+async fn a_categorys_nesting_reports_its_release_is_not_built() {
     let world = World::new().await;
     let category = world
         .create(
@@ -1986,13 +2012,7 @@ async fn the_types_whose_release_is_not_this_seams_owe_it_nothing() {
         .await;
     assert_eq!(
         detach(&world, category, EntityType::Category).await,
-        Detachment::NoContainer
-    );
-
-    let note = world.note(&world.one, "holds nothing").await;
-    assert_eq!(
-        detach(&world, note, EntityType::Note).await,
-        Detachment::NoContainer
+        Detachment::NotBuilt
     );
 }
 
@@ -2153,4 +2173,262 @@ async fn a_conflict_on_a_client_stated_time_retains_the_time_the_client_sent() {
     assert_eq!(time.mine.as_deref(), Some(mine.to_rfc3339().as_str()));
     assert_eq!(time.theirs.as_deref(), Some(theirs.to_rfc3339().as_str()));
     assert_eq!(item_row(&world, id).await.asserted_at, Some(mine));
+}
+
+// ---------------------------------------------------------------------------
+// A release is a write, so it owes provenance
+// ---------------------------------------------------------------------------
+
+/// **Which part moved travels with the identity**, because a child location
+/// lost its parent and an item lost its shelf, and those are different fields of
+/// different messages. Without it the release could not record provenance, and a
+/// counter would advance with nothing saying what changed.
+#[tokio::test]
+async fn a_release_reports_which_part_of_each_entity_moved() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    nest(&world, shelf, cupboard).await;
+    let tin = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                location_id: Some(id_bytes(cupboard)),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let parts = released_parts(&detach(&world, cupboard, EntityType::Location).await);
+    assert!(parts.contains(&(shelf, Part::Specific(1))), "{parts:?}");
+    assert!(parts.contains(&(tin, Part::Specific(4))), "{parts:?}");
+}
+
+/// A released entity records the part that moved, at the counter it moved at.
+///
+/// Otherwise a later stale edit to the same field merges silently, losing the
+/// fact that the container went away underneath it.
+#[tokio::test]
+async fn an_erase_records_provenance_for_what_it_released() {
+    let world = World::new().await;
+    let cupboard = a_location(&world, &world.one, "the cupboard").await;
+    let shelf = a_location(&world, &world.one, "the shelf").await;
+    nest(&world, shelf, cupboard).await;
+
+    world.submit(&world.one, erase(&[cupboard])).await;
+
+    let after = world.counter(shelf).await;
+    let moved = moved_parts(&world, shelf).await;
+    assert!(
+        moved
+            .iter()
+            .any(|(name, counter)| name == "specific.1" && *counter == after),
+        "the released parent recorded nothing at counter {after}: {moved:?}"
+    );
+}
+
+/// The membership half owes the same thing. Two parts move — the category and
+/// the position within it — and the counter advances, so both are recorded.
+#[tokio::test]
+async fn erasing_a_category_records_provenance_for_what_it_uncategorised() {
+    let world = World::new().await;
+    let category = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let filed = world
+        .create(
+            &world.one,
+            item(v1::ItemContent::default()),
+            v1::EntityContent {
+                title: Some("filed".into()),
+                category_id: Some(id_bytes(category)),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    world.submit(&world.one, erase(&[category])).await;
+
+    let after = world.counter(filed).await;
+    let moved = moved_parts(&world, filed).await;
+    for part in ["category_id", "category_position"] {
+        assert!(
+            moved
+                .iter()
+                .any(|(name, counter)| name == part && *counter == after),
+            "{part} moved with the counter and recorded nothing: {moved:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A write that changed nothing did not move the part
+// ---------------------------------------------------------------------------
+
+/// **The member who wrote nothing must not own the part.**
+///
+/// `entity_part_counter` carries who last moved a part. A same-value write is
+/// correctly not a conflict — but if it also claimed the part, a later conflict
+/// would name a member who authored nothing and erase the one who did, and
+/// `theirs_member_id` crosses the wire for a client to render.
+#[tokio::test]
+async fn a_write_that_changed_nothing_does_not_take_ownership_of_the_part() {
+    let world = World::new().await;
+    let id = shared_item(
+        &world,
+        v1::ItemContent {
+            unit: Some("tins".into()),
+            ..Default::default()
+        },
+    )
+    .await;
+    let base = world.counter(id).await;
+
+    // Two really moves it.
+    world
+        .submit(
+            &world.two,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    unit: Some("jars".into()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+    // One, stale, submits the same value. Not a conflict — and not a move.
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    unit: Some("jars".into()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert!(
+        world.conflicts(id).await.is_empty(),
+        "agreement was recorded as a disagreement"
+    );
+
+    let owner: Option<Uuid> = sqlx::query(
+        "SELECT member_id FROM entity_part_counter \
+         WHERE entity_id = $1 AND field_name = 'specific.2'",
+    )
+    .bind(id.as_uuid())
+    .fetch_one(&world.db.pool)
+    .await
+    .expect("part counter")
+    .try_get("member_id")
+    .expect("member");
+    assert_eq!(
+        owner,
+        Some(world.two.membership_id()),
+        "the no-op write took ownership of a part it did not change"
+    );
+}
+
+/// And the consequence the ownership bug actually produces: a later conflict
+/// naming the wrong person.
+#[tokio::test]
+async fn a_later_conflict_names_the_member_who_really_wrote_the_value() {
+    let world = World::new().await;
+    let id = shared_item(
+        &world,
+        v1::ItemContent {
+            unit: Some("tins".into()),
+            ..Default::default()
+        },
+    )
+    .await;
+    let base = world.counter(id).await;
+
+    for member in [&world.two, &world.one] {
+        world
+            .submit(
+                member,
+                edit_specific(
+                    id,
+                    base,
+                    item(v1::ItemContent {
+                        unit: Some("jars".into()),
+                        ..Default::default()
+                    }),
+                ),
+            )
+            .await;
+    }
+
+    // Now a third write, still from the old base, that genuinely disagrees.
+    world
+        .submit(
+            &world.two,
+            edit_specific(
+                id,
+                base,
+                item(v1::ItemContent {
+                    unit: Some("bottles".into()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    let conflicts = world.conflicts(id).await;
+    let unit = conflicts
+        .iter()
+        .find(|c| c.field.as_deref() == Some("specific.2"))
+        .expect("bottles disagrees with jars from a stale base");
+    assert_eq!(
+        unit.theirs_member,
+        Some(world.two.membership_id()),
+        "the displaced value is attributed to the member whose no-op touched it \
+         rather than the one who wrote it"
+    );
+}
+
+/// **The counter still advances on a no-op.** Clients learn that a write
+/// happened from the entity's counter; only the per-part record is withheld.
+#[tokio::test]
+async fn a_no_op_write_still_advances_the_entitys_counter() {
+    let world = World::new().await;
+    let id = world
+        .create(
+            &world.one,
+            item(v1::ItemContent {
+                unit: Some("tins".into()),
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+    let before = world.counter(id).await;
+
+    world
+        .submit(
+            &world.one,
+            edit_specific(
+                id,
+                before,
+                item(v1::ItemContent {
+                    unit: Some("tins".into()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await;
+
+    assert_eq!(world.counter(id).await, before + 1);
 }

--- a/crates/altaird/tests/type_content_tracking.rs
+++ b/crates/altaird/tests/type_content_tracking.rs
@@ -2432,3 +2432,64 @@ async fn a_no_op_write_still_advances_the_entitys_counter() {
 
     assert_eq!(world.counter(id).await, before + 1);
 }
+
+/// **What the unbuilt half actually leaves behind**, pinned so the fix is
+/// visible when it lands.
+///
+/// Erase category A with category B nested inside it. A's `category` row goes,
+/// A's `entity` row survives as a tombstone so the composite foreign key stays
+/// satisfied, and B's `parent_category_id` names A for ever. No client can
+/// repair it: re-parenting B means naming A, and `available_for_write` on an
+/// erased A refuses.
+///
+/// It is not a hang — `would_cycle` reads A's deleted row, finds none, and
+/// returns false — which is why it went unnoticed. A coherence problem is the
+/// quieter kind.
+///
+/// **LANE: Knowledge and categories.** This is a characterisation test, not an
+/// approval. When that lane implements the release, **invert this** — the
+/// assertion becomes `None`, exactly as the location one did.
+#[tokio::test]
+async fn erasing_a_parent_category_still_strands_its_nested_children() {
+    let world = World::new().await;
+    let outer = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent::default()),
+            v1::EntityContent {
+                title: Some("outer".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    let inner = world
+        .create(
+            &world.one,
+            v1::entity_content::Specific::Category(v1::CategoryContent {
+                parent_category_id: Some(id_bytes(outer)),
+                ..Default::default()
+            }),
+            v1::EntityContent {
+                title: Some("inner".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    world.submit(&world.one, erase(&[outer])).await;
+    assert_eq!(world.lifecycle(outer).await, "erased");
+
+    let stranded: Option<Uuid> =
+        sqlx::query("SELECT parent_category_id AS p FROM category WHERE entity_id = $1")
+            .bind(inner.as_uuid())
+            .fetch_one(&world.db.pool)
+            .await
+            .expect("category row")
+            .try_get("p")
+            .expect("parent");
+    assert_eq!(
+        stranded,
+        Some(outer.as_uuid()),
+        "wired already? invert this test — nested categories are released now"
+    );
+}

--- a/crates/altaird/tests/unwritten_tables.rs
+++ b/crates/altaird/tests/unwritten_tables.rs
@@ -1,0 +1,442 @@
+//! The tables v0 defines and deliberately does not write.
+//!
+//! # Why this exists
+//!
+//! `altair-v0-scope.md` defers versions, text extraction from files, and
+//! consumption and purchase logs. Migration one nevertheless creates
+//! `entity_version`, `derived_text`, `embedding`, `derivation_queue` and
+//! `event_record`. **That is not a contradiction.** The schema is an adopted
+//! artefact and is not re-derived; a table nothing writes costs nothing at
+//! runtime and saves a migration later. The scope defers *behaviour*, and no
+//! behaviour exists for any of them. On those terms the two documents agree.
+//!
+//! The gap is narrower, and it is in the code rather than the documents:
+//! **nothing marks these tables as deliberately unwritten.** A lane that needs
+//! somewhere to put a derived string finds `derived_text` sitting there,
+//! correctly shaped, with no signal that reaching it is out of scope — and the
+//! failure is silent, because writing to a table nothing reads breaks no test.
+//!
+//! `DEPENDENT_TABLES` in `write/entity.rs` is the precedent. Forgetting a table
+//! there is silent too, and the answer was a named constant plus a test that
+//! walks it. This is the same shape pointed the other way: that list says what
+//! erasure must remove, this one says what nothing may write.
+//!
+//! # What this test is not
+//!
+//! **Not a claim that these tables are wrong to exist**, and not an argument
+//! for deleting them. Each has a named wave. When that wave arrives, the entry
+//! comes out of [`UNWRITTEN`] with the same one-line edit that put it in, and
+//! the reason recorded beside it says which wave that is.
+
+mod common;
+
+use altair_proto::v1;
+use common::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// The list
+// ---------------------------------------------------------------------------
+
+/// Every table v0 defines and writes nothing into, with the reason.
+///
+/// The reason travels with the entry so that a failure names what was violated
+/// rather than only which table grew a row. Adding a table is one line;
+/// removing one when its wave lands is the same line.
+const UNWRITTEN: &[(&str, &str)] = &[
+    // `altair-v0-scope.md`: "Deferred: versions, text extraction from files."
+    (
+        "entity_version",
+        "version history is deferred in v0; nothing captures a version",
+    ),
+    // The same sentence, and Wave 5 besides: derived text is produced by the
+    // derivation worker, which does not exist. `specific/knowledge.rs` refuses
+    // a person's correction to extracted text for exactly this reason.
+    (
+        "derived_text",
+        "text extraction is deferred in v0 and derivation arrives at Wave 5",
+    ),
+    // Wave 5 chooses the embedding model, and the schema's dimension is a
+    // placeholder until it does — the one value in migration one that is not
+    // decided. Writing a vector against a placeholder dimension would have to
+    // be re-embedded.
+    (
+        "embedding",
+        "the embedding model is chosen at Wave 5 and the schema's dimension is \
+         still a placeholder",
+    ),
+    // The queue is an optimisation over work computable from provenance, and
+    // there is no worker to claim from it. Outstanding derivation is computed
+    // from the store, never from the queue, so an empty queue costs nothing.
+    (
+        "derivation_queue",
+        "the derivation worker arrives at Wave 5; outstanding work is computed \
+         from provenance, never from the queue",
+    ),
+    // `altair-v0-scope.md`: Tracking's "Deferred: consumption and purchase
+    // logs, low-stock thresholds, expiry, barcode capture, shopping lists." An
+    // event record is that log. The schema calls them immutable facts,
+    // appended and corrected by appending; v0 appends none.
+    (
+        "event_record",
+        "consumption and purchase logs are deferred in v0",
+    ),
+];
+
+/// Tables that look like candidates and are deliberately **not** listed.
+///
+/// Recorded here rather than left to be re-argued, in the register the design
+/// documents use for a rejected alternative. Each would make this test wrong
+/// in a different way.
+///
+/// - **`block`** — the write path writes it, now that the Bodies lane has
+///   landed: `write/body.rs` inserts and deletes blocks as a body divides.
+///   [`exercise`] writes one deliberately and
+///   [`the_exercise_actually_writes_something`] checks it landed, so this
+///   exclusion is demonstrated rather than asserted.
+/// - **`template` and `template_property`** — in force, not deferred. Migration
+///   one's gap (i) records the scope's ambiguity and resolves it on the reading
+///   that templates are in v0, and `specific/tracking.rs` serves `template_id`
+///   on both types and reads `template` to validate it. A template is declared
+///   out of band because no wire message declares one yet, exactly as a
+///   relation type is; forbidding the row would forbid the feature.
+/// - **`instance_config`** — the retention constants are Wave 2.4's named
+///   trigger, and the schema says v0 runs on the values set with the build.
+///   A row here is the expected state rather than a violation.
+/// - **`household`, `membership`, `relation_type`** — reference and bootstrap
+///   data, populated out of band and non-empty in every test in this suite.
+///   The write path does not create them and was never meant to.
+const NOT_LISTED: &[&str] = &[
+    "block",
+    "template",
+    "template_property",
+    "instance_config",
+    "household",
+    "membership",
+    "relation_type",
+];
+
+async fn rows_in(world: &World, table: &str) -> i64 {
+    let sql = format!("SELECT count(*) AS n FROM {table}");
+    sqlx::query(sqlx::AssertSqlSafe(sql))
+        .fetch_one(&world.db.pool)
+        .await
+        .unwrap_or_else(|e| panic!("counting {table}: {e}"))
+        .try_get("n")
+        .expect("n")
+}
+
+// ---------------------------------------------------------------------------
+// Exercising the write path
+// ---------------------------------------------------------------------------
+
+/// Put the write path through its range, so that "still empty" means something.
+///
+/// **Reused rather than novel**, which is where the value is: this asserts
+/// against the ordinary write path rather than a setup invented to be safe.
+/// Every served entity type is created, content is edited, a relation is formed
+/// and removed, and an entity is removed, restored, and erased — the erase in
+/// particular, because that is the one path that names these tables at all,
+/// in `DEPENDENT_TABLES`.
+///
+/// **A body is written on purpose**, now that the Bodies lane has landed. That
+/// path divides text into blocks and writes them, and it is the nearest thing
+/// in the write path to producing derived content — which makes it precisely
+/// the case worth pointing at `derived_text`. Derived text is the derivation
+/// worker's at Wave 5; dividing a body is not deriving anything.
+///
+/// A file is not created: that is refused until Wave 2.3, which is another
+/// lane's refusal to expire and not what this test is about.
+///
+/// Every submission is checked for having applied. An exercise whose writes
+/// were quietly refused would leave every table empty and pass, which is the
+/// one way this file could lie.
+async fn exercise(world: &World) {
+    use v1::entity_content::Specific;
+
+    // One of every type the create path serves, each addressing nothing, which
+    // is the state a bare create leaves them in.
+    let bare = [
+        Specific::Campaign(v1::CampaignContent::default()),
+        Specific::Arc(v1::ArcContent::default()),
+        Specific::Quest(v1::QuestContent::default()),
+        Specific::Note(v1::NoteContent::default()),
+        Specific::Item(v1::ItemContent::default()),
+        Specific::Location(v1::LocationContent::default()),
+        Specific::ShoppingList(v1::ShoppingListContent::default()),
+        Specific::Category(v1::CategoryContent::default()),
+    ];
+    for specific in bare {
+        world
+            .create(&world.one, specific, v1::EntityContent::default())
+            .await;
+    }
+
+    // Type content that actually moves, on the two types this lane and the
+    // spine settled. A part that reaches a side table is the interesting case:
+    // it is the write furthest from the shared model.
+    let holder = world
+        .create(
+            &world.one,
+            Specific::Category(v1::CategoryContent {
+                creation_default_audience_member_ids: vec![
+                    world.two.membership_id().as_bytes().to_vec(),
+                ],
+                ..Default::default()
+            }),
+            v1::EntityContent::default(),
+        )
+        .await;
+
+    let campaign = world
+        .create(
+            &world.one,
+            Specific::Campaign(v1::CampaignContent {
+                state: Some(v1::GuidanceState::Working as i32),
+                cleared: Vec::new(),
+            }),
+            v1::EntityContent {
+                title: Some("the kitchen".into()),
+                category_id: Some(holder.as_uuid().as_bytes().to_vec()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    // The shared model: a title, a labelled date, an assignment, an audience.
+    let base = world.counter(campaign).await as u64;
+    applied_or_panic(
+        world
+            .submit(
+                &world.one,
+                edit_entity(
+                    campaign,
+                    base,
+                    v1::EntityContent {
+                        title: Some("the kitchen, renamed".into()),
+                        dates: vec![v1::LabelledDate {
+                            label: "due".into(),
+                            when: Some(timestamp(chrono::Utc::now())),
+                            bring_forward: false,
+                        }],
+                        assigned_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                        audience_member_ids: vec![world.two.membership_id().as_bytes().to_vec()],
+                        bulk: Some(true),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await,
+        "editing the shared model",
+    );
+
+    // A body, which divides into blocks and writes them. Several paragraphs, so
+    // the division has something to do and the result is more than one row.
+    let noted = world
+        .create(
+            &world.one,
+            Specific::Note(v1::NoteContent {
+                body: Some(
+                    "The kettle is descaled twice a year.\n\n\
+                     Vinegar, an hour, then two rinses.\n\n\
+                     The filter is a separate job and is not this one."
+                        .into(),
+                ),
+                cleared: Vec::new(),
+            }),
+            v1::EntityContent {
+                title: Some("descaling".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    // And the body edited, so blocks are matched against what is held and only
+    // what changed is rewritten — the path that deletes as well as inserts.
+    let base = world.counter(noted).await as u64;
+    applied_or_panic(
+        world
+            .submit(
+                &world.one,
+                edit_entity(
+                    noted,
+                    base,
+                    v1::EntityContent {
+                        specific: Some(Specific::Note(v1::NoteContent {
+                            body: Some(
+                                "The kettle is descaled twice a year.\n\n\
+                                 Vinegar, an hour, then three rinses."
+                                    .into(),
+                            ),
+                            cleared: Vec::new(),
+                        })),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .await,
+        "editing a body",
+    );
+
+    // A relation, formed and then removed.
+    let other = world.note(&world.one, "something to point at").await;
+    let relation = Uuid::new_v4();
+    applied_or_panic(
+        world
+            .submit(
+                &world.one,
+                create_relation(relation, relation_between(campaign, other)),
+            )
+            .await,
+        "forming a relation",
+    );
+    applied_or_panic(
+        world.submit(&world.one, remove(&[], &[relation])).await,
+        "removing a relation",
+    );
+
+    // Removal, restoration, and erasure — the last being the only path that
+    // names the unwritten tables at all.
+    let doomed = world.note(&world.one, "removed, restored, erased").await;
+    applied_or_panic(
+        world.submit(&world.one, remove(&[doomed], &[])).await,
+        "removing an entity",
+    );
+    applied_or_panic(
+        world.submit(&world.one, restore(doomed, false)).await,
+        "restoring an entity",
+    );
+    applied_or_panic(
+        world.submit(&world.one, erase(&[doomed])).await,
+        "erasing an entity",
+    );
+}
+
+/// Every write in [`exercise`] has to have landed.
+///
+/// Without this the file's central assertion is vacuous in the worst way: a
+/// change that made the whole write path refuse would leave every table empty
+/// and turn this suite green. `World::create` already asserts as much for a
+/// create; this is the same check for everything submitted directly.
+fn applied_or_panic(ack: v1::Acknowledgement, what: &str) {
+    assert!(
+        matches!(ack.outcome, Some(v1::acknowledgement::Outcome::Applied(_))),
+        "{what} did not apply, so the write path was never exercised: {:?}",
+        ack.outcome
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The assertions
+// ---------------------------------------------------------------------------
+
+/// **The point of the file.** Exercise the write path, then find every
+/// deliberately-unwritten table exactly as empty as migration one left it.
+#[tokio::test]
+async fn the_write_path_writes_none_of_the_tables_v0_defers() {
+    let world = World::new().await;
+    exercise(&world).await;
+
+    for (table, why) in UNWRITTEN {
+        let n = rows_in(&world, table).await;
+        assert_eq!(
+            n, 0,
+            "the write path put {n} row(s) in `{table}`, which v0 does not \
+             write: {why}. If the wave that owns it has landed, remove the \
+             entry from UNWRITTEN in this file — do not loosen the assertion."
+        );
+    }
+}
+
+/// **The exercise is not a no-op.** Emptiness is only evidence if something
+/// happened first.
+///
+/// Checked against the tables the write path is *supposed* to fill, so that a
+/// change quietly narrowing what a write does cannot make this suite green by
+/// doing less. `block` carries most of the weight here: it is the table the
+/// Bodies lane added, it is the one deliberately left out of [`UNWRITTEN`] on
+/// the grounds that the write path fills it, and this is where that claim is
+/// demonstrated rather than asserted in a comment.
+#[tokio::test]
+async fn the_exercise_actually_writes_something() {
+    let world = World::new().await;
+    exercise(&world).await;
+
+    for (table, why) in [
+        ("entity", "every create lands here"),
+        (
+            "block",
+            "a body divides into blocks and the write path writes them",
+        ),
+        ("entity_date", "a labelled date was written"),
+        ("entity_assignment", "an assignment was written"),
+        (
+            "entity_part_counter",
+            "every part records the counter it moved at",
+        ),
+        (
+            "change",
+            "every accepted write appends to the change sequence",
+        ),
+        ("relation", "a relation was formed"),
+        ("intent", "every acknowledgement is held against its intent"),
+    ] {
+        assert!(
+            rows_in(&world, table).await > 0,
+            "`{table}` is empty after the exercise, so the emptiness of the \
+             deferred tables proves nothing — {why}"
+        );
+    }
+}
+
+/// A typo in [`UNWRITTEN`] would otherwise pass silently.
+///
+/// `count(*)` over a table that does not exist raises, so the walk above would
+/// fail loudly on a misspelling — but only once something reached it. This
+/// asks the planner directly, so the list is checked against the store whether
+/// or not anything is wrong.
+#[tokio::test]
+async fn every_table_named_here_exists() {
+    let world = World::new().await;
+    for (table, _) in UNWRITTEN {
+        rows_in(&world, table).await;
+    }
+    // And the ones deliberately left out are real tables too, so that entry
+    // stays an argument about scope rather than a stale name nobody noticed.
+    for table in NOT_LISTED {
+        rows_in(&world, table).await;
+    }
+}
+
+/// **The guard is not vacuous.** An assertion that something is empty passes
+/// just as well when it is looking in the wrong place, so this plants a row and
+/// checks the same helper reports it.
+///
+/// Written against `entity_version` because it is the entry with the least
+/// ambiguity behind it: the scope defers versions in as many words, and nothing
+/// anywhere reads the table.
+#[tokio::test]
+async fn the_check_would_notice_a_row() {
+    let world = World::new().await;
+    let entity = world.note(&world.one, "something to version").await;
+    assert_eq!(rows_in(&world, "entity_version").await, 0);
+
+    sqlx::query(
+        "INSERT INTO entity_version (id, entity_id, captured_at, author_member_id, body) \
+         VALUES ($1, $2, now(), $3, $4)",
+    )
+    .bind(Uuid::new_v4())
+    .bind(entity.as_uuid())
+    .bind(world.one.membership_id())
+    .bind("what the note said before")
+    .execute(&world.db.pool)
+    .await
+    .expect("a row can be planted, or this test proves nothing");
+
+    assert_eq!(
+        rows_in(&world, "entity_version").await,
+        1,
+        "the emptiness check cannot see a row, so its passing means nothing"
+    );
+}

--- a/crates/altaird/tests/write_spine.rs
+++ b/crates/altaird/tests/write_spine.rs
@@ -1049,6 +1049,48 @@ async fn a_timestamp_that_cannot_be_read_is_refused_wherever_it_arrives() {
     assert_eq!(w.counter(id).await, 1);
 }
 
+/// **Zero is refused from the other end, and it is the reachable one.**
+///
+/// The upper bound below is refused because a garbled value reads as *current*
+/// and skips conflict detection. Zero fails the same test — the first counter an
+/// entity has is 1, from its own create — but it arrives by accident rather than
+/// by garbling: `base_counter` is a proto3 `uint64`, so a client that omits the
+/// field sends zero and cannot tell that apart from meaning it.
+///
+/// Accepting it manufactured conflicts. A create records the parts it applied
+/// without comparing them, because on a create there is nothing to compare
+/// against — so an entity created with its title explicitly cleared carries
+/// provenance for a title that never changed. An edit with base zero reads
+/// `0 < 1`, asks what moved since, finds that record, and retains a conflict
+/// over a part only the second write ever touched.
+///
+/// The boundary is the point: 1 is a counter this instance issues, and 0 is not.
+#[tokio::test]
+async fn a_base_counter_of_zero_is_refused_and_one_is_not() {
+    let w = World::new().await;
+    let id = w.note(&w.one, "start").await;
+    assert_eq!(w.counter(id).await, 1, "a create issues the first counter");
+
+    let ack = w
+        .submit(
+            &w.one,
+            edit_entity(id, 0, note_content("omitted the field")),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+    assert_eq!(
+        w.title(id).await.as_deref(),
+        Some("start"),
+        "and nothing was written"
+    );
+
+    // The very next value is ordinary, so the refusal is a boundary rather than
+    // a rejection of early edits.
+    w.submit(&w.one, edit_entity(id, 1, note_content("stated it")))
+        .await;
+    assert_eq!(w.title(id).await.as_deref(), Some("stated it"));
+}
+
 #[tokio::test]
 async fn a_base_counter_this_instance_could_not_have_issued_is_refused() {
     // Clamping it was worse than it looks. A base larger than any counter the


### PR DESCRIPTION
Eighth of nine slices of Wave 2.2. Stacked on #27. One new test file, nothing else.

## The gap it closes, which is not where it first looks

`docs/altair-v0-scope.md` defers versions and text extraction. `entity_version` and `derived_text` both exist in migration one. **That is not the schema contradicting the scope.** Migration one is an adopted artefact and explicitly not re-derived; a table nothing writes costs nothing at runtime and saves a migration later. The scope defers *behaviour*, and no behaviour exists for either table. On those terms the two documents agree.

The real gap is narrower and it is in the code: **nothing marks those tables as deliberately unwritten.** A lane that needs to store a derived string finds `derived_text` sitting there, correctly shaped, with no signal that reaching it is out of scope — and the failure is silent, because writing to an unused table breaks no test.

The precedent is `DEPENDENT_TABLES` in `write/entity.rs`, where forgetting a table is also silent and the answer was a named constant plus a test that walks it.

## What it asserts

Five tables, each with its reason recorded beside it so a failure names what was violated rather than only which table grew a row:

| Table | Why v0 does not write it |
|---|---|
| `entity_version` | scope: "Deferred: versions" |
| `derived_text` | scope defers text extraction; derivation is Wave 5 |
| `embedding` | Wave 5 picks the model; the dimension is still a placeholder |
| `derivation_queue` | Wave 5's worker; outstanding work is computed from provenance, never the queue |
| `event_record` | scope: Tracking's "Deferred: consumption and purchase logs" — an event record *is* that log |

`event_record` is the one worth noticing. It is not derivation-related at all; it is deferred Tracking behaviour, and nothing else in the tree marked it.

**Exclusions are recorded too, with reasons, so they are not re-argued.** `block` is written now and listing it would go red on work correctly arriving. `template` and `template_property` are *in force*, not deferred — forbidding the row would forbid a feature. `instance_config` is expected to hold a row, since v0 runs on values set with the build. `household`, `membership` and `relation_type` are bootstrap data.

## Three defences against the assertion being vacuous

This is the part worth reviewing, because "assert it is empty" is the easiest assertion in the world to get wrong in a way that always passes.

1. **Every table named here exists** — a typo in either constant fails against the planner rather than silently.
2. **The check would notice a row** — it plants one in `entity_version` and confirms the same helper reports it.
3. **The exercise actually writes something** — `entity`, `block`, `entity_date`, `entity_assignment`, `entity_part_counter`, `change`, `relation` and `intent` are all asserted non-empty afterwards. **A change that made the whole write path refuse would otherwise leave every deferred table empty and turn this suite green**, and that failure would look exactly like success.

Confirmed by adding `block` to the list and watching it go red, then passing with it removed.

## The failure message names the right fix

When a wave lands and its table starts filling, the tempting fix is to weaken the check. The failure says otherwise: *"If the wave that owns it has landed, remove the entry from `UNWRITTEN` in this file — do not loosen the assertion."* An entry comes out with the same one-line edit that put it in.

## Verification

- `cargo test --workspace`: 32 targets, 443 tests, 0 failures.
- Green against the fully merged tree including the body path, which writes blocks and touches `entity.bulk` and puts nothing in `derived_text` — dividing a body is not deriving anything, and that is now checked rather than assumed.
