### PR TITLE
Wave 2.2 slice 9: let a relation say where it was formed

### DIFF
--- a/crates/altaird/src/write/body.rs
+++ b/crates/altaird/src/write/body.rs
@@ -294,9 +294,9 @@ async fn graduate(ctx: &mut Ctx<'_>, entity: EntityId) -> Applied<()> {
 /// That is the exact failure migration one declines a unique index to avoid —
 /// *"a body edit must never fail because a relation lost an anchor, and that
 /// outranks refusing a duplicate structurally"* — reintroduced by another
-/// route. It is unreachable today only because `write::relation` still refuses
-/// an anchor; it becomes reachable the moment that refusal expires, which is
-/// the item that follows this lane.
+/// route. It became reachable the moment `write::relation` began forming
+/// anchors, which is why the test that covers it lives beside the anchor suite
+/// as well as here.
 ///
 /// Clearing the phrase is also what the substrate means rather than a way
 /// around a check: *"where the block itself is removed the relation survives
@@ -308,6 +308,50 @@ async fn detach_anchors(ctx: &mut Ctx<'_>, removed: &[Uuid]) -> Applied<()> {
         .bind(removed)
         .execute(ctx.tx.conn())
         .await?;
+    Ok(())
+}
+
+/// Let go of the phrases whose words this write took out of a block.
+///
+/// **The rule that separates the two kinds of anchor.** A block anchor holds
+/// while its block remains, through any rewording of it; a phrase anchor holds
+/// only while its words do. *"A relation anchored to a phrase survives such an
+/// edit and loses its anchor; one anchored to a block keeps its anchor while
+/// the block remains."*
+///
+/// Stated a second time for the case where two people edit one block and one
+/// version is chosen: *"an anchor whose text survives holds, and one whose text
+/// does not leaves the relation intact without an anchor."* So the test is
+/// whether the phrase is still in the block, not whether the block was touched.
+///
+/// **The block goes with the phrase.** Both places the substrate states this
+/// say *without an anchor*, not "with a coarser one". Falling back to a block
+/// anchor would re-point somebody's connection from the words they chose at the
+/// whole paragraph — a place they never picked, which is the error
+/// [`crate::body::identity`] refuses to make with over-eager matching.
+/// `anchor_entity_id` stays: where the relation was formed is still true.
+///
+/// Both columns move in one statement, which is also what keeps this clear of
+/// the check `detach_anchors` exists to get around. Matched against the block's
+/// content rather than its verbatim slice, for the reason at the top of this
+/// module.
+///
+/// Only blocks whose content moved are considered. A phrase cannot stop
+/// occurring in text that did not change, so the others have nothing to lose.
+async fn lose_phrases_that_did_not_survive(
+    ctx: &mut Ctx<'_>,
+    block: Uuid,
+    text: &str,
+) -> Applied<()> {
+    sqlx::query(
+        "UPDATE relation SET anchor_block_id = NULL, anchor_phrase = NULL \
+         WHERE anchor_block_id = $1 AND anchor_phrase IS NOT NULL \
+           AND position(anchor_phrase in $2) = 0",
+    )
+    .bind(block)
+    .bind(text)
+    .execute(ctx.tx.conn())
+    .await?;
     Ok(())
 }
 
@@ -408,6 +452,12 @@ pub async fn apply(
         authored = true;
         touch.written.push(Part::Block(block.id));
         touch.changed.push(block.id);
+
+        // The words moved, so any phrase anchored into them may not have
+        // survived. A created block cannot be anchored into yet, but the
+        // statement is harmless there and leaving it unconditional keeps this
+        // from acquiring a case to get wrong later.
+        lose_phrases_that_did_not_survive(ctx, block.id, arriving).await?;
 
         // Only a carried block can be one side of a disagreement. A created
         // block's identity was minted a few lines above and no earlier write

--- a/crates/altaird/src/write/body.rs
+++ b/crates/altaird/src/write/body.rs
@@ -280,34 +280,43 @@ async fn graduate(ctx: &mut Ctx<'_>, entity: EntityId) -> Applied<()> {
     Ok(())
 }
 
-/// Let go of the phrases anchored into blocks this write is about to remove.
+/// Let go of the anchors into blocks this write is about to remove.
 ///
-/// **Without this, removing a block fails the body write.** The store detaches
-/// half an anchor by itself — `relation.anchor_block_id` is
-/// `ON DELETE SET NULL` — and the other half has no owner: `relation`'s
-/// `CHECK (anchor_phrase IS NULL OR anchor_block_id IS NOT NULL)` refuses the
-/// row the referential action produces, so the delete raises a constraint
-/// violation and the whole intent becomes a store fault. Confirmed against
-/// PostgreSQL 18 rather than reasoned about: the failure arrives as
-/// `relation_check3`, from inside the cascading `UPDATE`.
+/// **All three columns, and not by leaving any of it to the cascade.** The
+/// substrate says a removed block leaves the relation *"without its anchor"*,
+/// and migration one reasons from the same state in as many words: *"a relation
+/// that loses its anchor when its block is removed **becomes unanchored**"*.
+/// Unanchored is all three null.
 ///
-/// That is the exact failure migration one declines a unique index to avoid —
-/// *"a body edit must never fail because a relation lost an anchor, and that
-/// outranks refusing a duplicate structurally"* — reintroduced by another
-/// route. It became reachable the moment `write::relation` began forming
-/// anchors, which is why the test that covers it lives beside the anchor suite
-/// as well as here.
+/// `relation.anchor_block_id` is `ON DELETE SET NULL`, so it is tempting to let
+/// the referential action do its share and clear only what it cannot reach.
+/// That was the first shape of this function and it was wrong twice over:
 ///
-/// Clearing the phrase is also what the substrate means rather than a way
-/// around a check: *"where the block itself is removed the relation survives
-/// without its anchor"*. A phrase locating into a block that is gone locates
-/// into nothing. `anchor_entity_id` stays, because where the relation was
-/// formed is still true.
+/// - **It fails the write.** The action nulls the block and `relation`'s
+///   `CHECK (anchor_phrase IS NULL OR anchor_block_id IS NOT NULL)` then refuses
+///   the row it just produced, so the delete raises `relation_check3` from
+///   inside the cascading `UPDATE` and the whole intent becomes a store fault.
+///   Confirmed on PostgreSQL 18 rather than reasoned about. That is the exact
+///   failure migration one declines a unique index to avoid, arriving by
+///   another route.
+/// - **It leaves `anchor_entity_id` standing**, because the action is
+///   column-scoped. That residue is not a decision anybody took — it is what
+///   happens when a referential action reaches one column of three — and it
+///   costs more than the one bit it holds: a shape no client can resubmit, an
+///   ordinary relation edit that erases it silently, and a duplicate refusal
+///   naming a connection the person never mentioned.
+///
+/// Doing the whole thing here means the cascade finds nothing left to do, so
+/// the check is never approached rather than sidestepped, and the state the two
+/// documents describe is the state the store holds.
 async fn detach_anchors(ctx: &mut Ctx<'_>, removed: &[Uuid]) -> Applied<()> {
-    sqlx::query("UPDATE relation SET anchor_phrase = NULL WHERE anchor_block_id = ANY($1)")
-        .bind(removed)
-        .execute(ctx.tx.conn())
-        .await?;
+    sqlx::query(
+        "UPDATE relation SET anchor_entity_id = NULL, anchor_block_id = NULL, \
+         anchor_phrase = NULL WHERE anchor_block_id = ANY($1)",
+    )
+    .bind(removed)
+    .execute(ctx.tx.conn())
+    .await?;
     Ok(())
 }
 
@@ -324,17 +333,18 @@ async fn detach_anchors(ctx: &mut Ctx<'_>, removed: &[Uuid]) -> Applied<()> {
 /// does not leaves the relation intact without an anchor."* So the test is
 /// whether the phrase is still in the block, not whether the block was touched.
 ///
-/// **The block goes with the phrase.** Both places the substrate states this
-/// say *without an anchor*, not "with a coarser one". Falling back to a block
-/// anchor would re-point somebody's connection from the words they chose at the
-/// whole paragraph — a place they never picked, which is the error
-/// [`crate::body::identity`] refuses to make with over-eager matching.
-/// `anchor_entity_id` stays: where the relation was formed is still true.
+/// **The block goes with the phrase, and so does the entity.** Both places the
+/// substrate states this say *without an anchor*, not "with a coarser one".
+/// Falling back to a block anchor would re-point somebody's connection from the
+/// words they chose at the whole paragraph — a place they never picked, which is
+/// the error [`crate::body::identity`] refuses to make with over-eager matching.
+/// Keeping the entity alone would be a smaller version of the same invention,
+/// and it is a shape no client can resubmit; see [`detach_anchors`], which lost
+/// it for the same reason.
 ///
-/// Both columns move in one statement, which is also what keeps this clear of
-/// the check `detach_anchors` exists to get around. Matched against the block's
-/// content rather than its verbatim slice, for the reason at the top of this
-/// module.
+/// All three columns move in one statement, which is also what keeps this clear
+/// of the check `detach_anchors` describes. Matched against the block's content
+/// rather than its verbatim slice, for the reason at the top of this module.
 ///
 /// Only blocks whose content moved are considered. A phrase cannot stop
 /// occurring in text that did not change, so the others have nothing to lose.
@@ -344,7 +354,8 @@ async fn lose_phrases_that_did_not_survive(
     text: &str,
 ) -> Applied<()> {
     sqlx::query(
-        "UPDATE relation SET anchor_block_id = NULL, anchor_phrase = NULL \
+        "UPDATE relation SET anchor_entity_id = NULL, anchor_block_id = NULL, \
+         anchor_phrase = NULL \
          WHERE anchor_block_id = $1 AND anchor_phrase IS NOT NULL \
            AND position(anchor_phrase in $2) = 0",
     )

--- a/crates/altaird/src/write/relation.rs
+++ b/crates/altaird/src/write/relation.rs
@@ -26,6 +26,20 @@
 //!
 //! A constraint cannot do this, because symmetry is a property of the type
 //! declaration and a check constraint cannot reach another table.
+//!
+//! # Anchors, and why an anchor never refuses a connection away
+//!
+//! An anchor records **where a relation was formed** — a phrase inside a block,
+//! or the block itself. It belongs to the relation and not to the body, so the
+//! body stays plain text and removing the relation rewrites nothing. It is not
+//! a type-declared property and needs no type.
+//!
+//! The rule that shapes every decision below is one sentence of the substrate:
+//! *"Removing a person's connection as a side effect of them editing a sentence
+//! is not something the system does."* An anchor is the weakest thing a
+//! relation carries, so **the anchor gives way and the relation never does**.
+//! That is why a phrase this instance cannot find is not a refusal — see
+//! [`anchor`].
 
 use sqlx::Row;
 use uuid::Uuid;
@@ -65,6 +79,28 @@ struct Resolved {
     relation_type: Option<Uuid>,
     quantity: Option<String>,
     resolution: Option<&'static str>,
+    anchor: Anchored,
+}
+
+/// An anchor as the store holds one: three columns, and only the combinations
+/// the schema admits.
+///
+/// `0001_initial.sql` states them as three checks — the anchor entity is one of
+/// the two endpoints, a block requires an entity, a phrase requires a block —
+/// so the reachable shapes are: nothing at all; an entity alone; an entity and
+/// a block; all three.
+///
+/// **An entity alone is a residue, never a submission.** It is what a removed
+/// block leaves behind, because `anchor_block_id ... ON DELETE SET NULL` takes
+/// the block and leaves where the relation was formed standing. [`anchor`]
+/// refuses it on the way in and produces it on the way out, which is not an
+/// inconsistency: one is a client inventing a third kind of anchor, the other
+/// is this instance saying an anchor used to be here.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct Anchored {
+    entity: Option<Uuid>,
+    block: Option<Uuid>,
+    phrase: Option<String>,
 }
 
 /// An exact decimal, as text, for a `numeric` column.
@@ -151,15 +187,13 @@ async fn resolve(ctx: &mut Ctx<'_>, content: &v1::RelationContent) -> Applied<Re
         None => None,
     };
 
-    // An anchor locates into a body, and bodies arrive with Wave 2.2. Refused
-    // rather than dropped: silently discarding where somebody formed a
-    // connection is the kind of loss an acknowledgement should never hide.
-    if content.anchor.is_some() {
-        return Err(Refusal::Malformed(
-            "an anchor locates into a block, and bodies are not served yet".into(),
-        )
-        .into());
-    }
+    // Where the relation was formed, if it says. Resolved after the endpoints,
+    // because an anchor is only meaningful against them and because the block
+    // lookup below may only run once both ends are known visible.
+    let anchored = match &content.anchor {
+        Some(a) => anchor(ctx, a, from, to).await?,
+        None => Anchored::default(),
+    };
 
     // Properties the type declares, and no others.
     let (quantity, resolution) = match (&content.uses, &declared) {
@@ -200,6 +234,122 @@ async fn resolve(ctx: &mut Ctx<'_>, content: &v1::RelationContent) -> Applied<Re
         relation_type,
         quantity,
         resolution,
+        anchor: anchored,
+    })
+}
+
+/// Read an anchor off the wire and check it against the store.
+///
+/// # What is refused, and what is quietly given up instead
+///
+/// Two malformed shapes, both statements about the message rather than about
+/// what is in the store, so both may say what is wrong. The client already
+/// holds both endpoint identifiers, so neither discloses anything.
+///
+/// - **An entity that is not one of the two endpoints.** *"An anchor locates
+///   into one of the two things this joins, and nothing else."*
+/// - **No block.** The substrate names two kinds of anchor, *"at a phrase
+///   within a block or at the block itself"*, and an entity alone is neither.
+///
+/// One refusal that says nothing: **a block identifier this entity does not
+/// hold**, whether because nothing holds it or because something else does.
+/// The two are one answer. A block belongs to an entity, so confirming that a
+/// block identifier exists would confirm that an entity exists, which is the
+/// disclosure the single refusal reason exists to prevent — arriving by way of
+/// a field nobody thinks of as naming an entity.
+///
+/// # A phrase that is not there is not a refusal
+///
+/// **This is the decision worth reading twice.** A client submits an anchor
+/// against the body it last saw. If somebody else has since reworded that
+/// sentence, the phrase is gone by the time the intent arrives.
+///
+/// Refusing would destroy the whole connection, permanently: a refusal is an
+/// answer, the outbox holds no retry for it, and the person's connection would
+/// be gone because somebody else edited a sentence. That is a worse version of
+/// the exact thing the substrate prohibits.
+///
+/// So the anchor gives way and the relation is formed without one, which is
+/// the rule already written for the same situation later in the entity's life:
+/// *"an anchor whose text survives holds, and one whose text does not leaves
+/// the relation intact without an anchor."*
+///
+/// **The block goes with the phrase rather than the anchor falling back to
+/// it.** Both places the substrate states this say *without an anchor*, not
+/// "with a coarser one". Somebody pointed at particular words; re-pointing the
+/// connection at the whole paragraph would be this file making up a place the
+/// person never chose, which is the error `body::identity` refuses to make
+/// with over-eager matching. Where it was formed — the entity — is still true
+/// and stays.
+async fn anchor(
+    ctx: &mut Ctx<'_>,
+    a: &v1::Anchor,
+    from: EntityId,
+    to: EntityId,
+) -> Applied<Anchored> {
+    if a.entity_id.is_empty() {
+        return Err(Refusal::Malformed(
+            "an anchor names the endpoint whose body it locates into".into(),
+        )
+        .into());
+    }
+    let entity = EntityId::from_uuid(identifier(&a.entity_id)?);
+    if entity != from && entity != to {
+        return Err(Refusal::Malformed(
+            "an anchor locates into one of the two entities the relation joins, and this \
+             names neither"
+                .into(),
+        )
+        .into());
+    }
+    if a.block_id.is_empty() {
+        return Err(Refusal::Malformed(
+            "an anchor attaches at a block, or at a phrase within one, and this names no \
+             block"
+                .into(),
+        )
+        .into());
+    }
+    let block = identifier(&a.block_id)?;
+
+    // One read answers both questions: whether this entity holds the block, and
+    // what the block says. Scoped by entity, so a block of something else is
+    // the same nothing as a block of nothing.
+    let text: String = sqlx::query("SELECT text FROM block WHERE id = $1 AND entity_id = $2")
+        .bind(block)
+        .bind(entity.as_uuid())
+        .fetch_optional(ctx.tx.conn())
+        .await?
+        .ok_or(Refusal::NotAvailable)?
+        .try_get("text")?;
+
+    // Empty is the block itself, which the wire states outright. Stored as
+    // null rather than as an empty string: a phrase nobody wrote is not a
+    // phrase, and the schema's checks read presence.
+    if a.phrase.is_empty() {
+        return Ok(Anchored {
+            entity: Some(entity.as_uuid()),
+            block: Some(block),
+            phrase: None,
+        });
+    }
+
+    // Matched against the block's content rather than its verbatim slice, for
+    // the reason `write::body` sets out at length: the verbatim text carries
+    // the blank line after the block, which belongs to the body's shape rather
+    // than to anything a person wrote.
+    if !crate::body::content_of(&text).contains(&a.phrase) {
+        return Ok(Anchored {
+            entity: Some(entity.as_uuid()),
+            block: None,
+            phrase: None,
+        });
+    }
+
+    Ok(Anchored {
+        entity: Some(entity.as_uuid()),
+        block: Some(block),
+        phrase: Some(a.phrase.clone()),
     })
 }
 
@@ -213,8 +363,25 @@ async fn resolve(ctx: &mut Ctx<'_>, content: &v1::RelationContent) -> Applied<Re
 ///
 /// Only active relations count. One sitting in holding is not a connection that
 /// exists, and forming it again is the person's answer to having removed it.
+///
+/// # Both sides have to be unanchored, and only one of them was
+///
+/// The query below asks whether an *existing* row is untyped and unanchored.
+/// Until anchors could be formed that was the whole question, because nothing
+/// arriving could be anchored either. It is now half of it: an anchored
+/// relation arriving where an unanchored one already exists is a second
+/// connection, recorded at a place in the text, and refusing it would tell
+/// somebody their connection was already there when what is there says nothing
+/// about where they made theirs.
+///
+/// So the arriving side is checked here and the stored side in the query, and
+/// **an anchor of any kind is enough** — including the residue of one, an
+/// entity with no block left. That is deliberate rather than an oversight of
+/// the residue case: it is still a record of where a connection was formed, and
+/// it is what keeps a body edit that removes a block from turning a relation
+/// into somebody else's duplicate.
 async fn is_duplicate(ctx: &mut Ctx<'_>, r: &Resolved, itself: Option<Uuid>) -> Applied<bool> {
-    if r.relation_type.is_some() {
+    if r.relation_type.is_some() || r.anchor.entity.is_some() {
         return Ok(false);
     }
     let row = sqlx::query(
@@ -263,8 +430,8 @@ pub async fn create(ctx: &mut Ctx<'_>, id: Uuid, content: &v1::RelationContent) 
     let inserted = sqlx::query(
         "INSERT INTO relation \
          (id, from_entity_id, to_entity_id, relation_type_id, quantity, resolution, \
-          author_member_id, created_at) \
-         VALUES ($1, $2, $3, $4, $5::numeric, $6::uses_resolution, $7, $8) \
+          anchor_entity_id, anchor_block_id, anchor_phrase, author_member_id, created_at) \
+         VALUES ($1, $2, $3, $4, $5::numeric, $6::uses_resolution, $7, $8, $9, $10, $11) \
          ON CONFLICT (id) DO NOTHING",
     )
     .bind(id)
@@ -273,6 +440,9 @@ pub async fn create(ctx: &mut Ctx<'_>, id: Uuid, content: &v1::RelationContent) 
     .bind(r.relation_type)
     .bind(r.quantity.as_deref())
     .bind(r.resolution)
+    .bind(r.anchor.entity)
+    .bind(r.anchor.block)
+    .bind(r.anchor.phrase.as_deref())
     .bind(ctx.member.as_uuid())
     .bind(ctx.at)
     .execute(ctx.tx.conn())
@@ -329,9 +499,17 @@ pub async fn edit(ctx: &mut Ctx<'_>, id: Uuid, content: &v1::RelationContent) ->
         return Err(already_recorded().into());
     }
 
+    // Every column, from the message. **A relation's content has no untouched
+    // state**: there is no base counter to scope a write against and no part
+    // machinery over a relation, so an edit is the whole record and a field the
+    // message does not carry is a field the message cleared. That was already
+    // true of the type and of a quantity; the anchor joins them rather than
+    // acquiring a rule of its own. A `cleared` list therefore has nothing to
+    // add here, and naming a field in one changes nothing.
     sqlx::query(
         "UPDATE relation SET from_entity_id = $2, to_entity_id = $3, relation_type_id = $4, \
-         quantity = $5::numeric, resolution = $6::uses_resolution WHERE id = $1",
+         quantity = $5::numeric, resolution = $6::uses_resolution, \
+         anchor_entity_id = $7, anchor_block_id = $8, anchor_phrase = $9 WHERE id = $1",
     )
     .bind(id)
     .bind(r.from.as_uuid())
@@ -339,6 +517,9 @@ pub async fn edit(ctx: &mut Ctx<'_>, id: Uuid, content: &v1::RelationContent) ->
     .bind(r.relation_type)
     .bind(r.quantity.as_deref())
     .bind(r.resolution)
+    .bind(r.anchor.entity)
+    .bind(r.anchor.block)
+    .bind(r.anchor.phrase.as_deref())
     .execute(ctx.tx.conn())
     .await?;
 

--- a/crates/altaird/src/write/relation.rs
+++ b/crates/altaird/src/write/relation.rs
@@ -313,8 +313,18 @@ async fn anchor(
     let block = identifier(&a.block_id)?;
 
     // One read answers both questions: whether this entity holds the block, and
-    // what the block says. Scoped by entity, so a block of something else is
-    // the same nothing as a block of nothing.
+    // what the block says.
+    //
+    // **Scoped by entity, and the refusal below says nothing. Do not make it
+    // helpful.** The obvious improvement is to look the block up on its own and
+    // tell the client whether it does not exist or merely belongs to something
+    // else. That improvement is a disclosure: a block belongs to an entity, so
+    // an answer confirming a block identifier exists confirms that an entity
+    // exists — and it arrives through a field nobody thinks of as naming one,
+    // which is why it would survive a reading that was watching the endpoints.
+    // A block of something else and a block of nothing are one answer, with no
+    // detail, exactly as an entity nobody may see and an entity that is not
+    // there are one answer.
     let text: String = sqlx::query("SELECT text FROM block WHERE id = $1 AND entity_id = $2")
         .bind(block)
         .bind(entity.as_uuid())

--- a/crates/altaird/src/write/relation.rs
+++ b/crates/altaird/src/write/relation.rs
@@ -83,19 +83,25 @@ struct Resolved {
 }
 
 /// An anchor as the store holds one: three columns, and only the combinations
-/// the schema admits.
+/// anything ever puts there.
 ///
-/// `0001_initial.sql` states them as three checks — the anchor entity is one of
-/// the two endpoints, a block requires an entity, a phrase requires a block —
-/// so the reachable shapes are: nothing at all; an entity alone; an entity and
-/// a block; all three.
+/// `0001_initial.sql` states its own limits as three checks — the anchor entity
+/// is one of the two endpoints, a block requires an entity, a phrase requires a
+/// block — which admit four shapes: nothing at all; an entity alone; an entity
+/// and a block; all three.
 ///
-/// **An entity alone is a residue, never a submission.** It is what a removed
-/// block leaves behind, because `anchor_block_id ... ON DELETE SET NULL` takes
-/// the block and leaves where the relation was formed standing. [`anchor`]
-/// refuses it on the way in and produces it on the way out, which is not an
-/// inconsistency: one is a client inventing a third kind of anchor, the other
-/// is this instance saying an anchor used to be here.
+/// **An entity alone is admitted by the schema and produced by nothing.** The
+/// substrate says a lost anchor leaves the relation *"without its anchor"* and
+/// migration one says it *"becomes unanchored"*, so every path that takes an
+/// anchor away takes all three columns — see `write::body`. An entity alone was
+/// briefly a residue here, left standing because `ON DELETE SET NULL` reaches
+/// one column of three, and it cost a shape no client could resubmit, an
+/// ordinary edit that erased it in silence, and a duplicate refusal naming a
+/// connection nobody had mentioned. It holds one bit — which end — about a
+/// place that no longer exists, and nothing reads it.
+///
+/// So [`anchor`] refuses it on the way in and nothing produces it on the way
+/// out. The shape is not a state this system has.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct Anchored {
     entity: Option<Uuid>,
@@ -274,13 +280,13 @@ async fn resolve(ctx: &mut Ctx<'_>, content: &v1::RelationContent) -> Applied<Re
 /// *"an anchor whose text survives holds, and one whose text does not leaves
 /// the relation intact without an anchor."*
 ///
-/// **The block goes with the phrase rather than the anchor falling back to
-/// it.** Both places the substrate states this say *without an anchor*, not
-/// "with a coarser one". Somebody pointed at particular words; re-pointing the
-/// connection at the whole paragraph would be this file making up a place the
-/// person never chose, which is the error `body::identity` refuses to make
-/// with over-eager matching. Where it was formed — the entity — is still true
-/// and stays.
+/// **Without one means without one, all three columns.** Both places the
+/// substrate states this say *without an anchor*, not "with a coarser one".
+/// Somebody pointed at particular words; re-pointing the connection at the
+/// whole paragraph would be this file making up a place the person never chose,
+/// which is the error `body::identity` refuses to make with over-eager
+/// matching. Keeping the entity alone would be the same invention in miniature,
+/// and it would leave behind precisely the shape refused a few lines above.
 async fn anchor(
     ctx: &mut Ctx<'_>,
     a: &v1::Anchor,
@@ -349,11 +355,7 @@ async fn anchor(
     // the blank line after the block, which belongs to the body's shape rather
     // than to anything a person wrote.
     if !crate::body::content_of(&text).contains(&a.phrase) {
-        return Ok(Anchored {
-            entity: Some(entity.as_uuid()),
-            block: None,
-            phrase: None,
-        });
+        return Ok(Anchored::default());
     }
 
     Ok(Anchored {
@@ -385,11 +387,18 @@ async fn anchor(
 /// about where they made theirs.
 ///
 /// So the arriving side is checked here and the stored side in the query, and
-/// **an anchor of any kind is enough** — including the residue of one, an
-/// entity with no block left. That is deliberate rather than an oversight of
-/// the residue case: it is still a record of where a connection was formed, and
-/// it is what keeps a body edit that removes a block from turning a relation
-/// into somebody else's duplicate.
+/// the two ask the same thing because there is only one kind of anchored to be:
+/// every path that takes an anchor away takes all three columns, so a relation
+/// is anchored or it is not, and nothing is half of one.
+///
+/// **A relation that loses its anchor can therefore become a duplicate of one
+/// already recorded, and that is correct.** It is what migration one describes
+/// and accepts — *"a relation that loses its anchor when its block is removed
+/// becomes unanchored, collides with an existing relation between the same
+/// pair, and the block removal fails. A body edit must never fail because a
+/// relation lost an anchor, and that outranks refusing a duplicate
+/// structurally."* Nothing on the body path consults this function, so the two
+/// simply coexist, which is the price that sentence agrees to pay.
 async fn is_duplicate(ctx: &mut Ctx<'_>, r: &Resolved, itself: Option<Uuid>) -> Applied<bool> {
     if r.relation_type.is_some() || r.anchor.entity.is_some() {
         return Ok(false);

--- a/crates/altaird/src/write/relation.rs
+++ b/crates/altaird/src/write/relation.rs
@@ -256,6 +256,12 @@ async fn resolve(ctx: &mut Ctx<'_>, content: &v1::RelationContent) -> Applied<Re
 ///   into one of the two things this joins, and nothing else."*
 /// - **No block.** The substrate names two kinds of anchor, *"at a phrase
 ///   within a block or at the block itself"*, and an entity alone is neither.
+///   **Nothing on the other side produces that shape either** — every path that
+///   takes an anchor away takes all three columns — so this is not a client
+///   held to a stricter rule than the store keeps. It is a shape this system
+///   does not have, which is a stronger reason to refuse it than the one this
+///   refusal originally carried: that version left the store producing a shape
+///   its own write path would not accept back.
 ///
 /// One refusal that says nothing: **a block identifier this entity does not
 /// hold**, whether because nothing holds it or because something else does.
@@ -308,6 +314,12 @@ async fn anchor(
         )
         .into());
     }
+    // An entity with no block. Refused here, and produced by nothing anywhere —
+    // `write::body` takes all three columns whenever an anchor is lost, because
+    // the substrate says a relation is left *without* its anchor. Keep those two
+    // facts together: a refusal here without that would leave the store holding
+    // a shape its own write path will not accept back, which is what this used
+    // to do and what made an ordinary edit of such a relation refuse.
     if a.block_id.is_empty() {
         return Err(Refusal::Malformed(
             "an anchor attaches at a block, or at a phrase within one, and this names no \

--- a/crates/altaird/tests/type_content_bodies.rs
+++ b/crates/altaird/tests/type_content_bodies.rs
@@ -636,14 +636,20 @@ async fn rewording_a_block_leaves_an_anchor_into_it_alone() {
 /// Removing a block leaves the relation, without its anchor — and, critically,
 /// **the body write does not fail**.
 ///
-/// The store detaches half the anchor by itself and refuses the row that
-/// produces: `anchor_phrase` may not outlive `anchor_block_id`, so the delete
-/// raises `relation_check3` from inside the cascading update and the whole
-/// intent becomes a store fault. Migration one declines a unique index over the
-/// unanchored pair for exactly this reason — *a body edit must never fail
-/// because a relation lost an anchor* — and this is the same failure by another
-/// route. `write/body.rs` clears the phrase first; without that line this test
-/// is a fault rather than a failure.
+/// *Without its anchor* means all three columns, which is what the substrate
+/// says and what migration one reasons from: a relation that loses its anchor
+/// *becomes unanchored*. Nothing keeps a record of where the anchor used to be.
+///
+/// Leaving any of it to the store does not work, which is the second half of
+/// this test. `anchor_block_id` is `ON DELETE SET NULL`, and the row that
+/// referential action produces is refused by `anchor_phrase`'s own check — the
+/// delete raises `relation_check3` from inside the cascading update and the
+/// whole intent becomes a store fault. Migration one declines a unique index
+/// over the unanchored pair to avoid exactly that outcome — *a body edit must
+/// never fail because a relation lost an anchor* — and this is the same failure
+/// by another route. `write/body.rs` clears all three itself, so the cascade
+/// finds nothing to do; without that this test is a fault rather than a
+/// failure.
 #[tokio::test]
 async fn removing_a_block_leaves_the_relation_without_its_anchor_and_does_not_fail() {
     let world = World::new().await;
@@ -659,8 +665,9 @@ async fn removing_a_block_leaves_the_relation_without_its_anchor_and_does_not_fa
 
     assert_eq!(
         anchor_of(&world, relation).await,
-        (Some(note.as_uuid()), None, None),
-        "the relation did not survive its block, or kept a phrase locating into nothing"
+        (None, None, None),
+        "the relation did not survive its block, or kept part of an anchor \
+         locating into nothing"
     );
     assert_eq!(
         world.relation_lifecycle(relation).await.as_deref(),

--- a/crates/altaird/tests/write_relations.rs
+++ b/crates/altaird/tests/write_relations.rs
@@ -1179,3 +1179,100 @@ async fn after_a_conflict_over_one_block_the_surviving_phrase_keeps_its_anchor()
         (Some(note.as_uuid()), None, None)
     );
 }
+
+/// The same guarantee on the other path that takes an anchor away.
+///
+/// A block being *removed* and a phrase being *edited out* are two different
+/// statements in `write::body`, and only one of them was covered above. Both
+/// must leave a body edit able to land beside a relation that would otherwise
+/// be its duplicate, because migration one's sentence is about the outcome and
+/// not about which statement produced it.
+#[tokio::test]
+async fn losing_a_phrase_never_fails_beside_an_identical_unanchored_relation() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "buy eggs on the way home\n").await;
+    let other = w.note(&w.one, "the other end").await;
+
+    w.submit(
+        &w.one,
+        create_relation(Uuid::new_v4(), relation_between(note, other)),
+    )
+    .await;
+    let phrase = relation_id(&anchored(&w, note, other, at(note, blocks[0], "eggs")).await);
+
+    // The words the anchor names are edited away, and the body edit must land.
+    let base = w.counter(note).await;
+    let ack = w
+        .submit(
+            &w.one,
+            edit_entity(
+                note,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                        body: Some("buy bread on the way home\n".into()),
+                        cleared: Vec::new(),
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    applied(&ack);
+
+    assert_eq!(
+        w.relation_lifecycle(phrase).await.as_deref(),
+        Some("active")
+    );
+    assert_eq!(
+        anchor_of(&w, phrase).await,
+        (Some(note.as_uuid()), None, None)
+    );
+}
+
+/// **No body write can make a relation a duplicate, because no body write ever
+/// makes one fully unanchored.**
+///
+/// The reason migration one's collision cannot arise, stated as a property
+/// rather than left implicit in the two tests above: both paths that take an
+/// anchor away keep `anchor_entity_id`, and `is_duplicate` counts that as an
+/// anchor. Where the connection was formed outlives the words and the block.
+///
+/// This does not replace those tests. They assert the outcome the sentence
+/// requires — a body edit that lands — which stays true even if this property
+/// stops holding, because the body path consults no duplicate check at all.
+#[tokio::test]
+async fn no_body_write_leaves_a_relation_without_where_it_was_formed() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "buy eggs today\n- milk\n").await;
+    let other = w.note(&w.one, "the other end").await;
+
+    let phrase = relation_id(&anchored(&w, note, other, at(note, blocks[0], "eggs")).await);
+    let block = relation_id(&anchored(&w, note, other, at(note, blocks[1], "")).await);
+
+    // One write that edits the phrase away and removes the other block outright.
+    let base = w.counter(note).await;
+    applied(
+        &w.submit(
+            &w.one,
+            edit_entity(
+                note,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                        body: Some("buy bread today\n".into()),
+                        cleared: Vec::new(),
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await,
+    );
+
+    for id in [phrase, block] {
+        let (entity, b, p) = anchor_of(&w, id).await;
+        assert_eq!(entity, Some(note.as_uuid()), "where it was formed was lost");
+        assert_eq!((b, p), (None, None));
+    }
+}

--- a/crates/altaird/tests/write_relations.rs
+++ b/crates/altaird/tests/write_relations.rs
@@ -972,12 +972,12 @@ async fn an_anchored_relation_is_not_a_duplicate_of_an_unanchored_one() {
 /// fails. *"A body edit must never fail because a relation lost an anchor, and
 /// that outranks refusing a duplicate structurally."*
 ///
-/// Two things keep that true here, and the weaker one is the one to rely on.
-/// The relation does not become *fully* unanchored — where it was formed
-/// survives the block, so a residue remains and `is_duplicate` counts a residue
-/// as an anchor. But the guarantee does not rest on that: the removal path
-/// carries no duplicate check at all, so a later change to what counts as
-/// anchored cannot reintroduce the failure.
+/// The relation does become fully unanchored: all three columns go with the
+/// block, so it is now indistinguishable from the one already recorded between
+/// the same pair. Nothing catches that, and nothing is meant to — the removal
+/// path carries no duplicate check at all, which is where the guarantee rests.
+/// It does not rest on what `is_duplicate` happens to count as an anchor, so a
+/// later change to that cannot reintroduce the failure.
 #[tokio::test]
 async fn removing_a_block_never_fails_beside_an_identical_unanchored_relation() {
     let w = World::new().await;
@@ -1012,8 +1012,7 @@ async fn removing_a_block_never_fails_beside_an_identical_unanchored_relation() 
         .await;
     applied(&ack);
 
-    // Both relations are still here, and the second is now unanchored except
-    // for where it was formed.
+    // Both relations are still here, and the second is now fully unanchored.
     assert_eq!(
         w.relation_lifecycle(anchored_id).await.as_deref(),
         Some("active")

--- a/crates/altaird/tests/write_relations.rs
+++ b/crates/altaird/tests/write_relations.rs
@@ -363,34 +363,6 @@ async fn an_unknown_relation_type_is_nothing() {
     assert!(is_not_available(&ack));
 }
 
-#[tokio::test]
-async fn an_anchor_is_refused_for_a_reason_that_expires() {
-    let w = World::new().await;
-    let (a, b) = two_notes(&w).await;
-    let ack = w
-        .submit(
-            &w.one,
-            create_relation(
-                Uuid::new_v4(),
-                v1::RelationContent {
-                    anchor: Some(v1::Anchor {
-                        entity_id: a.as_uuid().as_bytes().to_vec(),
-                        block_id: Uuid::new_v4().as_bytes().to_vec(),
-                        phrase: String::new(),
-                    }),
-                    ..relation_between(a, b)
-                },
-            ),
-        )
-        .await;
-    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
-    assert!(
-        !refused(&ack).detail.is_empty(),
-        "silently discarding where somebody formed a connection is loss an \
-         acknowledgement should never hide"
-    );
-}
-
 // --- editing -------------------------------------------------------------
 
 #[tokio::test]
@@ -691,4 +663,519 @@ async fn a_relation_create_naming_an_invisible_identity_is_refused_and_never_fau
         .await
         .expect("an identifier somebody else holds is an answer, not a fault");
     assert!(is_not_available(&acks[0]));
+}
+
+// --- anchors -------------------------------------------------------------
+//
+// An anchor records where a relation was formed. It belongs to the relation and
+// not to the body, so the body stays plain text and removing the relation
+// rewrites nothing. It is not a type-declared property and needs no type.
+//
+// One sentence of the substrate decides most of what follows: *"Removing a
+// person's connection as a side effect of them editing a sentence is not
+// something the system does."* The anchor is the weakest thing a relation
+// carries, so wherever something has to give, the anchor gives and the relation
+// does not.
+
+/// A note whose body is one entry per line, and the identities of its blocks.
+async fn note_with_blocks(w: &World, body: &str) -> (EntityId, Vec<Uuid>) {
+    let id = w
+        .create(
+            &w.one,
+            v1::entity_content::Specific::Note(v1::NoteContent {
+                body: Some(body.into()),
+                cleared: Vec::new(),
+            }),
+            v1::EntityContent {
+                audience_member_ids: vec![
+                    w.one.membership_id().as_bytes().to_vec(),
+                    w.two.membership_id().as_bytes().to_vec(),
+                ],
+                ..Default::default()
+            },
+        )
+        .await;
+    let blocks = sqlx::query("SELECT id FROM block WHERE entity_id = $1 ORDER BY position")
+        .bind(id.as_uuid())
+        .fetch_all(&w.db.pool)
+        .await
+        .expect("blocks")
+        .iter()
+        .map(|r| r.try_get("id").unwrap())
+        .collect();
+    (id, blocks)
+}
+
+fn at(entity: EntityId, block: Uuid, phrase: &str) -> v1::Anchor {
+    v1::Anchor {
+        entity_id: entity.as_uuid().as_bytes().to_vec(),
+        block_id: block.as_bytes().to_vec(),
+        phrase: phrase.into(),
+    }
+}
+
+/// The three columns an anchor lives in.
+async fn anchor_of(w: &World, relation: Uuid) -> (Option<Uuid>, Option<Uuid>, Option<String>) {
+    let r = sqlx::query(
+        "SELECT anchor_entity_id, anchor_block_id, anchor_phrase FROM relation WHERE id = $1",
+    )
+    .bind(relation)
+    .fetch_one(&w.db.pool)
+    .await
+    .expect("relation");
+    (
+        r.try_get("anchor_entity_id").unwrap(),
+        r.try_get("anchor_block_id").unwrap(),
+        r.try_get("anchor_phrase").unwrap(),
+    )
+}
+
+async fn anchored(
+    w: &World,
+    from: EntityId,
+    to: EntityId,
+    anchor: v1::Anchor,
+) -> v1::Acknowledgement {
+    w.submit(
+        &w.one,
+        create_relation(
+            Uuid::new_v4(),
+            v1::RelationContent {
+                anchor: Some(anchor),
+                ..relation_between(from, to)
+            },
+        ),
+    )
+    .await
+}
+
+/// An anchor at the block itself. An empty phrase is what the wire says that
+/// is, and it is stored as null rather than as an empty string — a phrase
+/// nobody wrote is not a phrase.
+#[tokio::test]
+async fn an_anchor_at_a_block_records_the_block_and_no_phrase() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "- eggs\n- milk\n").await;
+    let other = w.note(&w.one, "the other end").await;
+
+    let ack = anchored(&w, note, other, at(note, blocks[0], "")).await;
+    let id = relation_id(&ack);
+
+    assert_eq!(
+        anchor_of(&w, id).await,
+        (Some(note.as_uuid()), Some(blocks[0]), None)
+    );
+}
+
+/// An anchor at a phrase within a block records the phrase as well.
+///
+/// **No type is involved.** An anchor is not a type-declared property and does
+/// not require a type, which is the one place the anchor rules and the
+/// properties rules differ.
+#[tokio::test]
+async fn an_anchor_at_a_phrase_records_it_and_needs_no_type() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "buy eggs on the way home\n").await;
+    let other = w.note(&w.one, "the other end").await;
+
+    let ack = anchored(&w, note, other, at(note, blocks[0], "eggs")).await;
+    let id = relation_id(&ack);
+
+    assert_eq!(
+        anchor_of(&w, id).await,
+        (Some(note.as_uuid()), Some(blocks[0]), Some("eggs".into()))
+    );
+    // Untyped, and none the worse for it.
+    let typed: Option<Uuid> =
+        sqlx::query("SELECT relation_type_id AS t FROM relation WHERE id = $1")
+            .bind(id)
+            .fetch_one(&w.db.pool)
+            .await
+            .expect("relation")
+            .try_get("t")
+            .unwrap();
+    assert!(typed.is_none());
+}
+
+/// An anchor locates into one of the two entities the relation joins.
+///
+/// Malformed with a detail, because it is a statement about the message: the
+/// client already holds both endpoint identifiers, so saying so tells it
+/// nothing it did not send.
+#[tokio::test]
+async fn an_anchor_into_an_entity_the_relation_does_not_join_is_malformed() {
+    let w = World::new().await;
+    let (elsewhere, blocks) = note_with_blocks(&w, "- eggs\n").await;
+    let (a, b) = two_notes(&w).await;
+
+    let ack = anchored(&w, a, b, at(elsewhere, blocks[0], "")).await;
+    let detail = &refused(&ack).detail;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+    assert!(detail.contains("one of the two entities"), "{detail}");
+}
+
+/// An anchor attaches at a block or at a phrase within one. An entity alone is
+/// neither, and is refused rather than admitted as a third kind.
+///
+/// The store *holds* that shape, because it is the residue a removed block
+/// leaves. Produced by the instance, never submitted by a client.
+#[tokio::test]
+async fn an_anchor_naming_no_block_is_malformed() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+
+    let ack = anchored(
+        &w,
+        a,
+        b,
+        v1::Anchor {
+            entity_id: a.as_uuid().as_bytes().to_vec(),
+            block_id: Vec::new(),
+            phrase: String::new(),
+        },
+    )
+    .await;
+    let detail = &refused(&ack).detail;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+    assert!(detail.contains("names no block"), "{detail}");
+}
+
+/// **A block of something else and a block of nothing are one answer.**
+///
+/// A block belongs to an entity, so an acknowledgement that distinguished the
+/// two would confirm that an entity exists — the disclosure the single refusal
+/// reason exists to prevent, arriving through a field nobody thinks of as
+/// naming an entity.
+#[tokio::test]
+async fn a_block_of_something_else_is_the_same_nothing_as_a_block_of_nothing() {
+    let w = World::new().await;
+    let (a, b) = two_notes(&w).await;
+    let (elsewhere, elsewhere_blocks) = note_with_blocks(&w, "- eggs\n").await;
+    let _ = elsewhere;
+
+    let nothing = anchored(&w, a, b, at(a, Uuid::new_v4(), "")).await;
+    let elsewhere = anchored(&w, a, b, at(a, elsewhere_blocks[0], "")).await;
+
+    assert!(is_not_available(&nothing));
+    assert!(is_not_available(&elsewhere));
+    assert_eq!(
+        refused(&nothing).detail,
+        refused(&elsewhere).detail,
+        "the two answers differ, and the difference is an oracle"
+    );
+    assert!(refused(&nothing).detail.is_empty());
+}
+
+/// **The decision worth reading twice: a phrase that is no longer there does
+/// not refuse the connection away.**
+///
+/// A client submits an anchor against the body it last saw. Somebody reworded
+/// that sentence meanwhile. Refusing would destroy the whole connection
+/// permanently — a refusal is an answer and the outbox holds no retry for it —
+/// because somebody else edited a sentence, which is a worse version of the
+/// thing the substrate prohibits. So the anchor gives way and the relation is
+/// formed without one.
+#[tokio::test]
+async fn a_phrase_that_is_no_longer_there_forms_the_relation_without_an_anchor() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "buy eggs on the way home\n").await;
+    let other = w.note(&w.one, "the other end").await;
+
+    // Somebody else rewords the sentence the anchor was formed against.
+    let base = w.counter(note).await;
+    w.submit(
+        &w.two,
+        edit_entity(
+            note,
+            base as u64,
+            v1::EntityContent {
+                specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                    body: Some("buy bread on the way home\n".into()),
+                    cleared: Vec::new(),
+                })),
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+
+    let ack = anchored(&w, note, other, at(note, blocks[0], "eggs")).await;
+    let id = relation_id(&ack);
+
+    // Formed, not refused...
+    assert_eq!(w.relation_lifecycle(id).await.as_deref(), Some("active"));
+    // ...and the block goes with the phrase rather than the anchor falling back
+    // to it. Where it was formed is still true and stays.
+    assert_eq!(anchor_of(&w, id).await, (Some(note.as_uuid()), None, None));
+}
+
+/// An edit carries an anchor, and an edit that does not carry one clears it.
+///
+/// A relation's content has no untouched state: there is no base counter to
+/// scope a write against and no part machinery over a relation, so an edit is
+/// the whole record. That was already true of the type and of a quantity, and
+/// the anchor joins them rather than acquiring a rule of its own.
+#[tokio::test]
+async fn an_edit_carries_the_anchor_and_an_edit_without_one_clears_it() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "- eggs\n- milk\n").await;
+    let other = w.note(&w.one, "the other end").await;
+
+    let id = relation_id(&anchored(&w, note, other, at(note, blocks[0], "")).await);
+
+    // Moved to the second entry.
+    w.submit(
+        &w.one,
+        edit_relation(
+            id,
+            v1::RelationContent {
+                anchor: Some(at(note, blocks[1], "milk")),
+                ..relation_between(note, other)
+            },
+        ),
+    )
+    .await;
+    assert_eq!(
+        anchor_of(&w, id).await,
+        (Some(note.as_uuid()), Some(blocks[1]), Some("milk".into()))
+    );
+
+    // And an edit carrying no anchor is an edit to a relation with no anchor.
+    w.submit(&w.one, edit_relation(id, relation_between(note, other)))
+        .await;
+    assert_eq!(anchor_of(&w, id).await, (None, None, None));
+}
+
+/// An anchored relation is not a duplicate of an unanchored one. Where a
+/// connection was formed is part of what distinguishes it.
+#[tokio::test]
+async fn an_anchored_relation_is_not_a_duplicate_of_an_unanchored_one() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "- eggs\n").await;
+    let other = w.note(&w.one, "the other end").await;
+
+    w.submit(
+        &w.one,
+        create_relation(Uuid::new_v4(), relation_between(note, other)),
+    )
+    .await;
+    let ack = anchored(&w, note, other, at(note, blocks[0], "")).await;
+    applied(&ack);
+}
+
+/// **Removing a block never fails a body write, beside an otherwise identical
+/// unanchored relation.**
+///
+/// Migration one declines a unique index over the unanchored pair for exactly
+/// this shape: a relation that loses its anchor becomes unanchored, collides
+/// with one already recorded between the same pair, and the block removal
+/// fails. *"A body edit must never fail because a relation lost an anchor, and
+/// that outranks refusing a duplicate structurally."*
+///
+/// Two things keep that true here, and the weaker one is the one to rely on.
+/// The relation does not become *fully* unanchored — where it was formed
+/// survives the block, so a residue remains and `is_duplicate` counts a residue
+/// as an anchor. But the guarantee does not rest on that: the removal path
+/// carries no duplicate check at all, so a later change to what counts as
+/// anchored cannot reintroduce the failure.
+#[tokio::test]
+async fn removing_a_block_never_fails_beside_an_identical_unanchored_relation() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "- eggs\n- milk\n").await;
+    let other = w.note(&w.one, "the other end").await;
+
+    // The unanchored one it will collide with, and the anchored one.
+    w.submit(
+        &w.one,
+        create_relation(Uuid::new_v4(), relation_between(note, other)),
+    )
+    .await;
+    let anchored_id = relation_id(&anchored(&w, note, other, at(note, blocks[0], "")).await);
+
+    // Remove the block the second is anchored to.
+    let base = w.counter(note).await;
+    let ack = w
+        .submit(
+            &w.one,
+            edit_entity(
+                note,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                        body: Some("- milk\n".into()),
+                        cleared: Vec::new(),
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await;
+    applied(&ack);
+
+    // Both relations are still here, and the second is now unanchored except
+    // for where it was formed.
+    assert_eq!(
+        w.relation_lifecycle(anchored_id).await.as_deref(),
+        Some("active")
+    );
+    assert_eq!(
+        anchor_of(&w, anchored_id).await,
+        (Some(note.as_uuid()), None, None)
+    );
+}
+
+/// A block anchor holds while its block remains, including through edits to
+/// the block's own text. This is the half of block identity that anchors rely
+/// on: rewording an entry does not detach a relation anchored to the entry.
+#[tokio::test]
+async fn a_block_anchor_holds_through_a_rewording_of_its_block() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "- eggs\n- milk\n").await;
+    let other = w.note(&w.one, "the other end").await;
+    let id = relation_id(&anchored(&w, note, other, at(note, blocks[0], "")).await);
+
+    let base = w.counter(note).await;
+    w.submit(
+        &w.one,
+        edit_entity(
+            note,
+            base as u64,
+            v1::EntityContent {
+                specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                    body: Some("- half a dozen eggs\n- milk\n".into()),
+                    cleared: Vec::new(),
+                })),
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        anchor_of(&w, id).await,
+        (Some(note.as_uuid()), Some(blocks[0]), None),
+        "rewording an entry detached a relation anchored to the entry itself"
+    );
+}
+
+/// **A phrase anchor is lost when its text is edited, and the relation
+/// survives without an anchor.**
+///
+/// The counterpart of the test above, and the one that separates the two kinds:
+/// the same edit that a block anchor rides out takes a phrase anchor with it,
+/// because the words the person pointed at are no longer there. The block goes
+/// with the phrase rather than the anchor falling back to it — both places the
+/// substrate states this say *without an anchor*, and re-pointing somebody's
+/// connection at the whole paragraph would be choosing a place they never did.
+#[tokio::test]
+async fn a_phrase_anchor_is_lost_when_its_text_is_edited() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "buy eggs on the way home\n").await;
+    let other = w.note(&w.one, "the other end").await;
+    let id = relation_id(&anchored(&w, note, other, at(note, blocks[0], "eggs")).await);
+
+    let base = w.counter(note).await;
+    w.submit(
+        &w.one,
+        edit_entity(
+            note,
+            base as u64,
+            v1::EntityContent {
+                specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                    body: Some("buy bread on the way home\n".into()),
+                    cleared: Vec::new(),
+                })),
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+
+    assert_eq!(w.relation_lifecycle(id).await.as_deref(), Some("active"));
+    assert_eq!(anchor_of(&w, id).await, (Some(note.as_uuid()), None, None));
+}
+
+/// An edit that leaves the phrase standing leaves the anchor standing. The rule
+/// is that the anchor's *text* survives, not that the block was untouched.
+#[tokio::test]
+async fn a_phrase_anchor_survives_an_edit_that_leaves_its_words_alone() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "buy eggs on the way home\n").await;
+    let other = w.note(&w.one, "the other end").await;
+    let id = relation_id(&anchored(&w, note, other, at(note, blocks[0], "eggs")).await);
+
+    let base = w.counter(note).await;
+    w.submit(
+        &w.one,
+        edit_entity(
+            note,
+            base as u64,
+            v1::EntityContent {
+                specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                    body: Some("buy eggs on the way back\n".into()),
+                    cleared: Vec::new(),
+                })),
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        anchor_of(&w, id).await,
+        (Some(note.as_uuid()), Some(blocks[0]), Some("eggs".into())),
+        "an edit elsewhere in the sentence took a phrase anchor with it"
+    );
+}
+
+/// **Where two people edit one block and both values are retained, anchors are
+/// judged against the version that landed.**
+///
+/// *"Where they edit the same block and one version is chosen, an anchor whose
+/// text survives holds, and one whose text does not leaves the relation intact
+/// without an anchor."* Both halves in one write: the phrase that is still in
+/// the stored text keeps its anchor, the phrase that is not loses it, and the
+/// conflict over the block is recorded either way.
+#[tokio::test]
+async fn after_a_conflict_over_one_block_the_surviving_phrase_keeps_its_anchor() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "buy eggs and bread today\n").await;
+    let other = w.note(&w.one, "the other end").await;
+
+    let eggs = relation_id(&anchored(&w, note, other, at(note, blocks[0], "eggs")).await);
+    let today = relation_id(&anchored(&w, note, other, at(note, blocks[0], "today")).await);
+    let base = w.counter(note).await;
+
+    let reword = |body: &str| {
+        edit_entity(
+            note,
+            base as u64,
+            v1::EntityContent {
+                specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                    body: Some(body.into()),
+                    cleared: Vec::new(),
+                })),
+                ..Default::default()
+            },
+        )
+    };
+
+    w.submit(&w.one, reword("buy eggs and milk today\n")).await;
+    let ack = w.submit(&w.two, reword("buy bread and milk today\n")).await;
+
+    // A conflict over the block, both values retained.
+    let conflict = applied(&ack).conflict.as_ref().expect("a conflict");
+    assert_eq!(conflict.block_ids, vec![blocks[0].as_bytes().to_vec()]);
+
+    // "today" is in the version that landed and keeps its anchor.
+    assert_eq!(
+        anchor_of(&w, today).await,
+        (Some(note.as_uuid()), Some(blocks[0]), Some("today".into()))
+    );
+    // "eggs" is not, and its relation survives without an anchor.
+    assert_eq!(w.relation_lifecycle(eggs).await.as_deref(), Some("active"));
+    assert_eq!(
+        anchor_of(&w, eggs).await,
+        (Some(note.as_uuid()), None, None)
+    );
 }

--- a/crates/altaird/tests/write_relations.rs
+++ b/crates/altaird/tests/write_relations.rs
@@ -906,7 +906,7 @@ async fn a_phrase_that_is_no_longer_there_forms_the_relation_without_an_anchor()
     assert_eq!(w.relation_lifecycle(id).await.as_deref(), Some("active"));
     // ...and the block goes with the phrase rather than the anchor falling back
     // to it. Where it was formed is still true and stays.
-    assert_eq!(anchor_of(&w, id).await, (Some(note.as_uuid()), None, None));
+    assert_eq!(anchor_of(&w, id).await, (None, None, None));
 }
 
 /// An edit carries an anchor, and an edit that does not carry one clears it.
@@ -1018,10 +1018,7 @@ async fn removing_a_block_never_fails_beside_an_identical_unanchored_relation() 
         w.relation_lifecycle(anchored_id).await.as_deref(),
         Some("active")
     );
-    assert_eq!(
-        anchor_of(&w, anchored_id).await,
-        (Some(note.as_uuid()), None, None)
-    );
+    assert_eq!(anchor_of(&w, anchored_id).await, (None, None, None));
 }
 
 /// A block anchor holds while its block remains, including through edits to
@@ -1092,7 +1089,7 @@ async fn a_phrase_anchor_is_lost_when_its_text_is_edited() {
     .await;
 
     assert_eq!(w.relation_lifecycle(id).await.as_deref(), Some("active"));
-    assert_eq!(anchor_of(&w, id).await, (Some(note.as_uuid()), None, None));
+    assert_eq!(anchor_of(&w, id).await, (None, None, None));
 }
 
 /// An edit that leaves the phrase standing leaves the anchor standing. The rule
@@ -1174,10 +1171,7 @@ async fn after_a_conflict_over_one_block_the_surviving_phrase_keeps_its_anchor()
     );
     // "eggs" is not, and its relation survives without an anchor.
     assert_eq!(w.relation_lifecycle(eggs).await.as_deref(), Some("active"));
-    assert_eq!(
-        anchor_of(&w, eggs).await,
-        (Some(note.as_uuid()), None, None)
-    );
+    assert_eq!(anchor_of(&w, eggs).await, (None, None, None));
 }
 
 /// The same guarantee on the other path that takes an anchor away.
@@ -1224,33 +1218,39 @@ async fn losing_a_phrase_never_fails_beside_an_identical_unanchored_relation() {
         w.relation_lifecycle(phrase).await.as_deref(),
         Some("active")
     );
-    assert_eq!(
-        anchor_of(&w, phrase).await,
-        (Some(note.as_uuid()), None, None)
-    );
+    assert_eq!(anchor_of(&w, phrase).await, (None, None, None));
 }
 
-/// **No body write can make a relation a duplicate, because no body write ever
-/// makes one fully unanchored.**
+/// **A relation that loses its anchor becomes a duplicate of one already
+/// recorded, and both stay.**
 ///
-/// The reason migration one's collision cannot arise, stated as a property
-/// rather than left implicit in the two tests above: both paths that take an
-/// anchor away keep `anchor_entity_id`, and `is_duplicate` counts that as an
-/// anchor. Where the connection was formed outlives the words and the block.
+/// The case migration one names, reachable at last. It was not, while a lost
+/// anchor left an entity behind: `is_duplicate` counted that residue and the
+/// collision could not form. Removing the residue restores the state the schema
+/// comment reasons about, so the outcome it requires can finally be observed
+/// rather than argued.
 ///
-/// This does not replace those tests. They assert the outcome the sentence
-/// requires — a body edit that lands — which stays true even if this property
-/// stops holding, because the body path consults no duplicate check at all.
+/// *"A relation that loses its anchor when its block is removed becomes
+/// unanchored, collides with an existing relation between the same pair, and
+/// the block removal fails. A body edit must never fail because a relation lost
+/// an anchor, and that outranks refusing a duplicate structurally."* So the
+/// body edit lands, two identical untyped unanchored relations coexist, and
+/// nothing tries to reconcile them.
 #[tokio::test]
-async fn no_body_write_leaves_a_relation_without_where_it_was_formed() {
+async fn a_relation_that_loses_its_anchor_becomes_a_duplicate_and_both_stay() {
     let w = World::new().await;
     let (note, blocks) = note_with_blocks(&w, "buy eggs today\n- milk\n").await;
     let other = w.note(&w.one, "the other end").await;
 
-    let phrase = relation_id(&anchored(&w, note, other, at(note, blocks[0], "eggs")).await);
-    let block = relation_id(&anchored(&w, note, other, at(note, blocks[1], "")).await);
+    let plain = relation_id(
+        &w.submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(note, other)),
+        )
+        .await,
+    );
+    let was_anchored = relation_id(&anchored(&w, note, other, at(note, blocks[1], "")).await);
 
-    // One write that edits the phrase away and removes the other block outright.
     let base = w.counter(note).await;
     applied(
         &w.submit(
@@ -1260,7 +1260,7 @@ async fn no_body_write_leaves_a_relation_without_where_it_was_formed() {
                 base as u64,
                 v1::EntityContent {
                     specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
-                        body: Some("buy bread today\n".into()),
+                        body: Some("buy eggs today\n".into()),
                         cleared: Vec::new(),
                     })),
                     ..Default::default()
@@ -1270,9 +1270,73 @@ async fn no_body_write_leaves_a_relation_without_where_it_was_formed() {
         .await,
     );
 
-    for id in [phrase, block] {
-        let (entity, b, p) = anchor_of(&w, id).await;
-        assert_eq!(entity, Some(note.as_uuid()), "where it was formed was lost");
-        assert_eq!((b, p), (None, None));
+    // Two records of one connection, both active, neither reconciled.
+    for id in [plain, was_anchored] {
+        assert_eq!(w.relation_lifecycle(id).await.as_deref(), Some("active"));
     }
+    assert_eq!(anchor_of(&w, was_anchored).await, (None, None, None));
+
+    // And the one that lost its anchor is now an ordinary unanchored relation,
+    // so forming a third is refused exactly as it would have been all along.
+    let ack = w
+        .submit(
+            &w.one,
+            create_relation(Uuid::new_v4(), relation_between(note, other)),
+        )
+        .await;
+    assert_eq!(refused(&ack).reason, v1::RefusalReason::Malformed as i32);
+}
+
+/// **A relation that lost its anchor is editable like any other.**
+///
+/// The defect that decided the residue's fate, kept as the test that would
+/// catch it coming back. While a lost anchor left an entity standing, an
+/// ordinary edit to such a relation had two bad outcomes and no good one: it
+/// erased that entity in silence, or — beside an identical unanchored relation
+/// — it was refused as *this connection is already recorded*, naming a
+/// connection the person had not mentioned. Neither needed a read path; the
+/// client only needs the identifier it minted itself.
+#[tokio::test]
+async fn a_relation_that_lost_its_anchor_can_still_be_edited() {
+    let w = World::new().await;
+    let (note, blocks) = note_with_blocks(&w, "buy eggs today\n").await;
+    let other = w.note(&w.one, "the other end").await;
+    let mentions = w.declare_type("mentions", true, false).await;
+
+    let id = relation_id(&anchored(&w, note, other, at(note, blocks[0], "")).await);
+
+    let base = w.counter(note).await;
+    applied(
+        &w.submit(
+            &w.one,
+            edit_entity(
+                note,
+                base as u64,
+                v1::EntityContent {
+                    specific: Some(v1::entity_content::Specific::Note(v1::NoteContent {
+                        body: Some("- milk\n".into()),
+                        cleared: Vec::new(),
+                    })),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await,
+    );
+
+    // An ordinary edit, carrying no anchor because the relation has none.
+    let ack = w
+        .submit(
+            &w.one,
+            edit_relation(
+                id,
+                v1::RelationContent {
+                    relation_type_id: Some(mentions.as_bytes().to_vec()),
+                    ..relation_between(note, other)
+                },
+            ),
+        )
+        .await;
+    applied(&ack);
+    assert_eq!(anchor_of(&w, id).await, (None, None, None));
 }


### PR DESCRIPTION
Last of nine slices of Wave 2.2. Stacked on #28. Serves anchors, which the plan lists for 2.2 and which were deliberately held until bodies had landed.

## What an anchor is

A relation may carry a record of where in a body it was formed. It attaches at a phrase within a block, or at the block itself. It belongs to the relation and not to the body — the body stays plain text, so removing the relation removes the anchor and rewrites nothing.

Wave 2.1 refused one, saying "an anchor locates into a block, and bodies are not served yet". That refusal expires here.

## The three behaviours, and where each lives

- **A block anchor holds while its block remains**, including through edits to the block's own text. Proved on `- eggs` → `- half a dozen eggs`, the case block identity matching was tuned for.
- **A phrase anchor is lost when its text is edited**, and the relation survives. *"Removing a person's connection as a side effect of them editing a sentence is not something the system does."*
- **A removed block leaves the relation active** without its anchor.

The middle one is not reachable from the relation write path at all — it happens when a **body** write changes a block's text, so it lives in `write/body.rs` beside the existing removal path. Without it a phrase anchor survives an edit that destroys the phrase it names, pointing at words that are no longer there. Both loss paths compare the block's **content**, not its verbatim slice, since the verbatim slice includes trailing whitespace and reordering paragraphs changes it without changing any paragraph.

## Two judgement calls worth reviewing on their own

**A phrase that no longer occurs in the block is accepted and degraded, never refused.** A refusal is final — the outbox does not retry it — so refusing would make a client with a slightly stale body lose *the whole connection* because somebody else edited a sentence. That is a worse version of what the substrate prohibits, applied at capture time; and the substrate already specifies degradation for the identical situation later in the entity's life, so accepting-and-degrading makes the two moments agree rather than behave oppositely.

**A lost phrase drops the block anchor too, rather than falling back to one.** The substrate says *without an anchor*, not "with a coarser one". Falling back would silently re-point a person's connection from the words they chose to the whole paragraph — the same class of error block identity matching deliberately refuses to make with over-eager matching.

## The residue, which was a mistake and is now removed

An earlier version of this work left `anchor_entity_id` behind when an anchor was lost, on the reasoning that *where the relation was formed is still true*. That was wrong, and it is worth saying why plainly.

`ON DELETE SET NULL` nulls only `anchor_block_id`; the entity survived because **the referential action is column-scoped, not because anything decided it should.** Prose was then written over an accident and carried into the phrase path by analogy.

Two authorities say the post-removal state is unanchored without qualification. The substrate: *"survives such an edit and loses its anchor"*, and *"where the block itself is removed the relation survives without its anchor."* Migration one, in the comment this work quoted throughout: *"a relation that loses its anchor when its block is removed **becomes unanchored**, collides with an existing relation between the same pair, and the block removal fails."*

**The residue disarmed the very case that comment exists to protect** — and the signal was a test reported as passing because "migration one's collision does not arise". The honest reading was not a stronger guarantee; it was that the state the schema reasons about had been changed. A test passing because the author changed the world to suit it is indistinguishable from a test passing because the case is handled.

**It was reachable, and not only through a read path.** With no `Query` and no `Changes` served: create an anchored relation, create an ordinary one between the same pair, let a body write remove the block, then edit the anchored relation. **It is refused as a duplicate**, citing a connection the person never mentioned. With the second relation absent, the same edit silently erases the residue instead.

Both loss paths now take all three columns in one statement, which also means the check constraint that `ON DELETE SET NULL` would otherwise violate is never approached rather than worked around a second time.

**The consequence is accepted deliberately:** migration one's collision becomes real. A relation that loses its anchor is genuinely unanchored and can duplicate one already recorded, and both stay. That is exactly what the schema describes and why it declined a unique index — *a body edit must never fail because a relation lost an anchor, and that outranks refusing a duplicate structurally.* The tests now exercise that case for real instead of passing because it had been made unreachable.

## Refusals, and why the unhelpful answer is the right one

An anchor entity that is not an endpoint refuses **malformed with detail**: the client already holds both endpoint identifiers, so saying so discloses nothing it does not have.

A block naming nothing and a block belonging to something else refuse **`NOT_AVAILABLE` with byte-identical empty detail**, and the reasoning now sits on the query rather than in the function header, because the person who "simplifies" that line is by definition somebody who did not read the header:

> The obvious improvement is to look the block up on its own and tell the client whether it does not exist or merely belongs to something else. That improvement is a disclosure: a block belongs to an entity, so an answer confirming a block identifier exists confirms that an entity exists — and it arrives through a field nobody thinks of as naming one, which is why it would survive a reading that was watching the endpoints.

An entity-only anchor is refused on input, and **nothing anywhere produces it**, so it is not a state this system has.

## `is_duplicate` changed twice

An anchor makes a connection distinguishable by where it was formed, so an anchored relation is never a duplicate. The function asked whether the *existing* row was unanchored, which was the whole question while nothing arriving could be anchored and became half of it afterwards — so **creating an anchored relation where an unanchored one already existed was refused as already recorded.** Found by a test after a reading of the same function had concluded it was still correct.

Removing the residue then changed its meaning again without changing a line: the arriving anchor is now `Some` exactly when a whole anchor resolved, so both sides ask the same question and there is no third state for them to disagree about.

## Verification

- `cargo test --workspace`: 32 targets, 458 tests, 0 failures.
- `prek run --all-files`: 13 hooks, all passed.
- The removal path was confirmed still load-bearing after the residue change rather than assumed: with it disabled, two tests fail; restored, both pass.

## Not settled here

The proto records that a phrase anchor carries its text only and **how it is located within a block is not settled.** Storage takes the text and nothing locates it. No test asserts a locating rule.
