### PR TITLE
📐 Wave 4, planned: the terminal client is a replica client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 # hand to allow --no-verify and friends for a window; never committed.
 .claude/.hooks-unlock
 
+# Worktrees for parallel lanes, checked out inside the repository. Each is a
+# working copy of this same repository, so committing one commits the tree into
+# itself. Remove a finished one with `git worktree remove`, not `rm -rf`.
+.claude/worktrees/
+
 # Rust build output (includes protoc/tonic codegen written to OUT_DIR)
 /target
 **/target

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repository is right now
 
-**Design documents plus the first two waves of the instance.** Everything in `docs/` specifies a self-hosted personal system ("Altair"); `crates/` is the beginning of it. Wave 0, all five Wave 1 lanes, and Wave 2.1 have landed — store bootstrap and the audience predicate, block division, the object store, token validation, the outbox conformance suite, and the intent spine. **Wave 2.2 onward — type content, file bodies, reclamation — is next and is not started.** There is no client, and the instance serves `Submit` and nothing else.
+**Design documents plus the instance's write and read paths.** Everything in `docs/` specifies a self-hosted personal system ("Altair"); `crates/` is the instance. Wave 0, all five Wave 1 lanes, Waves 2.1 through 2.3 and all three Wave 3 lanes have landed — store bootstrap and the audience predicate, block division, the object store, token validation, the outbox conformance suite, the intent spine, type content across all three domains, file bodies, literal retrieval, the change stream, and health. **Wave 2.4 — reclamation, the retention windows, the horizon value — was skipped and is still outstanding**, and Wave 3 proceeded without it. All six calls in the interface are served. There is no client.
 
 Consequences for working here:
 
@@ -50,6 +50,8 @@ altair-vision.md                          normative, permanent product identity
   ├── altair-data-model.md                assembled: every persistent thing, decides nothing
   ├── altair-v0-scope.md                  sequencing; defers, never amends
   │     └── altair-v0-implementation-plan.md
+  │           └── altair-wave-4-plan.md   the next wave only; sequencing and
+  │                                       verification, deliberately no module tree
   └── DR-001 … DR-007                     product/technology choices made against the above
 ```
 
@@ -92,9 +94,10 @@ Rules that follow from this and are easy to violate:
 What has actually been built so far, which is observation rather than a settled tree:
 
 ```text
-crates/altaird/            the instance: store/ (audience, tx, entity, ids), body/, objects/,
-                           auth/, write/ (parts, provenance, changes, intent, entity, relation),
-                           service.rs (Submit served, the other five unimplemented)
+crates/altaird/            the instance: store/ (audience, tx, entity, relation, search, health,
+                           ids), body/, objects/, auth/, read/ (changes),
+                           write/ (parts, provenance, changes, intent, entity, relation, body,
+                           specific/ one module per domain), service.rs (all six calls served)
 crates/altaird/migrations/ 0001_initial.sql and 0002_write_provenance.sql, not re-derived
 crates/altair-proto/       generated contract types (protox + tonic)
 crates/altair-conformance/ the outbox harness and a null client stub
@@ -108,8 +111,8 @@ Seven waves. Waves 1–3 are planned against reality; Wave 5 onward names outcom
 |---|---|---|
 | 0 · Plumbing | Cargo workspace, proto codegen in the build, migration runner (`0001_initial.sql` as migration one), integration harness, CI | Harness stands up a **real PostgreSQL**, not a mock — the audience predicate, both indexes and `SKIP LOCKED` are Postgres behaviour. Done when a fresh checkout runs one command and passes an empty suite. |
 | 1 · Foundations | 1.1 store bootstrap · 1.2 block division · 1.3 object store · 1.4 token validation · 1.5 outbox conformance suite | Five genuinely independent lanes, one worktree each. 1.5's deliverable is a **red suite** — every scenario runs and fails. |
-| 2 · Write path | 2.1 intent spine, **including relations and the served submission call** — landed · 2.2 type content, all three domains · 2.3 file bodies · 2.4 reclamation | 2.1 is sequential and load-bearing; do not parallelise the spine, do parallelise what hangs off it. Re-planned at the Wave 1 boundary: **migration two** opens 2.1, adding per-part write provenance and a lifecycle on a relation. |
-| 3 · Read path | 3.1 literal retrieval arm · 3.2 change stream and horizon · 3.3 health | Literal only. Build the instance half of the change stream even though the TUI need not consume it — omitting the instance side is one-way. |
+| 2 · Write path | 2.1 intent spine, **including relations and the served submission call** — landed · 2.2 type content, all three domains — landed · 2.3 file bodies — landed · 2.4 reclamation — **not started** | 2.1 is sequential and load-bearing; do not parallelise the spine, do parallelise what hangs off it. Re-planned at the Wave 1 boundary: **migration two** opens 2.1, adding per-part write provenance and a lifecycle on a relation. |
+| 3 · Read path | 3.1 literal retrieval arm · 3.2 change stream and horizon · 3.3 health — all landed | Literal only. The six served calls include **no way to fetch an entity by identity and no way to list what a container holds**: `Query` is the literal arm, it cannot enumerate, and it answers with entities and never relations. The change stream is the only source of either. |
 | 4 · Terminal client | 4.1 Rust outbox (turns 1.5 green) · 4.2 ratatui client | **First useful day.** The TUI carries the whole editing surface; there is no browser and no second client. |
 | 5 · Semantic | derivation worker · inference boundary and bi-encoder · semantic arm and fusion | The embedding model is chosen **here**, against a real corpus, and fixes the schema dimension. |
 | 6 · Second client and ops | message bridge · packaging · backup/restore/upgrade | The bridge is the first test of whether the interface carries the obligations rather than the TUI's code. |
@@ -124,9 +127,11 @@ Specifics worth knowing before touching the relevant lane:
 - **The change sequence allocates from a single position row in the write transaction, so every write serialises on it. That is intended** — a sequence leaves gaps and a poller can read past an uncommitted position and never see it. Record why prominently near the code; this is exactly the shape of thing a future reader removes as an obvious bottleneck.
 - **`crates/altaird/migrations/0001_initial.sql` already contains Wave 2's test plan**, under *"Checks this file cannot make, which the write path owes"* (line 886). Turn that list into the suite. The plan document still calls this file `altair-schema.sql`; the name changed when it was adopted as migration one. **The list spans the whole wave rather than 2.1 alone** — the plan says which item closes which lines.
 - **The schema's `ON DELETE CASCADE`s never fire under erasure**, because every one hangs off a delete of the `entity` row and erasure leaves a tombstone. The erase path removes blocks, dates, assignments, property values, side-table rows, event records, embeddings, derived text, and the relations at either end explicitly.
-- **Two schema gaps were named for Wave 0 and neither closed there, correctly.** The embedding dimension stays a placeholder until Wave 5 chooses the model, which is its own trigger; cycle prevention in nested locations and categories is a write-path check owned by 2.2, because both are type content.
+- **Two schema gaps were named for Wave 0 and neither closed there, correctly.** The embedding dimension stays a placeholder until Wave 5 chooses the model, which is its own trigger. Cycle prevention in nested locations and categories was a write-path check owned by 2.2 and landed there, in `write/specific/nesting.rs`.
 - **Outstanding derivation is computed from provenance in the store, never from the queue.** Losing the queue costs time, not reportability.
-- **The horizon is null, or longer than every other retention window. A middle value is a bug**, not a tuning choice.
+- **The read path cannot write, and this is enforced rather than reviewed.** `store::begin_read` makes a genuine `INSERT`/`UPDATE`/`DELETE` from inside `read/` a database error. The other half of the constraint — no record of what was asked — is the module's own to keep.
+- **A relation reaches the change stream only when the member can see both of its endpoints**, via `relation::endpoints_visible`. The row-level filter in the page query covers entities; relations are filtered after loading, and dropping that check is a leak the SQL will not catch.
+- **The horizon is null, or longer than every other retention window. A middle value is a bug**, not a tuning choice. Nothing implements one yet: 2.4 did not land, so there is no retention constant anywhere and nothing trims the change sequence — which is the only reason a client can still rebuild from position zero.
 
 **Deferred decisions have triggers, not dates** — the table at the end of the plan names the moment each becomes cheap to take correctly (embedding model at Wave 5, bridge transport at 6.1, retention constants at 2.4, the surrogate key on `entity` only when insert cost tracks table size). Do not take one early.
 
@@ -182,7 +187,7 @@ Match the existing register — these documents have a deliberate and consistent
 Observations from building the intent spine that 2.2, 2.3, and 2.4 would otherwise re-derive.
 
 - **A part is named in one place.** `crates/altaird/src/write/parts.rs` holds the wire field number, the store's text name, and the conflict row's spelling, and `tests/write_parts.rs` keeps them in step. Adding a type-specific part in 2.2 means adding it there, not beside the code that writes it.
-- **Type content is not applied yet, deliberately.** 2.1 creates each type's side-table row with defaults; the fields inside `content.specific` are read for the type tag and nothing else. That is the plan's division, and it is invisible in v0 because no client exists before Wave 4.
-- **Three refusals expire.** A file create, an anchor on a relation, and an explicit `category_position` are all refused as malformed with a detail saying why. Each waits on a lane that is named: 2.3, 2.2, and whatever first reorders.
+- **Type content is applied, as of 2.2.** 2.1 created each type's side-table row with defaults and read `content.specific` for the type tag alone; `write/specific/` now writes guidance, knowledge, tracking and categories. What still refuses is a type v0 defines and never writes — routines, focus sessions, check-ins — and it refuses distinguishably, with `tests/unwritten_tables.rs` saying which.
+- **The three refusals 2.1 named have all expired.** A file create landed at 2.3, an anchor on a relation at 2.2, and an explicit `category_position` is now accepted in `write/content.rs`. Kept here because the shape is the useful part: a refusal that waits on a named lane, carrying a detail saying which.
 - **Erasure's dependent-table list is a constant**, `DEPENDENT_TABLES` in `write/entity.rs`. A new table holding entity content is one line there and one line in `tests/write_lifecycle.rs`, and forgetting is silent because the schema's cascades never fire.
 - **The guards are blunt on purpose and were sharpened twice here.** `WritePath::new` tripped the object-store boundary on `Path::`, and the wire's audience field tripped the one-predicate column check. Both now match at a word boundary, and the two whole-tree checks that reason about the instance skip test sources — a test asserting that both paths call one predicate has to be able to read past it. Watch a guard fail on a deliberate violation before and after touching one.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Licence: AGPL-3.0-or-later](https://img.shields.io/badge/licence-AGPL--3.0--or--later-blue)](LICENSE)
 
 [![Status: pre-alpha](https://img.shields.io/badge/status-pre--alpha-orange)](#status)
-[![Waves 0 and 1 complete](https://img.shields.io/badge/waves-0%20and%201%20complete-yellowgreen)](docs/altair-v0-implementation-plan.md)
+[![Waves 0 to 3 complete](https://img.shields.io/badge/waves-0%20to%203%20complete-yellowgreen)](docs/altair-v0-implementation-plan.md)
 [![Rust edition 2024](https://img.shields.io/badge/rust-edition%202024-dea584)](Cargo.toml)
 [![PostgreSQL 18 with pgvector](https://img.shields.io/badge/postgresql-18%20with%20pgvector-336791)](docs/DR-002-postgresql-structured-store.md)
 
@@ -17,7 +17,7 @@ One instance serves one household. Nobody else can raise the price, change the t
 
 ## Status
 
-**Early construction.** The design is written and the first code has landed; there is no running instance yet and nothing to install.
+**Early construction.** The design is written and the instance answers every call in its interface; there is no client yet and nothing to install.
 
 | Part | State |
 |---|---|
@@ -26,8 +26,8 @@ One instance serves one household. Nobody else can raise the price, change the t
 | Structured store schema (`crates/altaird/migrations/`) | `0001_initial.sql` is migration one, applied and exercised on PostgreSQL 18.6 with pgvector 0.8.6. `0002_write_provenance.sql` adds per-part write provenance and a lifecycle on a relation |
 | Wave 0 · plumbing | Landed. Workspace, proto codegen, migration runner, a real-Postgres test harness, CI |
 | Wave 1 · foundations | Landed. Store bootstrap and the audience predicate, block division, the object store, token validation, and the outbox conformance suite |
-| Wave 2 · write path | 2.1, the intent spine, has landed: identity and idempotent replay, the counter and conflict detection, the change sequence, relations, lifecycle, and the served submission call. Type content, file bodies, and reclamation are next |
-| Wave 3 · read path | Literal retrieval, the change stream and its horizon, health |
+| Wave 2 · write path | 2.1 the intent spine, 2.2 type content across all three domains, and 2.3 file bodies have landed. **2.4, reclamation, was skipped and is still outstanding** — there is no retention window, no horizon value, and nothing sweeps |
+| Wave 3 · read path | Landed. Literal retrieval, the per-member change stream, and health. All six calls in the interface are now served |
 | Wave 4 · terminal client | The first useful day. Nothing before it is usable software |
 | Waves 5 and 6 | Semantic retrieval, then the message bridge and operations |
 

--- a/docs/altair-v0-implementation-plan.md
+++ b/docs/altair-v0-implementation-plan.md
@@ -68,9 +68,9 @@ flowchart TB
         R3["Health"]
     end
 
-    subgraph W4["Wave 4 · The terminal client"]
-        C1["Rust outbox"]
-        C2["Terminal client"]
+    subgraph W4["Wave 4 · The terminal client, one lane"]
+        C1["Device store, outbox face:<br/>the conformance suite goes green"]
+        C2["Device store, replica face,<br/>and the terminal client"]
     end
 
     subgraph W5["Wave 5 · Semantic"]
@@ -107,6 +107,7 @@ flowchart TB
     A1 --> C1
     C1 --> C2
     R1 --> C2
+    R2 --> C2
 
     A2 --> S1
     S1 --> S2
@@ -292,6 +293,8 @@ Small, and hangs directly off erasure rather than waiting for a later wave.
 
 **Done when:** an erasure followed by a pass leaves no bytes, a pass over a healthy store changes no answer to any query, and a test refuses a horizon set between two other retention windows.
 
+> ⚠️ **This did not land, and Wave 3 proceeded without it.** The tree goes 2.1, 2.2, 2.3, Wave 3; there is no retention constant and no horizon value anywhere in the instance, and `Changes` derives its horizon implicitly from the earliest surviving change row. Two consequences, and the second is the one that matters. Nothing expires out of the deleted holding state, so a surface drawing an expiry date is drawing a promise the instance does not keep. And because nothing trims the change sequence, `Changes(since=0)` still replays the whole history — which is the only reason a client can rebuild at all. **Whoever picks this up owes clients a rebuild path before the first row is trimmed**, since trimming without one turns every client's rebuild into `PositionUnanswerable` with nowhere to go. That is a stronger obligation than this item was written with.
+
 ---
 
 ## Wave 3 · Read path, literal only
@@ -317,6 +320,8 @@ Three lanes, parallel with each other.
 
 The architecture explicitly permits a client that always fetches current state and never uses the change stream, and calls it conforming. Omitting the instance side is one-way; omitting the client side is not.
 
+> ℹ️ **The instance half was right and the sentence about the client was wrong.** "Always fetches current state" names no call, and the served interface has none. `Query` is the literal arm, whose predicate matches nothing when the text is empty, so it cannot enumerate; its `Result` carries an entity and never a relation, so backlinks, `uses` commitments and the ladder graph are unreachable through it. `Changes` is the only surface that yields a relation at all, which makes it the only source of client state, and a rebuild from nothing **is** `Changes(since=0)`. The conforming client that never touches the change stream is not currently constructible, and Wave 4 is where that is discovered. Recorded rather than deleted, because the reasoning was sound against the architecture and wrong against the wire, and that gap is worth being able to see.
+
 - Per-member change set assembly, filtered at the source rather than late.
 - Position past the horizon returns `PositionUnanswerable`, which is an outcome and not an error.
 - The horizon is null, or longer than every other retention window. **A middle value is a bug**, not a tuning choice.
@@ -337,32 +342,56 @@ Outstanding derivation is computed from provenance in the store, never from the 
 
 **Where the project becomes something you use rather than something you test.**
 
-### 4.1 Rust outbox
+**Re-planned at the Wave 3 boundary, 2026-08-19.** Two things were settled before any of this was written, and both came out of reading the served interface rather than the documents:
+
+- **The terminal client is a replica client, and this is not a choice.** The instance offers no way to read an entity by identity and no way to list what a container holds. `Query` is the literal arm and cannot enumerate; it answers with entities and never with relations. Every screen that is not search — the ladder, the tracking tree, a detail with its derived backlinks — is assembled on the device from what `Changes` delivered. §3.2 carries the correction.
+- **4.1 and 4.2 are one lane, because they are one store.** They were planned as separable and are not. The outbox owes durable local acceptance and has to answer what the person captured while the instance is unreachable; the replica owes the same store the instance's version of the same entities. Two stores would put "what do I show" in neither of them.
+
+### 4.1 The device store, outbox face
 
 The conformance suite from 1.5 goes green.
 
 Durable, ordered per entity, idempotent, non-blocking, silent while waiting and never silent while failing. The suite defines it; do not add behaviour it does not require.
 
+**This face lands first, before anything is drawn.** Thirty-five scenarios turning green one at a time is the deliverable Wave 1.5 was built to produce, and it is only legible if nothing else is moving at the same time.
+
 **Done when:** every scenario in sections A through G passes.
 
-### 4.2 Terminal client
+### 4.2 The device store, replica face, and the terminal client
 
-ratatui. The deliberate surface: where bodies are written and where the work that is not capture happens.
+ratatui over crossterm, so Linux and Windows are both served. The deliberate surface: where bodies are written and where the work that is not capture happens.
 
 **It carries the whole editing surface**, because there is no second client to fall back to and no browser. Everything the instance can do is reachable here or is not reachable at all in v0.
+
+The replica half: seeded by `Changes(since=0)`, kept current by polling, and holding pending local writes in the same store as the instance's truth.
+
+**The invariant this wave exists to keep:** what the person sees is instance truth overlaid with pending local writes, and a pending write never becomes invisible because the instance is unreachable. Its other half is already a standing constraint — no surface ever *counts* what is pending. The suite permits exactly one number anywhere in the client, and it is how many the instance refused.
 
 Scope:
 
 - **Capture**, on the fast path, never stopping to ask.
 - **Ladder work**: campaigns, arcs, quests, states, moving between them.
-- **Body composition**: markdown, with the writing surface as the place relations are formed at the point the thought occurred.
+- **Body composition**, handed to the person's own editor rather than written here.
 - **Relations**, typed and untyped, including the create-from-reference gesture where nothing matches.
 - **Tracking**: items, locations, asserting amounts, "just mark it lower."
 - **Retrieval**, across all three domains in one pass, with the answer's state visible.
 - **Fault signalling and silence.** Depth is never shown. A refusal is.
 - **Token flow.** Device flow unless something argues otherwise.
 
+**A body is written in `$EDITOR`; the fast path never leaves the client.** The client suspends, the child inherits the terminal, and the text that comes back is submitted whole. A single line is never worth that, so capture, a field, a search and the word typed to confirm an erasure all stay here — capture that stops to ask is not on the fast path. Resolution is `$ALTAIR_EDITOR`, then `$VISUAL`, then `$EDITOR`, then whatever `nvim` is on the path; having none of them is a **fault** rather than a wait, because no amount of waiting produces an editor.
+
+**This costs less than it appears, because the relation gesture was never inside the editor.** The wire says a body is plain text with no relation markers in it, and that a client never divides one, so a block identity does not exist until the instance has divided and answered. An anchor names a block. Forming a relation from a selection was therefore always a gesture over blocks that came back, whoever wrote the text — the editor holds prose, and what Altair relates against is the division. What is genuinely given up is the promise that the buffer is kept as the person types: the client owns the file the editor writes into, so what survives a crash is that file, recovered on the next launch, and the help surface says that rather than the older, now untrue thing.
+
+**What the surface does not reach in v0**, decided against the mock-ups rather than discovered while building them. Each is refused for a reason that expires, in the same way 2.1 refused a file create:
+
+- **Versions.** Deferred in v0, so nothing writes a version row and there is nothing for a restore to put back. The screen is a view over an empty table.
+- **The holding window's expiry.** A deleted thing shows that it is deleted and not when it stops being so, because [2.4](#24-reclamation) did not land and nothing expires.
+- **A conflict, reached for real.** Both retained sides render, driven by a fixture. Reaching one needs a second writer, which arrives with the bridge at 6.1.
+- **Templates as a gesture**, and creating one thing from the shape of another. The tables exist; the plan already defers the gestures.
+
 **Nothing about this client may become the definition of a client.** DR-006's obligation: a second client arriving must not discover that the first one's habits were load-bearing.
+
+**The visual language is settled and lives outside this repository**, in a Claude Design project holding the screens in both themes. It is deliberately not a terminal convention: no box-drawing frames, no tree glyphs, no gutter, no modal block. Two things in it do not survive contact with a terminal and are the client's to fix rather than the design's. Its state family, its arrows and its hairline indent are all East-Asian-Width *ambiguous*, so terminals disagree about how many cells each occupies and columns drift on somebody else's; the mark, the disclosure triangles and the return and delete keycaps are neutral and safe. And one screen binds a key that does not exist off a Mac.
 
 **Done when:** you capture into it daily and stop reaching for Lattice.
 

--- a/docs/altair-wave-4-plan.md
+++ b/docs/altair-wave-4-plan.md
@@ -1,0 +1,332 @@
+# Altair Wave 4 Plan · The Terminal Client
+
+**Status:** Accepted for build. Sequencing and verification only.
+**Date:** 2026-08-19
+**Governed by:** Altair v0 Implementation Plan, Component Model, DR-004 through DR-007.
+**Related:** `conformance/scenarios.md`, `proto/altair/v1/altair.proto`, `crates/altair-conformance/README.md`
+
+---
+
+## What this document is
+
+**The next wave, planned at its own boundary, and nothing beyond it.** It decides what
+Wave 4 builds, in what order, and how each piece is known to work. It records the three
+decisions that had to be taken before any of it could be sequenced, with the
+alternatives, so none of them is re-argued.
+
+**It decides no module tree.** The implementation plan prescribes no file list and no
+directory layout, and this document does not smuggle one in. Every item below is an
+outcome with a verification condition; where a path appears it is a file that already
+exists. What the crate is called and how it divides is decided while implementing.
+
+**It amends nothing above it.** Where this document and the implementation plan
+disagree, the implementation plan is right and this one gets corrected.
+
+---
+
+## What Wave 3 taught that the plan did not know
+
+Three findings, all from reading the served interface rather than the documents.
+
+**The terminal client is a replica client, and this was never a choice.** The instance
+offers no way to read an entity by identity and no way to list what a container holds.
+`Query` is the literal arm: its predicate matches nothing when the text is empty, so it
+cannot enumerate, and its `Result` carries an entity and never a relation. Every screen
+that is not search — the ladder, the tracking tree, a detail with its derived backlinks
+— is assembled on the device from what `Changes` delivered. A rebuild from nothing
+**is** `Changes(since=0)`.
+
+**Wave 2.4 was skipped, and that is currently load-bearing.** Nothing trims the change
+sequence, so position zero is always answerable. A client can rebuild today because a
+wave did not happen. That is worth knowing before somebody closes the gap.
+
+**4.1 and 4.2 are one lane, because they are one store.** The outbox owes durable local
+acceptance and has to answer what the person captured while the instance is unreachable.
+The replica owes the same store the instance's version of the same entities. Two stores
+would put "what do I show" in neither of them.
+
+---
+
+## The shape of the work
+
+```mermaid
+flowchart TB
+    subgraph OUTBOX["4.1 · the device store, outbox face"]
+        S1["stage 1 · Foundation<br/>the store, and the suite pointed at it"]
+        S2["stage 2 · Outbox<br/>thirty-five scenarios, section by section"]
+    end
+
+    subgraph CLIENT["4.2 · replica face, and the terminal client"]
+        S3["stage 3 · Canary<br/>one entity, end to end, against a real instance<br/>needs a database, so verified on Linux"]
+        S4["stage 4 · Replica<br/>rebuild, catch-up, and the overlay<br/>needs a database, so verified on Linux"]
+        S5["stage 5 · Shell<br/>both themes, the keys, the editor handoff"]
+        G1["stage 6 · browse and find"]
+        G2["stage 6 · create and update"]
+        G3["stage 6 · when it goes sideways"]
+    end
+
+    S1 --> S2 --> S3 --> S4 --> S5
+    S5 --> G1
+    S5 --> G2
+    S5 --> G3
+
+    style S2 fill:#e6f4ff,stroke:#2b7fd9
+    style S4 fill:#e6f4ff,stroke:#2b7fd9
+```
+
+**Six stages, not six waves.** The implementation plan names two items in this wave,
+4.1 and 4.2, and both keep their meaning: **4.1 is finished at the end of stage 2**,
+which is the moment the conformance suite goes green, and 4.2 is everything after it.
+The numbering matters beyond this document — a CI job, a task description and the
+conformance crate's own prose all say "Wave 4.1" and mean the outbox.
+
+**Stages 1 to 5 are sequential and that is forced rather than chosen**, because they are
+successive layers of one store and one seam. Only the screens genuinely parallelise:
+three groups touching different screens over a shell that is already settled.
+
+**Every stage but the middle two runs on both platforms.** The canary and the replica are
+integration against a real instance and therefore against a database; everything else —
+the store, the outbox against its fake instance, the shell and the screens — needs
+neither, and is verified on Linux and Windows from the first commit.
+
+---
+
+## Decisions taken here
+
+### The store holds encoded entities, not columns mirroring the wire
+
+**An entity is kept as its encoded `Entity` message, keyed by identity, with small index
+tables beside it for the orders the screens navigate by.** The client does not shred the
+wire into a local schema.
+
+This is the decision that removes the most work. A client schema mirroring `Entity`
+would have to change every time the contract grows a field, which the contract is
+explicitly designed to do — field numbers are permanent and closing a recorded gap adds
+a field. Holding the message whole means the proto can grow without a client migration,
+a rebuild is a truncate and a replay rather than a reconciliation, and nothing about the
+storage forecloses export, which DR-001 requires of everything.
+
+**Reversible.** The index tables are derived from the messages and can be rebuilt or
+re-shaped without touching what is stored.
+
+### The device store is SQLite, through `rusqlite`
+
+**The deciding argument is not SQL.** Sections B and F of the conformance scenarios kill
+the client process without warning and then assert what survived. The durability
+primitive under that must not be new code.
+
+Everything else follows rather than leads: the captures list, the ladder, the tracking
+tree and the deleted list all want ordered scans, which come free; it is one file to
+back up; and the bundled build removes a system dependency on Windows.
+
+> **Rejected: `redb`.** A pure-Rust build is genuinely nicer, and on a project that must
+> compile cleanly on two platforms that counts for something. It loses on the two things
+> that matter more — every index and every ordering becomes hand-rolled, and surviving
+> `SIGKILL` becomes our own correctness problem rather than a property we inherit.
+
+**Reversible**, behind the store's own boundary, and the encoded-entity decision above is
+what keeps it so.
+
+### The conformance adapter is a mode of the real client, not a lookalike
+
+**The adapter is a hidden mode of the client's own binary.** The suite drives it over one
+newline-delimited JSON channel, as `crates/altair-conformance/README.md` describes, and
+Wave 4 flips one function in `crates/altair-conformance/tests/scenarios.rs` to point at
+it.
+
+A separate adapter binary would be a second implementation of local acceptance, and the
+suite would then be judging something shaped like the client rather than the client. The
+scenarios observe two boundaries only, so a mode that speaks the channel and otherwise
+uses exactly the same store is the honest arrangement.
+
+> **Rejected: a second fake instance.** `altair_conformance::instance::FakeInstance` is
+> already public, already accepts, refuses, stalls and drops connections, and already
+> records what arrived. The outbox develops against it. It answers `Submit` and
+> `PutBody` and leaves the rest unimplemented.
+>
+> **The replica therefore develops against a real instance**, which is better: it makes
+> the canary a genuine end-to-end proof rather than a proof about a mock.
+
+### Windows is tested from the first commit, and the instance is not tested at all
+
+**The client's tests take no database, and CI runs them on both platforms from stage 1.**
+Not as a late verification pass: the Windows-specific surface is almost entirely in the
+first two stages. The bundled SQLite build is a toolchain question that fails first; an
+unwarned kill is `TerminateProcess` rather than a signal, and section B is entirely about
+surviving one; the adapter's newline-delimited channel is where a carriage return breaks
+something quietly rather than loudly; and the harness hands the client a durable
+directory and an ephemeral one, which are names for concepts Windows does not have.
+Finding all four at the end of the wave means finding two of them as flakiness.
+
+**The split falls along the stages.** Foundation, outbox, shell and screens need no
+database — the outbox develops against the conformance crate's fake instance — so they
+run on both platforms. The canary and the replica are integration against a real
+instance and stay Linux-only. **The most valuable Windows job in this plan is the
+conformance suite**, because it is the one that proves durable local acceptance under a
+kill, on the platform where a kill is least like the one it was written against.
+
+**One scenario needs a Windows path.** The harness is already portable — `kill` is the
+standard library's, every dependency is cross-platform, and the single `#[cfg(unix)]`
+behaviour is making the state directory unwritable, which A4 alone uses. On Windows that
+is an access control entry rather than a mode bit. Thirty-four scenarios need nothing.
+
+> **The instance stays Linux-only, deliberately.** `altaird` is a self-hosted server,
+> DR-002 pins PostgreSQL, and the deployment story has never been anything else. Recorded
+> here so that three Linux jobs are read as a decision rather than as an oversight
+> somebody later corrects.
+
+**Reversible**, and cheap in this direction only. Adding a platform once the code assumes
+one is the expensive direction, which is the whole argument for taking it at stage 1.
+
+### Two glyph sets, and no layout that depends on a glyph's width
+
+**The design's glyphs are the default, a narrow-safe set sits behind configuration, and
+nothing is aligned by measuring a glyph.** Each renders into a padded cell of fixed
+width.
+
+The locked design's state family, its arrows and its hairline indent are all
+East-Asian-Width *ambiguous*: terminals disagree about whether each occupies one cell or
+two, and where they disagree, columns drift. The mark, the disclosure triangles and the
+return and delete keycaps are neutral and safe.
+
+> **Rejected: substituting globally**, which damages a settled design over a hazard most
+> terminals do not have. **Rejected: measuring at startup**, because terminals answer
+> that question unreliably and a wrong answer is worse than a fixed cell.
+
+One separate correction, which is a bug rather than a decision: the deliberate-create
+screen binds a key that does not exist off a Mac.
+
+---
+
+## The stages
+
+### Stage 1 · Foundation — part of 4.1
+
+- The workspace crate, depending on the generated contract and not on the instance.
+- The device store: open, durable write, read back, holding entities as encoded messages
+  with index tables beside them.
+- The adapter mode, speaking the channel the harness expects.
+- `client_under_test()` repointed away from the null stub.
+
+- The test split: the client's own tests take no database, and CI runs them on Linux
+  and Windows. A4's unwritable-storage step gains a Windows path or an explicit skip.
+
+**Done when:** the workspace lints clean under the repository's own clippy gate;
+`mise run conformance` still reports red — now against the real client rather than
+against a stub that implements nothing; and both platforms report that red identically.
+
+### Stage 2 · Outbox — completes 4.1
+
+Sequential, and the longest stretch in this wave without something to look at. Taken
+section by section, in the scenarios' own order: acceptance, durability under an
+unwarned kill, ordering per entity, idempotent replay, non-blocking, silence and
+signalling, and the outcomes the instance returns.
+
+**Silence and signalling is the hard one** — nine scenarios, and almost all of them
+assert that the client is showing the person nothing at all.
+
+**Done when:** every scenario in sections A through G passes **on both platforms**, and
+the ledger says so on each.
+**Nothing here may make a scenario pass without an outbox behind it**; that is the one
+way to destroy a deliverable Wave 1.5 spent itself producing.
+
+### Stage 3 · Canary — opens 4.2
+
+**One entity, the whole way through, before anything is generalised.** Captured in the
+client, held locally, replayed to a real instance, returned through `Changes`, landed in
+the replica, and drawn on the captures list.
+
+**Done when:** with the instance stopped, a capture is accepted and shown; the instance
+is started; the row arrives without the person asking.
+
+### Stage 4 · Replica
+
+- Rebuild from `Changes(since=0)`, and incremental catch-up from a held position.
+- The overlay: instance truth with pending local writes over it.
+- `ConflictRetained` resolving back into the overlay, with both sides kept.
+- The projections the screens navigate by — the captures order, the ladder, the location
+  tree, relations read from both ends.
+
+**Done when:** a rebuild and an incremental catch-up over the same history produce the
+same state, shown by a property test; and a pending write stays visible across an
+instance that cannot be reached.
+
+### Stage 5 · Shell
+
+- Both themes as a token swap over one set of markup.
+- The glyph table, the keycaps, the modal pill, the section rules.
+- The help surface, which is the only place the client's promises are written in the
+  person's own words and should be checked against the substrate the way an assembled
+  document is.
+- The editor handoff, and recovering the file after a crash mid-composition.
+- Token flow.
+
+**Done when:** each element has a snapshot in both themes, and an editor round trip
+returns what was written on both platforms — including the case where the configured
+editor is not installed, which is a fault and not a wait.
+
+### Stage 6 · Screens
+
+Three groups, genuinely parallel, over a shell that is already settled: browse and find;
+create and update; when it goes sideways.
+
+**Done when:** every screen has a snapshot in both themes and the whole tree passes
+`prek run --all-files`.
+
+---
+
+## Pinned invariants
+
+**Written down because these are what a long build erodes**, not because they are new.
+Re-read them at each stage boundary.
+
+- The audience predicate never moves to the client. A client narrows what it already
+  holds and can never widen it.
+- Acceptance is local and durable before it is shown. Credentials and connectivity do
+  not participate.
+- **Exactly one number exists anywhere in this client**, and it is how many the instance
+  refused. No queue depth, no badge, no counter that rises while the person is away.
+- A stale base counter is never a rejection.
+- Bytes before the record on creation.
+- The client never divides a body, and a body carries no relation markers. Both are the
+  wire's words.
+- Waiting is silent and faults signal. An unreachable instance and an expired session
+  are the same wait, and neither is ever a login page.
+- No habit of this client becomes the definition of a client.
+
+---
+
+## Non-goals
+
+**The fence. Downstream checks measure correctness, not sprawl.**
+
+- Versions, and the holding window's expiry.
+- A conflict reached for real, as opposed to rendered from a fixture.
+- Template gestures, and creating one thing from the shape of another.
+- Semantic retrieval, the derivation worker, and the inference boundary.
+- Reclamation, retention windows, and choosing the horizon's value.
+- A second client, packaging, backup and restore.
+- **Any change to the instance at all.** Wave 4 adds no call, no field and no migration.
+
+---
+
+## Deliberately not decided
+
+- **What the crate is called and how it divides.** Decided while implementing, as every
+  wave before this one was.
+- **How much history the client keeps once it has caught up.** Nothing forces an answer
+  until something trims, and nothing trims.
+- **Whether incremental catch-up is worth its complexity on this device.** The
+  architecture says a client may always rebuild, so this is an optimisation with a
+  measurement behind it rather than a design question.
+
+---
+
+## Open questions
+
+- **Whether `writing` stays one modal state.** The design drew it as one when one editor
+  was assumed. It now covers a field edited in the client and a body edited elsewhere,
+  and the second has no modal state at all because the client is not on screen.
+- **What the help surface says about a buffer it no longer holds.** The promise that the
+  buffer is kept as the person types belonged to an in-client editor. What is true now is
+  that the client owns the file the editor writes into.


### PR DESCRIPTION
> Re-planned at the Wave 3 boundary. Documents only: the diff is four markdown files and one `.gitignore` entry, and no Rust changes.

## 💡 What this is

Wave 4 builds the terminal client. The plan for it assumed the client could ask the instance for what it wanted to draw, and it cannot. The served interface has six calls, and none of them fetches an entity by identity or lists what a container holds. `Query` is the literal retrieval arm: its predicate in `crates/altaird/src/store/search.rs:112-125` matches nothing when the query text is empty, so it cannot enumerate, and its `Result` carries an entity and never a relation.

`Changes` is therefore the only source of client state, and a rebuild from nothing is `Changes(since=0)`. Every screen that is not search gets assembled on the device from what the change stream delivered.

This PR adds `docs/altair-wave-4-plan.md`, which sequences the wave on that basis, and corrects the three places the existing documents said otherwise.

## 🤔 Why the previous plan could not be built as written

Section 3.2 of `docs/altair-v0-implementation-plan.md` said "Build the instance half. The TUI need not consume it in v0", resting on the architecture's statement that a client which always fetches current state and never uses the change stream is conforming. That reasoning holds against `docs/altair-architecture.md` and fails against `proto/altair/v1/altair.proto`: "fetches current state" names no call, and the wire has none. The section keeps its original text with a note recording the correction, because the distance between those two documents is worth being able to see.

Two consequences follow, and both are now written down.

**4.1 and 4.2 are one lane, because they are one store.** They were planned as separable and they are not. The outbox owes durable local acceptance while the instance is unreachable, and the replica owes that same store the instance's version of the same entities. Two stores would put "what do I show" in neither of them.

**Wave 2.4 never landed, and the client currently depends on its absence.** The tree goes 2.1, 2.2, 2.3, Wave 3, and there is no retention constant anywhere in `crates/altaird`. Nothing trims the change sequence, so position zero stays answerable and a client can rebuild. Whoever picks 2.4 up owes clients a rebuild path before the first row is trimmed, which is a stronger obligation than that item was written with.

## 🎯 The invariant to anchor the review on

What the person sees is instance truth with pending local writes over it, and a pending write never becomes invisible because the instance cannot be reached.

Its other half is already a standing constraint: no surface ever counts what is pending. Exactly one number exists anywhere in this client, and it is how many the instance refused.

## 🛠️ What the plan decides

**Entities are stored as encoded `Entity` messages, not shredded into client columns.** Index tables sit beside them for the orders the screens navigate by. Field numbers on the wire are permanent and closing a recorded gap adds a field, so a client schema mirroring `Entity` would need a migration every time the contract grows. Holding the message whole means a rebuild is a truncate and a replay, and nothing about the storage forecloses export.

**The device store is SQLite through `rusqlite`.** The argument is not SQL. Sections B and F of `conformance/scenarios.md` kill the client process without warning and then assert what survived, and the durability primitive under that should not be new code. `redb` is recorded as the rejected alternative: a pure Rust build is genuinely nicer, but every index and ordering becomes hand written and surviving an unwarned kill becomes our own correctness problem.

**Bodies are written in `$EDITOR`, and the fast path never leaves the client.** This costs less than it appears. `NoteContent.body` in the proto is "the whole body, markdown, plain text with no relation markers in it. A client never divides it", so marker syntax parsed on return is ruled out by the contract, and an `Anchor` names a `block_id` that does not exist until the instance has divided and answered. Forming a relation from a selection was always a gesture over blocks that came back from a submit, whoever typed the text.

**Thirteen of the sixteen mocked screens ship.** Versions have nothing to restore because v0 defers them, the deleted screen's expiry column needs 2.4, and a conflict needs a second writer that arrives with the bridge at 6.1. Each is refused for a reason that expires, the same shape 2.1 used when it refused a file create.

**Windows is tested from stage 1, and the instance stays Linux only.** The Windows sensitive surface sits in the first two stages: the bundled SQLite build, an unwarned kill that is `TerminateProcess` rather than a signal, and carriage returns in the adapter's newline delimited channel. The conformance harness is already portable (`kill` is the standard library's, every dependency is cross platform), and the single `#[cfg(unix)]` behaviour is making the state directory unwritable, which scenario A4 alone uses. `altaird` stays Linux only on purpose, recorded so three `ubuntu-latest` jobs read as a decision rather than an oversight.

**Six stages, not six waves.** `Wave 4.1` has a fixed public meaning, referenced by the CI job name, the `mise` task description, `README.md`, and doc comments through `crates/altair-conformance`. The plan's six steps are stages: stage 2 completes 4.1 at the moment the suite goes green, and stages 3 to 6 are 4.2.

## 🧹 Documents brought up to what is merged

`CLAUDE.md` claimed Wave 2.1 was the latest landed work, that "Wave 2.2 onward is next and is not started", and that the instance "serves `Submit` and nothing else". All three were false: 2.2, 2.3 and every Wave 3 lane are merged and all six calls are served. Two bullets under "What Wave 2.1 settled" were also false. Type content has been applied since 2.2, and all three of the refusals that section described as pending have expired: a file create at 2.3, an anchor on a relation at 2.2, and an explicit `category_position` now accepted at `crates/altaird/src/write/content.rs:350`.

`README.md` gets the same treatment on its badge, status line and two wave rows.

The second commit adds `.claude/worktrees/` to `.gitignore`. Each entry there is a working copy of this same repository, so committing one commits the tree into itself, and being untracked it appeared in every `git status` waiting to be staged by accident.

## 🧪 Validation

- `prek run --files` on each changed document: `mado` passed, plus trailing whitespace, end of file, mixed line ending, merge conflict, case conflict, large file and private key checks. The `cargo` hooks did not run because no Rust file changed.
- The plan's mermaid diagram validated through the Mermaid renderer: `valid: true`, `diagramType: flowchart`.
- `git diff --name-only main...HEAD` returns five paths, four `.md` and one `.gitignore`. No source file, no proto, no migration.
- Every claim the plan makes about the instance was read out of the tree rather than inferred. The empty query predicate, relation visibility through `relation::endpoints_visible` in `crates/altaird/src/read/changes.rs:205`, `category_position` acceptance, cycle prevention landing in `crates/altaird/src/write/specific/nesting.rs`, and the absence of any retention constant were each checked against source.

⚠️ The full `prek run --all-files` gate, which includes `cargo clippy --workspace --all-targets --all-features -- -D warnings`, was not run locally. It proves nothing about a diff with no Rust in it, and CI runs it on this branch.

## 🔍 What reviewers should focus on

- **The replica conclusion itself.** If there is a way to read an entity or enumerate a container that I missed, the whole plan changes shape. The counter example that would do it is a call, or a use of `Query`, that returns something the change stream does not.
- **Section 3.2's correction.** It leaves the original wrong sentence in place with a note beside it. The alternative was deleting the sentence, which hides that the architecture and the wire disagree.
- **The store decision.** SQLite is argued from surviving an unwarned kill, not from queries. If that argument does not hold, `redb` becomes the better answer and the rejected alternative section says why it was close.
- **Whether stage 2 is too long without a visible deliverable.** Seven scenario sections against one file set, no parallelism. The canary could move ahead of it, at the cost of the suite's clean gradient.
- Out of scope: any change to the instance. Wave 4 adds no call, no field and no migration, and the plan's non-goals section fences that explicitly.

## 📌 Follow-ups

- The plan carries two open questions the mock ups cannot answer, both about the editor handoff. Whether `writing` stays one modal state now that it covers a field edited in the client and a body edited elsewhere, and what the help surface says about a buffer the client no longer holds.
- A leftover worktree from Wave 2.3 sits at `.claude/worktrees/wave-2+2.3-file-bodies`. It is ignored now rather than removed, because removing a worktree can discard uncommitted work.
